### PR TITLE
chore: import the upstream improvements this package was split from

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "shiora-orchestration",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shiora-orchestration",
+      "version": "0.0.0",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "shiora-orchestration",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
+  "upstreamRepo": "menimani/orchestration-core",
   "engines": {
     "node": ">=23.6"
   },
@@ -14,6 +16,7 @@
     "queue": "node src/cli.ts queue",
     "stop": "node src/cli.ts stop",
     "delegate": "node src/cli.ts delegate",
+    "report-upstream": "node src/cli.ts report-upstream",
     "start": "node src/cli.ts start",
     "status": "node src/cli.ts status",
     "logs": "node src/cli.ts logs",

--- a/src/adapters/forge-github.ts
+++ b/src/adapters/forge-github.ts
@@ -2,7 +2,8 @@ import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { z } from 'zod'
 import type {
-  CheckConclusion, CreateIssueOptions, CreatePrOptions, Forge, ForgeIssue, PrStatus, WorkflowRun,
+  CheckConclusion, CreateIssueInRepositoryOptions, CreateIssueOptions, CreatePrOptions, Forge,
+  ForgeIssue, PrStatus, WorkflowRun,
 } from './forge.ts'
 import { ForgeRateLimitError } from './forge.ts'
 
@@ -12,6 +13,7 @@ const execFileAsync = promisify(execFile)
 // enough to a URL that a looser match once stored the error text and every later cycle
 // asked gh about a pull request called "check your internet connection".
 const PR_URL_PATTERN = /^https:\/\/\S+\/pull\/\d+$/
+const ISSUE_URL_PATTERN = /^https:\/\/\S+\/issues\/\d+$/
 
 const rollupEntrySchema = z.object({
   __typename: z.string().optional(),
@@ -33,6 +35,7 @@ const prStatusSchema = z.object({
 
 const prBodySchema = z.object({ body: z.string() })
 const currentUserSchema = z.object({ login: z.string() })
+const labelListSchema = z.array(z.object({ name: z.string() }))
 
 const workflowRunSchema = z.object({
   databaseId: z.number(),
@@ -317,6 +320,32 @@ export function createGithubForge(
         throw new Error(`gh issue create returned no issue URL: ${stdout.trim()}`)
       }
       return Number(match[1])
+    },
+
+    async createIssueInRepository(options: CreateIssueInRepositoryOptions): Promise<string> {
+      const labels: string[] = []
+      for (const label of options.optionalLabels) {
+        const labelArgs = [
+          'label', 'list', '--repo', options.repository, '--search', label,
+          '--limit', '100', '--json', 'name',
+        ]
+        const stdout = await checkedGh(repoRoot, labelArgs)
+        const available = parseGhJson(labelArgs, stdout, labelListSchema)
+        if (available.some((candidate) => candidate.name === label)) labels.push(label)
+      }
+
+      const args = [
+        'issue', 'create', '--repo', options.repository,
+        '--title', options.title, '--body', options.body,
+      ]
+      for (const label of labels) args.push('--label', label)
+      const stdout = await checkedGh(repoRoot, args)
+      const url = stdout.split(/\r?\n/).map((line) => line.trim())
+        .find((line) => ISSUE_URL_PATTERN.test(line))
+      if (url === undefined) {
+        throw new Error(`gh issue create returned no issue URL: ${stdout.trim()}`)
+      }
+      return url
     },
 
     async getIssue(issueNumber: number): Promise<ForgeIssue> {

--- a/src/adapters/forge.ts
+++ b/src/adapters/forge.ts
@@ -50,6 +50,14 @@ export interface CreateIssueOptions {
   assignees?: string[]
 }
 
+export interface CreateIssueInRepositoryOptions {
+  repository: string
+  title: string
+  body: string
+  /** Labels to apply when they already exist in the target repository. */
+  optionalLabels: string[]
+}
+
 export interface WorkflowRun {
   id: number
   createdAt: string
@@ -95,6 +103,8 @@ export interface Forge {
   currentUser(): Promise<string>
   ensureLabel(name: string, description: string): Promise<void>
   createIssue(options: CreateIssueOptions): Promise<number>
+  /** Create an issue outside the current repository and return its URL. */
+  createIssueInRepository(options: CreateIssueInRepositoryOptions): Promise<string>
   getIssue(issueNumber: number): Promise<ForgeIssue>
   /** Add a comment to an issue. */
   commentIssue(issueNumber: number, comment: string): Promise<void>

--- a/src/adapters/project.ts
+++ b/src/adapters/project.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 // The project adapter carries everything the orchestration knows about the repository
 // it runs in: which checks verify a merge, which suites prove a cycle's tip, and which
@@ -68,8 +68,6 @@ export interface ProjectAdapter {
   scanWorktreeSetup?: WorktreeSetupStep[]
 }
 
-const ORCHESTRATION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
-
 function isProjectAdapter(value: unknown, name: string): value is ProjectAdapter {
   if (typeof value !== 'object' || value === null) return false
   const candidate = value as Partial<ProjectAdapter>
@@ -79,13 +77,14 @@ function isProjectAdapter(value: unknown, name: string): value is ProjectAdapter
 }
 
 export async function loadProject(
+  orchestrationRoot: string,
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<ProjectAdapter> {
   const name = env['PROJECT'] === undefined || env['PROJECT'] === '' ? 'shiora' : env['PROJECT']
   const configuredPath = env['PROJECT_ADAPTER']
   const adapterPath = configuredPath === undefined || configuredPath === ''
-    ? resolve(ORCHESTRATION_ROOT, 'project', `project-${name}.ts`)
-    : resolve(ORCHESTRATION_ROOT, configuredPath)
+    ? resolve(orchestrationRoot, 'project', `project-${name}.ts`)
+    : resolve(orchestrationRoot, configuredPath)
 
   if (!existsSync(adapterPath)) {
     throw new Error(`Project adapter not found: ${adapterPath}`)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,7 +166,7 @@ const cmdStart: Command = async (paths, args) => {
   }
   const config = loadConfig()
   const runner = await loadRunner(config.runner)
-  const project = await loadProject()
+  const project = await loadProject(paths.root)
   const result = await startTask(paths, runner, taskId, {
     effort: effort === '' ? 'medium' : effort,
     model: model === '' ? undefined : model,
@@ -224,7 +224,7 @@ const cmdDeploy: Command = async (paths, args) => {
     return 1
   }
   const config = loadConfig()
-  const project = await loadProject()
+  const project = await loadProject(paths.root)
   if (project.deployment === undefined) {
     console.error(`Project '${project.name}' does not define a deployment.`)
     return 1
@@ -273,7 +273,7 @@ const cmdMerge: Command = async (paths, args) => {
       taskGate: config.taskGate,
       testCmd: testCmd ?? (config.testCmd === '' ? undefined : config.testCmd),
       skipAutoTest: config.skipAutoTest,
-      project: await loadProject(),
+      project: await loadProject(paths.root),
       closesIssue: linkedIssue,
     })
     if (linkedIssue !== undefined) {
@@ -536,7 +536,7 @@ async function runLoopDaemon(
     )
     const forge = await loadForge(config.forge, paths.repoRoot)
     const runner = await loadRunner(config.runner)
-    const project = await loadProject()
+    const project = await loadProject(paths.root)
     const loop = createLoop({ paths, config, forge, runner, project, log, now: () => new Date() })
 
     await loop.initializeIssueQueue()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import { mergeTask, MergeError, syncOrchestrationDepsAtStartup } from './merge.t
 import { deploy } from './deploy.ts'
 import { isScanTaskId, logFile, orchPaths, type OrchPaths } from './paths.ts'
 import { pruneTasks } from './prune.ts'
+import { reportUpstream } from './reportUpstream.ts'
 import { listTaskIds, refreshAll, refreshTask } from './refresh.ts'
 import { readStatus } from './status.ts'
 import { startTask } from './start.ts'
@@ -138,6 +139,18 @@ const cmdDelegate: Command = async (paths, args) => {
     console.log('The loop is not running. The task waits in the backlog until the loop starts,')
     console.log(`or run the start command with ${result.taskId} to run it now.`)
   }
+  return 0
+}
+
+const cmdReportUpstream: Command = async (paths, args) => {
+  const description = args[0]
+  if (description === undefined || description.trim() === '' || args.length !== 1) {
+    console.error('Usage: report-upstream "<description>"')
+    return 1
+  }
+  const config = loadConfig()
+  const forge = await loadForge(config.forge, paths.repoRoot)
+  console.log(await reportUpstream(paths, description, forge))
   return 0
 }
 
@@ -601,6 +614,7 @@ const commands: Record<string, Command> = {
   'new': cmdNew,
   'enqueue': cmdEnqueue,
   'delegate': cmdDelegate,
+  'report-upstream': cmdReportUpstream,
   'start': cmdStart,
   'status': cmdStatus,
   'logs': cmdLogs,

--- a/src/reportUpstream.ts
+++ b/src/reportUpstream.ts
@@ -1,0 +1,112 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { platform } from 'node:os'
+import { basename, join } from 'node:path'
+import type { Forge } from './adapters/forge.ts'
+import type { OrchPaths } from './paths.ts'
+
+interface PackageMetadata {
+  version?: unknown
+  upstreamRepo?: unknown
+}
+
+export interface ReportUpstreamRuntime {
+  env: NodeJS.ProcessEnv
+  nodeVersion: string
+  platform: string
+  git(repoRoot: string, args: string[]): string
+}
+
+const defaultRuntime: ReportUpstreamRuntime = {
+  env: process.env,
+  nodeVersion: process.version,
+  platform: platform(),
+  git: (repoRoot, args) => execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    windowsHide: true,
+  }),
+}
+
+function configuredString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed === '' ? undefined : trimmed
+}
+
+function repositoryFromRemote(remote: string): string | undefined {
+  const trimmed = remote.trim().replace(/\.git$/, '')
+  const scpPath = /^[^@]+@[^:]+:(.+)$/.exec(trimmed)?.[1]
+  if (scpPath !== undefined) return scpPath.replace(/^\/+|\/+$/g, '') || undefined
+  try {
+    const path = new URL(trimmed).pathname.replace(/^\/+|\/+$/g, '')
+    return path || undefined
+  } catch {
+    return undefined
+  }
+}
+
+function reportingRepository(paths: OrchPaths, runtime: ReportUpstreamRuntime): string {
+  try {
+    const remote = runtime.git(paths.repoRoot, ['remote', 'get-url', 'origin'])
+    return repositoryFromRemote(remote) ?? basename(paths.repoRoot)
+  } catch {
+    return basename(paths.repoRoot)
+  }
+}
+
+function subtreeCommit(paths: OrchPaths, runtime: ReportUpstreamRuntime): string | undefined {
+  try {
+    const message = runtime.git(paths.repoRoot, [
+      'log', '-1', '--format=%B', '--grep=git-subtree-split', '--fixed-strings',
+      '--', 'orchestration/ts',
+    ])
+    return /^git-subtree-split:\s*([0-9a-f]{7,40})\s*$/im.exec(message)?.[1]
+  } catch {
+    return undefined
+  }
+}
+
+export async function reportUpstream(
+  paths: OrchPaths,
+  description: string,
+  forge: Forge,
+  runtime: ReportUpstreamRuntime = defaultRuntime,
+): Promise<string> {
+  const packageFile = join(paths.repoRoot, 'orchestration', 'ts', 'package.json')
+  const metadata = JSON.parse(readFileSync(packageFile, 'utf8')) as PackageMetadata
+  const upstreamRepository = configuredString(runtime.env.UPSTREAM_REPO)
+    ?? configuredString(metadata.upstreamRepo)
+  if (upstreamRepository === undefined) {
+    throw new Error(
+      'No upstream repository is configured. Set UPSTREAM_REPO or upstreamRepo in orchestration/ts/package.json.',
+    )
+  }
+
+  const coreVersion = subtreeCommit(paths, runtime) ?? configuredString(metadata.version)
+  if (coreVersion === undefined) {
+    throw new Error(
+      'No core version is available. Record a git subtree commit or set version in orchestration/ts/package.json.',
+    )
+  }
+  const repository = reportingRepository(paths, runtime)
+  const body = [
+    '## Description',
+    '',
+    description.trim(),
+    '',
+    '## Reporter',
+    '',
+    `- Repository: \`${repository}\``,
+    `- Core version: \`${coreVersion}\``,
+    `- Platform: \`${runtime.platform}\``,
+    `- Node version: \`${runtime.nodeVersion}\``,
+  ].join('\n')
+
+  return forge.createIssueInRepository({
+    repository: upstreamRepository,
+    title: `Core defect reported by ${repository}`,
+    body,
+    optionalLabels: ['upstream:report'],
+  })
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -47,6 +47,7 @@ describe('command registry', () => {
     expect(result.status).toBe(1)
     expect(result.stderr).toContain('deploy')
     expect(result.stderr).toContain('ci-wait')
+    expect(result.stderr).toContain('report-upstream')
   })
 
   it('refuses to start a worker without a base ref', () => {

--- a/tests/fakeForge.ts
+++ b/tests/fakeForge.ts
@@ -1,5 +1,5 @@
 import type {
-  CreateIssueOptions, CreatePrOptions, Forge, ForgeIssue, PrStatus,
+  CreateIssueInRepositoryOptions, CreateIssueOptions, CreatePrOptions, Forge, ForgeIssue, PrStatus,
 } from '../src/adapters/forge.ts'
 
 // An in-memory forge for tests: PR calls answer from a settable status, and the issue
@@ -12,6 +12,8 @@ export interface FakeForge extends Forge {
   prStatusCalls: number
   issues: Map<number, ForgeIssue>
   issueComments: Map<number, string[]>
+  repositoryIssues: Array<CreateIssueInRepositoryOptions & { labels: string[]; url: string }>
+  repositoryLabels: Map<string, Set<string>>
   listOpenIssuesCalls: string[]
   listIssueCommentsCalls: number[]
   user: string
@@ -26,6 +28,8 @@ export function makeFakeForge(user = 'worker-a'): FakeForge {
     prStatusCalls: 0,
     issues: new Map(),
     issueComments: new Map(),
+    repositoryIssues: [],
+    repositoryLabels: new Map(),
     listOpenIssuesCalls: [],
     listIssueCommentsCalls: [],
     user,
@@ -68,6 +72,14 @@ export function makeFakeForge(user = 'worker-a'): FakeForge {
         updatedAt: fake.clock().toISOString(),
       })
       return issueNumber
+    },
+    async createIssueInRepository(options: CreateIssueInRepositoryOptions): Promise<string> {
+      const labels = options.optionalLabels.filter(
+        (label) => fake.repositoryLabels.get(options.repository)?.has(label) === true,
+      )
+      const url = `https://example.test/${options.repository}/issues/${fake.repositoryIssues.length + 1}`
+      fake.repositoryIssues.push({ ...options, optionalLabels: [...options.optionalLabels], labels, url })
+      return url
     },
     async getIssue(issueNumber: number): Promise<ForgeIssue> {
       const issue = fake.issues.get(issueNumber)

--- a/tests/forge-github.test.ts
+++ b/tests/forge-github.test.ts
@@ -86,6 +86,39 @@ describe('GitHub workflow dispatch correlation', () => {
   })
 })
 
+describe('GitHub upstream issue creation', () => {
+  it.each([
+    { available: [{ name: 'upstream:report' }], expectedLabel: true },
+    { available: [], expectedLabel: false },
+  ])('applies the optional label only when it exists', async ({ available, expectedLabel }) => {
+    const calls: string[][] = []
+    const command: GithubCommand = async (_root, args) => {
+      calls.push(args)
+      return args[0] === 'label'
+        ? JSON.stringify(available)
+        : 'https://github.com/menimani/orchestration-core/issues/42\n'
+    }
+    const forge = createGithubForge('repo-root', command)
+
+    await expect(forge.createIssueInRepository({
+      repository: 'menimani/orchestration-core',
+      title: 'Core defect report',
+      body: 'Report body',
+      optionalLabels: ['upstream:report'],
+    })).resolves.toBe('https://github.com/menimani/orchestration-core/issues/42')
+
+    expect(calls[0]).toEqual([
+      'label', 'list', '--repo', 'menimani/orchestration-core', '--search', 'upstream:report',
+      '--limit', '100', '--json', 'name',
+    ])
+    expect(calls[1]).toEqual([
+      'issue', 'create', '--repo', 'menimani/orchestration-core',
+      '--title', 'Core defect report', '--body', 'Report body',
+      ...(expectedLabel ? ['--label', 'upstream:report'] : []),
+    ])
+  })
+})
+
 describe('GitHub forge JSON schemas', () => {
   it('queries the GraphQL reset when a rate-limit error does not report one', async () => {
     const calls: string[][] = []

--- a/tests/project-loader.test.ts
+++ b/tests/project-loader.test.ts
@@ -1,12 +1,74 @@
-import { resolve } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
 import { loadProject } from '../src/adapters/project.ts'
 
 const fixture = resolve(import.meta.dirname, 'fixtures', 'project-loader-fixture.ts')
+const loaderSource = resolve(import.meta.dirname, '..', 'src', 'adapters', 'project.ts')
+
+const fixtureRepositories: string[] = []
+
+afterEach(() => {
+  for (const repository of fixtureRepositories.splice(0)) {
+    rmSync(repository, { recursive: true, force: true })
+  }
+})
+
+function createFixtureRepository(): string {
+  const repository = mkdtempSync(join(tmpdir(), 'project-loader-'))
+  fixtureRepositories.push(repository)
+  return repository
+}
+
+function writeFixtureAdapter(adapterPath: string, workflow: string): void {
+  mkdirSync(dirname(adapterPath), { recursive: true })
+  writeFileSync(adapterPath, `
+export const fixtureProject = {
+  name: 'fixture',
+  deployment: {
+    workflow: '${workflow}',
+    revisionUrl: 'https://example.com/fixture-revision',
+  },
+  mergeChecks: () => [],
+  cycleSuite: () => [],
+}
+`)
+}
+
+async function loadFromFixtureRepository(packagePath: string): Promise<string | undefined> {
+  const repository = createFixtureRepository()
+  const packageRoot = resolve(repository, packagePath)
+  const loaderPath = join(packageRoot, 'src', 'adapters', 'project.ts')
+  mkdirSync(dirname(loaderPath), { recursive: true })
+  copyFileSync(loaderSource, loaderPath)
+
+  const orchestrationRoot = join(repository, 'orchestration')
+  const adapterPath = join(orchestrationRoot, 'project', 'project-fixture.ts')
+  writeFixtureAdapter(
+    adapterPath,
+    relative(repository, packageRoot).replaceAll('\\', '/') || 'repository-root',
+  )
+
+  const fixtureLoader = await import(pathToFileURL(loaderPath).href) as typeof import(
+    '../src/adapters/project.ts'
+  )
+  const project = await fixtureLoader.loadProject(orchestrationRoot, { PROJECT: 'fixture' })
+  return project.deployment?.workflow
+}
 
 describe('project adapter loading', () => {
+  it('resolves the adapter when the package is under orchestration/ts', async () => {
+    await expect(loadFromFixtureRepository('orchestration/ts')).resolves.toBe('orchestration/ts')
+  })
+
+  it('resolves the adapter when the package is at the repository root', async () => {
+    await expect(loadFromFixtureRepository('')).resolves.toBe('repository-root')
+  })
+
   it('loads an explicit absolute PROJECT_ADAPTER path', async () => {
-    const project = await loadProject({
+    const project = await loadProject(import.meta.dirname, {
       PROJECT: 'shiora',
       PROJECT_ADAPTER: fixture,
     })
@@ -14,10 +76,26 @@ describe('project adapter loading', () => {
     expect(project.deployment?.workflow).toBe('fixture.yml')
   })
 
+  it('resolves a relative PROJECT_ADAPTER from the orchestration root', async () => {
+    const repository = createFixtureRepository()
+    const orchestrationRoot = join(repository, 'orchestration')
+    writeFixtureAdapter(join(orchestrationRoot, 'custom', 'project-fixture.ts'), 'relative.yml')
+
+    const project = await loadProject(orchestrationRoot, {
+      PROJECT: 'fixture',
+      PROJECT_ADAPTER: 'custom/project-fixture.ts',
+    })
+
+    expect(project.deployment?.workflow).toBe('relative.yml')
+  })
+
   it('names the resolved path when the adapter is absent', async () => {
     const missingPath = resolve(import.meta.dirname, 'fixtures', 'project-missing.ts')
 
-    await expect(loadProject({ PROJECT: 'missing', PROJECT_ADAPTER: missingPath })).rejects.toThrow(
+    await expect(loadProject(import.meta.dirname, {
+      PROJECT: 'missing',
+      PROJECT_ADAPTER: missingPath,
+    })).rejects.toThrow(
       `Project adapter not found: ${missingPath}`,
     )
   })

--- a/tests/report-upstream.test.ts
+++ b/tests/report-upstream.test.ts
@@ -1,0 +1,105 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { orchPaths } from '../src/paths.ts'
+import { reportUpstream, type ReportUpstreamRuntime } from '../src/reportUpstream.ts'
+import { makeFakeForge } from './fakeForge.ts'
+
+let repoRoot: string
+
+beforeEach(() => {
+  repoRoot = mkdtempSync(join(tmpdir(), 'report-upstream-'))
+  mkdirSync(join(repoRoot, 'orchestration', 'ts'), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(repoRoot, { recursive: true, force: true })
+})
+
+function writePackage(metadata: Record<string, unknown>): void {
+  writeFileSync(
+    join(repoRoot, 'orchestration', 'ts', 'package.json'),
+    `${JSON.stringify({ name: 'consumer-orchestration', ...metadata })}\n`,
+  )
+}
+
+function runtime(overrides: Partial<ReportUpstreamRuntime> = {}): ReportUpstreamRuntime {
+  return {
+    env: {},
+    nodeVersion: 'v24.7.0',
+    platform: 'linux',
+    git: (_root, args) => args[0] === 'remote'
+      ? 'git@github.com:consumer/reporting-repo.git\n'
+      : '',
+    ...overrides,
+  }
+}
+
+describe('upstream defect reports', () => {
+  it('composes the maintainer context and prefers a recorded subtree commit', async () => {
+    writePackage({ upstreamRepo: 'configured/core', version: '1.2.3' })
+    const forge = makeFakeForge()
+    forge.repositoryLabels.set('configured/core', new Set(['upstream:report']))
+    const commit = '0123456789abcdef0123456789abcdef01234567'
+
+    const url = await reportUpstream(orchPaths(repoRoot), 'The queue loses a finding.', forge,
+      runtime({
+        git: (_root, args) => args[0] === 'remote'
+          ? 'git@github.com:consumer/reporting-repo.git\n'
+          : `git-subtree-dir: orchestration/ts\ngit-subtree-split: ${commit}\n`,
+      }))
+
+    expect(url).toBe('https://example.test/configured/core/issues/1')
+    expect(forge.repositoryIssues).toHaveLength(1)
+    expect(forge.repositoryIssues[0]).toMatchObject({
+      repository: 'configured/core',
+      title: 'Core defect reported by consumer/reporting-repo',
+      labels: ['upstream:report'],
+    })
+    expect(forge.repositoryIssues[0]?.body).toBe([
+      '## Description',
+      '',
+      'The queue loses a finding.',
+      '',
+      '## Reporter',
+      '',
+      '- Repository: `consumer/reporting-repo`',
+      `- Core version: \`${commit}\``,
+      '- Platform: `linux`',
+      '- Node version: `v24.7.0`',
+    ].join('\n'))
+    expect(forge.repositoryIssues[0]?.body).not.toContain(repoRoot)
+  })
+
+  it('honours UPSTREAM_REPO over package configuration and falls back to package version', async () => {
+    writePackage({ upstreamRepo: 'configured/core', version: '2.4.1' })
+    const forge = makeFakeForge()
+
+    await reportUpstream(orchPaths(repoRoot), 'A core defect.', forge,
+      runtime({ env: { UPSTREAM_REPO: 'environment/core' } }))
+
+    expect(forge.repositoryIssues[0]?.repository).toBe('environment/core')
+    expect(forge.repositoryIssues[0]?.body).toContain('- Core version: `2.4.1`')
+  })
+
+  it('fails clearly when no upstream repository is configured', async () => {
+    writePackage({ version: '2.4.1' })
+
+    await expect(reportUpstream(
+      orchPaths(repoRoot), 'A core defect.', makeFakeForge(), runtime(),
+    )).rejects.toThrow(
+      'No upstream repository is configured. Set UPSTREAM_REPO or upstreamRepo in orchestration/ts/package.json.',
+    )
+  })
+
+  it('files the report without a missing optional label', async () => {
+    writePackage({ upstreamRepo: 'configured/core', version: '2.4.1' })
+    const forge = makeFakeForge()
+
+    await expect(reportUpstream(
+      orchPaths(repoRoot), 'A core defect.', forge, runtime(),
+    )).resolves.toBe('https://example.test/configured/core/issues/1')
+    expect(forge.repositoryIssues[0]?.labels).toEqual([])
+  })
+})


### PR DESCRIPTION
The extraction happened while the project the package came from kept improving it. This imports what landed there since: the project adapter resolved from the repository root rather than the package's own location, the `report-upstream` command a consumer uses to file a core defect here, and the forge-poll budget work.

327 tests and `tsc --noEmit` pass locally; this pull request's checks cover Linux.

https://claude.ai/code/session_01QPGH5AhkS14CwTuRcMhUKy
