### PR TITLE
test: bound the CLI invocations so a loop that will not exit fails instead of hanging

### DIFF
--- a/src/adapters/project.ts
+++ b/src/adapters/project.ts
@@ -117,20 +117,46 @@ export interface ProjectAdapter {
   pullRequest: PullRequestPresentation
 }
 
-function isProjectAdapter(value: unknown, name?: string): value is ProjectAdapter {
-  if (typeof value !== 'object' || value === null) return false
+interface ProjectAdapterValidation {
+  candidate: boolean
+  problem?: string
+}
+
+function validateProjectAdapter(value: unknown, name?: string): ProjectAdapterValidation {
+  if (typeof value !== 'object' || value === null) return { candidate: false }
   const candidate = value as Partial<ProjectAdapter>
-  return typeof candidate.name === 'string'
-    && candidate.name !== ''
-    && (name === undefined || candidate.name === name)
-    && typeof candidate.mergeChecks === 'function'
-    && typeof candidate.cycleSuite === 'function'
-    && typeof candidate.pullRequest === 'object'
-    && candidate.pullRequest !== null
-    && Array.isArray(candidate.pullRequest.categories)
-    && typeof candidate.pullRequest.titleFallback === 'string'
-    && typeof candidate.pullRequest.classifyCommit === 'function'
-    && typeof candidate.pullRequest.detectRisks === 'function'
+  if (typeof candidate.name !== 'string' || candidate.name === '') return { candidate: false }
+  if (name !== undefined && candidate.name !== name) return { candidate: false }
+
+  const required = (
+    owner: Record<string, unknown>,
+    member: string,
+    valid: (memberValue: unknown) => boolean,
+    expected: string,
+  ): string | undefined => {
+    if (!(member in owner)) return `is missing required member '${member}'`
+    if (!valid(owner[member])) return `has invalid required member '${member}' (expected ${expected})`
+    return undefined
+  }
+  const topLevel = candidate as Record<string, unknown>
+  const problem = required(topLevel, 'mergeChecks', (member) => typeof member === 'function', 'a function')
+    ?? required(topLevel, 'cycleSuite', (member) => typeof member === 'function', 'a function')
+    ?? required(
+      topLevel,
+      'pullRequest',
+      (member) => typeof member === 'object' && member !== null,
+      'an object',
+    )
+  if (problem !== undefined) return { candidate: true, problem }
+
+  const pullRequest = candidate.pullRequest as unknown as Record<string, unknown>
+  return {
+    candidate: true,
+    problem: required(pullRequest, 'categories', Array.isArray, 'an array')
+      ?? required(pullRequest, 'titleFallback', (member) => typeof member === 'string', 'a string')
+      ?? required(pullRequest, 'classifyCommit', (member) => typeof member === 'function', 'a function')
+      ?? required(pullRequest, 'detectRisks', (member) => typeof member === 'function', 'a function'),
+  }
 }
 
 function discoverProjectAdapter(orchestrationRoot: string): { path: string; name: string } {
@@ -180,8 +206,18 @@ export async function loadProject(
   }
 
   const mod = await import(pathToFileURL(adapterPath).href) as Record<string, unknown>
+  let matchingProblem: string | undefined
   for (const value of Object.values(mod)) {
-    if (isProjectAdapter(value, name)) return value
+    const validation = validateProjectAdapter(value, name)
+    if (!validation.candidate) continue
+    if (validation.problem === undefined) return value as ProjectAdapter
+    matchingProblem ??= validation.problem
+  }
+  if (matchingProblem !== undefined) {
+    const projectName = name ?? 'the matching project'
+    throw new Error(
+      `Project adapter '${adapterPath}' exports project '${projectName}' but ${matchingProblem}`,
+    )
   }
   const expected = name === undefined ? 'a project adapter' : `project '${name}'`
   throw new Error(`Project adapter '${adapterPath}' does not export ${expected}`)

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -10,6 +10,15 @@ import { writeStatus } from '../src/status.ts'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const CLI = join(HERE, '..', 'src', 'cli.ts')
+
+// Several of these run `cli.ts loop` and rely on the loop deciding to exit — a
+// burst-failure cap, an exhausted cycle cap, a rejected PID lock. When a condition stops
+// holding, a synchronous spawn becomes a permanent block: `spawnSync` cannot be
+// interrupted by vitest's test timeout, so the worker freezes with no failure and no
+// output. That happened inside a merge gate twice, and each attempt sat for fifty minutes
+// before anyone thought to look at the process list. A bound turns it into a failed test.
+const CLI_TIMEOUT_MS = 120_000
+
 const CORE_ENV = {
   ...process.env,
   PROJECT: 'shiora',
@@ -60,6 +69,7 @@ describe('command registry', () => {
       cwd: repoRoot,
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(1)
@@ -73,6 +83,7 @@ describe('command registry', () => {
       cwd: repoRoot,
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(1)
@@ -90,6 +101,7 @@ describe('command registry', () => {
       },
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(1)
@@ -108,6 +120,7 @@ describe('logs', () => {
       cwd: repoRoot,
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(1)
@@ -139,6 +152,7 @@ describe('manual merge', () => {
       env: CORE_ENV,
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(0)
@@ -178,6 +192,7 @@ describe('manual merge', () => {
       env: CORE_ENV,
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(1)
@@ -199,6 +214,7 @@ describe('manually promoted run ending', () => {
       env: { ...process.env, MAX_SCAN_CYCLES: '3' },
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(0)
@@ -219,6 +235,7 @@ describe('manually promoted run ending', () => {
       env: { ...process.env, MAX_SCAN_CYCLES: '8' },
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(0)
@@ -232,6 +249,7 @@ describe('manually promoted run ending', () => {
       cwd: repoRoot,
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(1)
@@ -269,6 +287,7 @@ describe('loop daemon ownership', () => {
       },
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     }))
     const completions = children.map(childCompletion)
 
@@ -326,6 +345,7 @@ describe('loop daemon ownership', () => {
       },
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     }))
     const completions = children.map(childCompletion)
 
@@ -370,6 +390,7 @@ describe('loop daemon ownership', () => {
       },
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(0)
@@ -402,6 +423,7 @@ describe('loop daemon ownership', () => {
         },
         encoding: 'utf8',
         windowsHide: true,
+        timeout: CLI_TIMEOUT_MS,
       },
     )
 
@@ -423,6 +445,7 @@ describe('loop daemon ownership', () => {
       env: { ...CORE_ENV, FORGE: 'missing', ISSUE_QUEUE_ENABLED: 'true' },
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(1)
@@ -446,6 +469,7 @@ describe('loop daemon ownership', () => {
       },
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(0)
@@ -467,6 +491,7 @@ describe('loop daemon ownership', () => {
       },
       encoding: 'utf8',
       windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
     })
 
     expect(result.status).toBe(0)

--- a/tests/consumer-smoke.test.ts
+++ b/tests/consumer-smoke.test.ts
@@ -1,0 +1,134 @@
+import { execFileSync } from 'node:child_process'
+import { copyFileSync, cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Forge } from '../src/adapters/forge.ts'
+import type { ProjectAdapter } from '../src/adapters/project.ts'
+import { makeFakeForge } from './fakeForge.ts'
+
+const packageRoot = resolve(import.meta.dirname, '..')
+const fixtureRoot = resolve(import.meta.dirname, 'fixtures', 'consumer')
+const repositories: string[] = []
+
+afterEach(() => {
+  for (const repository of repositories.splice(0)) {
+    rmSync(repository, { recursive: true, force: true })
+  }
+})
+
+function git(repository: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: repository,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  }).trim()
+}
+
+function createConsumerRepository(): string {
+  const repository = mkdtempSync(join(tmpdir(), 'orchestration-consumer-'))
+  repositories.push(repository)
+
+  cpSync(fixtureRoot, repository, { recursive: true })
+  const installedPackage = join(repository, 'orchestration', 'ts')
+  cpSync(join(packageRoot, 'src'), join(installedPackage, 'src'), { recursive: true })
+  copyFileSync(join(packageRoot, 'package.json'), join(installedPackage, 'package.json'))
+  copyFileSync(join(packageRoot, 'package-lock.json'), join(installedPackage, 'package-lock.json'))
+
+  git(repository, ['init', '--initial-branch=main'])
+  git(repository, ['config', 'user.email', 'consumer-smoke@example.test'])
+  git(repository, ['config', 'user.name', 'Consumer Smoke'])
+  git(repository, ['add', '-A'])
+  git(repository, ['commit', '-m', 'chore: create consumer fixture'])
+  git(repository, ['checkout', '-b', 'consumer-smoke'])
+  return repository
+}
+
+function referencedPaths(project: ProjectAdapter): string[] {
+  const paths: string[] = []
+  const record = (step: {
+    cwd: string
+    requires?: string
+    installWhenMissing?: { path: string }
+    repairWhenMissing?: { path: string }
+  }): void => {
+    if (step.cwd !== '') paths.push(step.cwd)
+    if (step.requires !== undefined) paths.push(step.requires)
+    if (step.installWhenMissing !== undefined) paths.push(step.installWhenMissing.path)
+    if (step.repairWhenMissing !== undefined) paths.push(step.repairWhenMissing.path)
+  }
+  for (const step of project.scanWorktreeSetup ?? []) record(step)
+  for (const step of project.mergeChecks('full')) record(step)
+  for (const step of project.cycleSuite()) record(step)
+  return [...new Set(paths)]
+}
+
+describe('consumer startup', () => {
+  it('discovers a consumer adapter and reaches the first poll', async () => {
+    const repository = createConsumerRepository()
+    expect(git(repository, ['branch', '--show-current'])).toBe('consumer-smoke')
+    expect(git(repository, ['rev-list', '--count', 'HEAD'])).toBe('1')
+
+    const installedPackage = join(repository, 'orchestration', 'ts')
+    const projectModule = await import(pathToFileURL(
+      join(installedPackage, 'src', 'adapters', 'project.ts'),
+    ).href) as typeof import('../src/adapters/project.ts')
+    const pathsModule = await import(pathToFileURL(
+      join(installedPackage, 'src', 'paths.ts'),
+    ).href) as typeof import('../src/paths.ts')
+    const configModule = await import(pathToFileURL(
+      join(installedPackage, 'src', 'config.ts'),
+    ).href) as typeof import('../src/config.ts')
+    const loopModule = await import(pathToFileURL(
+      join(installedPackage, 'src', 'loop.ts'),
+    ).href) as typeof import('../src/loop.ts')
+
+    const project = await projectModule.loadProject(join(repository, 'orchestration'), {})
+    expect(project.name).toBe('consumer')
+    const fixturePaths = referencedPaths(project)
+    expect(fixturePaths).toContain('orchestration/project/scripts/ensure-environment.ts')
+    for (const fixturePath of fixturePaths) {
+      expect(existsSync(join(repository, fixturePath)), fixturePath).toBe(true)
+    }
+
+    const forgeCalls: string[] = []
+    const forge = new Proxy(makeFakeForge(), {
+      get(target, property, receiver) {
+        const member = Reflect.get(target, property, receiver) as unknown
+        if (typeof member !== 'function') return member
+        return (...args: unknown[]) => {
+          forgeCalls.push(String(property))
+          return Reflect.apply(member, target, args)
+        }
+      },
+    }) as Forge
+    const runnerStart = vi.fn(async () => process.pid)
+    const logs: string[] = []
+    const paths = pathsModule.orchPaths(repository)
+    const config = configModule.loadConfig({
+      AUTO_MERGE: 'false',
+      AUTO_PR: 'false',
+      CORE_AUTO_UPDATE: 'false',
+      ISSUE_QUEUE_ENABLED: 'false',
+      REVIEW_ENABLED: 'false',
+      SCAN_ENABLED: 'false',
+    })
+    const loop = loopModule.createLoop({
+      paths,
+      config,
+      forge,
+      runner: { start: runnerStart },
+      project,
+      log: (line) => logs.push(line),
+      now: () => new Date('2026-08-12T00:00:00Z'),
+    })
+
+    loop.initializeSessionStateForBranch()
+    await expect(loop.poll()).resolves.toBe('continue')
+    expect(logs).toContain('Status Running=0  Queue=0')
+    expect(runnerStart).not.toHaveBeenCalled()
+    expect(forgeCalls).toEqual([])
+  })
+})

--- a/tests/fixtures/consumer/orchestration/project/project-consumer.ts
+++ b/tests/fixtures/consumer/orchestration/project/project-consumer.ts
@@ -1,0 +1,54 @@
+import type {
+  MergeCheck,
+  ProjectAdapter,
+  SuiteStep,
+} from '../ts/src/adapters/project.ts'
+
+const ENVIRONMENT_CHECK = 'orchestration/project/scripts/ensure-environment.ts'
+const ORCHESTRATION_MANIFEST = 'orchestration/ts/package.json'
+
+export const consumerProject: ProjectAdapter = {
+  name: 'consumer',
+  scanWorktreeSetup: [
+    {
+      label: 'Consumer environment',
+      cwd: '',
+      command: `node ${ENVIRONMENT_CHECK}`,
+      requires: ENVIRONMENT_CHECK,
+    },
+  ],
+
+  mergeChecks(_taskGate: 'full' | 'light'): MergeCheck[] {
+    return [
+      {
+        label: 'Orchestration package',
+        cwd: 'orchestration/ts',
+        command: 'npm run typecheck',
+        requires: ORCHESTRATION_MANIFEST,
+      },
+    ]
+  },
+
+  cycleSuite(): SuiteStep[] {
+    return [
+      {
+        label: 'Orchestration suite',
+        cwd: 'orchestration/ts',
+        command: 'npm test',
+        requires: ORCHESTRATION_MANIFEST,
+      },
+    ]
+  },
+
+  pullRequest: {
+    categories: [
+      { label: 'Features', title: { singular: 'feature', plural: 'features' } },
+      { label: 'Bug Fixes', title: { singular: 'fix', plural: 'fixes' } },
+    ],
+    titleFallback: 'tooling only',
+    classifyCommit: ({ subject }) => ({
+      category: subject.startsWith('feat:') ? 'Features' : 'Bug Fixes',
+    }),
+    detectRisks: () => [],
+  },
+}

--- a/tests/fixtures/consumer/orchestration/project/scripts/ensure-environment.ts
+++ b/tests/fixtures/consumer/orchestration/project/scripts/ensure-environment.ts
@@ -1,0 +1,2 @@
+// A consumer-owned setup script referenced by the project adapter.
+process.exitCode = 0

--- a/tests/fixtures/consumer/orchestration/ts/src/adapters/project.ts
+++ b/tests/fixtures/consumer/orchestration/ts/src/adapters/project.ts
@@ -1,0 +1,3 @@
+// This type-only bridge lets the checked-in consumer adapter participate in the core's
+// typecheck. The smoke test replaces the bridge with the package's actual source tree.
+export type * from '../../../../../../../src/adapters/project.ts'

--- a/tests/fixtures/consumer/package.json
+++ b/tests/fixtures/consumer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "orchestration-consumer-smoke",
+  "private": true,
+  "type": "module"
+}

--- a/tests/project-loader.test.ts
+++ b/tests/project-loader.test.ts
@@ -154,4 +154,22 @@ describe('project adapter loading', () => {
       `Project adapter not found: ${missingPath}`,
     )
   })
+
+  it('names a missing member on the matching project export', async () => {
+    const repository = createFixtureRepository()
+    const orchestrationRoot = join(repository, 'orchestration')
+    const adapterPath = join(orchestrationRoot, 'project', 'project-fixture.ts')
+    mkdirSync(dirname(adapterPath), { recursive: true })
+    writeFileSync(adapterPath, `
+export const fixtureProject = {
+  name: 'fixture',
+  mergeChecks: () => [],
+  cycleSuite: () => [],
+}
+`)
+
+    await expect(loadProject(orchestrationRoot, {})).rejects.toThrow(
+      `Project adapter '${adapterPath}' exports project 'fixture' but is missing required member 'pullRequest'`,
+    )
+  })
 })


### PR DESCRIPTION
Two merge gates hung today, fifty minutes each, on `tests/cli.test.ts`. The suite produced no failure and no further output; the only evidence was a live `node …/src/cli.ts loop` in the process list, inside the merge worktree.

Four tests run the CLI's `loop` command with `spawnSync` and rely on the loop deciding to exit — a burst-failure cap, an exhausted cycle cap, a rejected PID lock. When one of those conditions does not hold, the spawn blocks forever, and **vitest's test timeout cannot interrupt a synchronous spawn**: the worker freezes rather than failing.

Adding `timeout` to every CLI invocation in the file turns that into a failed test with output.

This is not a fix for whatever made the loop keep polling — the same suite passed 439/439 on the branch it was blocking, both before and after, so the trigger is a race rather than a defect in the tree under test. It is a fix for the failure mode: a race that costs fifty minutes of silence is much worse than one that costs a red test.

Verified: typecheck clean, `tests/cli.test.ts` 16 passing.