### PR TITLE
test: make the cleanup fixtures independent of the host filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+
+# Loop state: queues, logs, worktrees and task files are per-checkout runtime data.
+orchestration/queue/
+orchestration/logs/
+orchestration/worktrees/
+orchestration/tasks/

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -20,6 +20,16 @@ function seedTask(pid: number | null): void {
   writeFileSync(join(paths.queueDir, 'scanned', `${taskId}.failed`), '')
 }
 
+// These fixtures declare win32 so the Windows removal path is exercised on every host,
+// and that path prefixes the extended-length marker — meaningless to a Linux filesystem,
+// where rmSync would then silently remove nothing. Strip it before touching real files.
+function plainPath(path: string): string {
+  if (!path.startsWith('\\\\?\\')) return path
+  const withoutMarker = path.slice(4)
+  // The marker comes with Windows separators; a POSIX host needs its own back.
+  return process.platform === 'win32' ? withoutMarker : withoutMarker.replaceAll('\\', '/')
+}
+
 function makeRuntime(overrides: Partial<CleanupRuntime> = {}): CleanupRuntime {
   let worktreeRegistered = true
   let branchPresent = true
@@ -48,8 +58,8 @@ function makeRuntime(overrides: Partial<CleanupRuntime> = {}): CleanupRuntime {
       }
       return ''
     },
-    exists: existsSync,
-    remove: rmSync,
+    exists: (path) => existsSync(plainPath(path)),
+    remove: (path, options) => { rmSync(plainPath(path), options) },
     now: Date.now,
     sleep: () => {},
     ...overrides,


### PR DESCRIPTION
The core's first CI run on Linux failed two cleanup tests. The fixtures declare `platform: 'win32'` so the Windows long-path removal is exercised on every host, then hand the resulting extended-length path to a real `rmSync`; on Linux that path names nothing, `force` swallows the miss, and the worktree survives, so cleanup reports a different error than the test expects.

The fixture now strips the extended-length marker before touching the filesystem. The covered code path is unchanged — only the fixture's pretend filesystem becomes portable.

This also adds the `.gitignore` the repository never had: the split carried the package but not the ignore rules that lived at the old repository's root, so `node_modules` and the loop's runtime directories were untracked only by luck.

317 tests and `tsc --noEmit` pass locally on Windows; this pull request's checks cover Linux.

https://claude.ai/code/session_01QPGH5AhkS14CwTuRcMhUKy
