### PR TITLE
feat: let the core run its own improvement loop

### DIFF
--- a/orchestration/project/project-core.ts
+++ b/orchestration/project/project-core.ts
@@ -1,0 +1,39 @@
+import type { MergeCheck, ProjectAdapter, SuiteStep } from '../../src/adapters/project.ts'
+
+// The package this adapter gates is the same one running the loop, so both gates are the
+// package's own two commands: the type checker the sources are executed under, and the
+// suite that pins SPEC.md. A task runs in a fresh worktree, which carries the lockfile but
+// no node_modules, so every command installs first.
+//
+// The suite is single-threaded because its fixtures drive real git repositories in
+// temporary directories, and parallel workers made those fixtures race.
+
+const INSTALL = 'npm ci --no-audit --no-fund'
+const TYPECHECK = 'npx tsc --noEmit'
+const SUITE = 'npm test -- --pool=threads --poolOptions.threads.singleThread'
+
+export const coreProject: ProjectAdapter = {
+  name: 'core',
+
+  mergeChecks(taskGate: 'full' | 'light'): MergeCheck[] {
+    return [
+      {
+        label: 'Core gate',
+        cwd: '',
+        command: taskGate === 'light'
+          ? `${INSTALL} && ${TYPECHECK}`
+          : `${INSTALL} && ${TYPECHECK} && ${SUITE}`,
+      },
+    ]
+  },
+
+  cycleSuite(): SuiteStep[] {
+    return [
+      {
+        label: 'Core suite',
+        cwd: '',
+        command: `${INSTALL} && ${TYPECHECK} && ${SUITE}`,
+      },
+    ]
+  },
+}

--- a/orchestration/templates/pitfalls/code.md
+++ b/orchestration/templates/pitfalls/code.md
@@ -1,0 +1,17 @@
+## Known pitfalls — check your diff against every line before committing
+
+<!-- Curation: at most 20 entries. A pattern earns a line only after reviews flagged it
+     twice. At the cap, drop the lowest-impact entry to admit a new one; if a dropped
+     pattern recurs, restore its line and let the list exceed the cap. -->
+
+- Paths: never assume a separator. Windows hosts produce backslashes and extended-length prefixes; POSIX hosts do not. Build paths with node:path and convert only where a platform demands it.
+- Long Windows paths defeat plain removal: keep the extended-length fallback and report honestly which attempt succeeded.
+- Never inherit a child process's stdio into the daemon log. Capture it, route it to the task's own log, and surface only a summarized line.
+- Forge calls are the scarce resource: one listing per poll, cached verdicts keyed by updatedAt, and a rate-limit error means waiting until the reported reset, not retrying every poll.
+- A step that cannot verify its own effect must not report success — a merge, a push, and a deploy are each judged by what the target holds afterwards, not by the command's exit code.
+- Fail closed at the gate: when the loop cannot tell whether remote work is outstanding, it waits rather than promoting.
+- Never leave a claim nobody is executing. A startup failure releases the issue in the same poll that discovered it.
+- Frozen output tokens (CYCLE_COMPLETE, LOOP_DONE, FAILED, NEXT_TASK, DECISION_REQUIRED, TASK_COMPLETE) are a contract with skills and consumers; changing their spelling breaks callers you cannot see.
+- Every line the daemon writes goes through the log helper, in the aligned event format, capped and timestamped. A raw console write is a bug.
+- Keep repository specifics out of the core: a command, a path, or a filename that belongs to one project belongs in that project's adapter.
+- The daemon holds the code it started with. A fix only takes effect after a restart — never report it as active before that.

--- a/orchestration/templates/pitfalls/docs.md
+++ b/orchestration/templates/pitfalls/docs.md
@@ -1,0 +1,12 @@
+## Known pitfalls — check your diff against every line before committing
+
+<!-- Curation: at most 20 entries. A pattern earns a line only after reviews flagged it
+     twice. At the cap, drop the lowest-impact entry to admit a new one; if a dropped
+     pattern recurs, restore its line and let the list exceed the cap. -->
+
+- SPEC.md is the contract, not a summary: a behaviour change lands with the specification item that describes it, in the same commit.
+- README.md is what a consumer reads before adopting the package. A command, variable, or path named there must exist exactly as written.
+- Do not duplicate what the source already states. A listing of commands or environment variables drifts by construction; point at the code or generate it.
+- Comments earn their place by naming a constraint or an incident the code cannot show. A comment that restates the next line is deletable.
+- Write in English throughout, including commit messages and issue text.
+- When documenting a workaround, say what forced it — a platform limitation, a tool's behaviour — so a later reader can tell when it stops being necessary.

--- a/orchestration/templates/pitfalls/tests.md
+++ b/orchestration/templates/pitfalls/tests.md
@@ -1,0 +1,14 @@
+## Known pitfalls — check your diff against every line before committing
+
+<!-- Curation: at most 20 entries. A pattern earns a line only after reviews flagged it
+     twice. At the cap, drop the lowest-impact entry to admit a new one; if a dropped
+     pattern recurs, restore its line and let the list exceed the cap. -->
+
+- The suite runs on Windows and on Linux CI. A fixture that touches the real filesystem must work on both: strip extended-length markers and convert separators inside the fixture, never assume the host the author used.
+- A fixture that declares a platform must behave like that platform all the way down, or the test proves nothing about the path it claims to cover.
+- Assert exact strings and exact call arguments; "was called" locks nothing down, and the log format is a contract worth pinning line by line.
+- Pin every environment variable the assertion depends on. A test that inherits MAX_SCAN_CYCLES from a running daemon passes on the author's machine and fails in CI.
+- Reset mock implementations per test — clearAllMocks keeps implementations, so a predecessor's rejection leaks into the next test.
+- Tests that drive real git repositories need their own temporary directory and must remove it afterwards; the suite runs single-threaded because these fixtures raced.
+- Assert the failure paths, not only the success: what the loop does when a merge fails, when the forge is unreachable, when a claim has no local task.
+- A test that cannot fail is worse than no test: if deleting the implementation leaves it green, it is describing nothing.

--- a/orchestration/templates/scan-template.md
+++ b/orchestration/templates/scan-template.md
@@ -1,0 +1,145 @@
+# {{SCAN_ID}}
+
+## Purpose
+
+Investigate this repository and report improvements as NEXT_TASK. **No code changes**.
+
+This repository is the orchestration core itself: the loop that runs this very scan. A
+finding here changes how every consuming repository is driven, so prefer the boring,
+provable defect over the interesting redesign.
+
+{{SCAN_SCOPE}}
+
+## Investigation procedure
+
+Perform in the following order. Run the commands and read their output before judging.
+
+### 1. Automatic checks
+
+```bash
+npx tsc --noEmit
+```
+```bash
+npm test -- --pool=threads --poolOptions.threads.singleThread 2>&1 | tail -40
+```
+
+Any type error or failing test is a finding. A test that fails only sometimes is a finding
+about the test, not a reason to rerun until it passes.
+
+---
+
+### 2. Behaviour against the specification
+
+`SPEC.md` is the contract this package keeps. Read it against the code and report where
+they disagree — a documented behaviour no code implements, an implemented behaviour the
+specification never mentions, or a numbered item whose wording no longer matches what the
+tests pin.
+
+Report the direction of the fix: whether the specification or the code is the one that
+moved.
+
+---
+
+### 3. Portability
+
+The package runs on Windows and on Linux CI, and its consumers may sit on either. Look for
+code and tests that assume one of them:
+
+- Path separators, drive letters, extended-length prefixes, `/tmp`
+- Line endings, shell quoting, commands that exist on only one platform
+- Process handling: signals, `kill`, process trees
+- Tests that pass on the developer's host because they touch the real filesystem
+
+Two of these already reached CI as failures. Prefer a fixture that works everywhere over a
+platform guard in the test.
+
+---
+
+### 4. Adapter boundaries
+
+Three seams keep this package independent of any repository: `forge`, `runner`, `project`.
+Report anything that leaks across them — a forge command outside the forge adapter, an
+agent-CLI assumption in the loop, a repository-specific path, command, or filename
+anywhere in `src/` outside the adapter interfaces.
+
+The generic adapters (`forge-github`, `runner-codex`) may name their own tools; the loop
+core may not.
+
+---
+
+### 5. Failure handling
+
+This package's job is to keep running unattended and to stop safely when it cannot. Look
+for paths that:
+
+- Report success without verifying the effect (a merge that never checked the result)
+- Fail silently, or log a warning where the loop then proceeds as if nothing happened
+- Retry forever without a bound, or give up without recording why
+- Leave state behind that a later poll reads as work in progress
+
+State in the finding what the loop would do wrongly, not merely that the code looks fragile.
+
+---
+
+### 6. Tests worth having or deleting
+
+```bash
+npm test -- --pool=threads --poolOptions.threads.singleThread --coverage 2>&1 | tail -30
+```
+
+Report untested behaviour rather than uncovered lines: a state transition in the gate, a
+branch in the issue queue's claim logic, an error path that decides whether the loop stops.
+Report tests that assert an implementation detail rather than a behaviour, tests that
+cannot fail, and duplicates.
+
+---
+
+### 7. Redundancy — keep only what is needed
+
+Read the sources for material whose deletion loses nothing: comments that restate the
+adjacent code or narrate history instead of naming a constraint, unused exports, dead
+branches, and documentation that duplicates what the code states.
+
+A deletion finding must name the evidence that nothing references the item — the search
+performed. Comments that carry an incident or a constraint stay: they are why this package
+behaves as it does.
+
+---
+
+### 8. Consumer-facing surface
+
+`README.md` is what a new consumer reads. Check its claims against the code: the commands
+it lists, the environment variables it documents, the adapter contract it describes, the
+subtree instructions it gives. Report a mismatch as `[DOCS]` naming the claim and what the
+source actually does.
+
+---
+
+## Output
+
+After completing the investigation, output **actual issues only**, one line each:
+
+`NEXT_TASK: [category] specific description → fix approach`
+
+Categories: `BUG` / `TEST` / `DOCS` / `PORTABILITY` / `SECURITY`.
+
+**Rules:**
+- Report only what you determined to be a problem; no guesses
+- Name the file and the symbol so the implementer needs no further context
+- Up to 8 items, most important first
+- No code changes
+- Write findings in English
+
+If you found nothing, print `NO_FINDINGS` on its own line and no NEXT_TASK lines.
+
+### Findings that are not yours to act on
+
+Where the finding is a choice rather than a defect — a dependency's major version, a change
+to the adapter contract that every consumer would have to follow — report it as:
+
+`DECISION_REQUIRED: what the choice is, what each way costs, and what you would need to know`
+
+## Completion marker
+
+Finally print the following on its own line:
+TASK_COMPLETE


### PR DESCRIPTION
The package can drive any repository through a project adapter and had none for the repository it lives in, so improvements to it had to be made in a consumer and split back. This adds what a consumer supplies:

- `orchestration/project/project-core.ts` — gates merges on `tsc --noEmit` and the suite this package ships, installing first because a task worktree carries the lockfile but no `node_modules`, and running the suite single-threaded because its fixtures drive real git repositories.
- `orchestration/templates/scan-template.md` — a checklist written for this package rather than an application: specification drift, portability across the two hosts its CI and its authors use, adapter-boundary leaks, failure handling, and redundancy.
- `orchestration/templates/pitfalls/` — the constraints already paid for, including the two that reached CI as failures today.

No source changes; the loop's own behaviour is untouched.

https://claude.ai/code/session_01QPGH5AhkS14CwTuRcMhUKy
