### PR TITLE
test: keep the caller's loop settings out of the CLI tests

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -19,8 +19,23 @@ const CLI = join(HERE, '..', 'src', 'cli.ts')
 // before anyone thought to look at the process list. A bound turns it into a failed test.
 const CLI_TIMEOUT_MS = 120_000
 
+// The loop reads its settings from the environment, so inheriting the caller's is enough
+// to change what the CLI under test does. An operator running the suite in a checkout
+// where a loop is started with `CORE_AUTO_UPDATE=false` made a test asserting
+// `auto-update on` fail, which then blocked every merge in that repository until the
+// variable was noticed. Only the settings a test sets deliberately may reach the child.
+const INHERITED_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([name]) => !isLoopSetting(name)),
+)
+
+function isLoopSetting(name: string): boolean {
+  return name === 'PROJECT' || name === 'PROJECT_ADAPTER' || name === 'FORGE'
+    || name === 'RUNNER' || name === 'UPSTREAM_REMOTE' || name === 'UPSTREAM_BRANCH'
+    || /^(CORE_|MAX_|SCAN_|TASK_|REVIEW_|ISSUE_|CI_|AUTO_|POLL_)/.test(name)
+}
+
 const CORE_ENV = {
-  ...process.env,
+  ...INHERITED_ENV,
   PROJECT: 'shiora',
   PROJECT_ADAPTER: join(HERE, 'fixtures', 'project-loader-fixture.ts'),
 }
@@ -211,7 +226,7 @@ describe('manually promoted run ending', () => {
 
     const result = spawnSync(process.execPath, [CLI, 'shipped', '322'], {
       cwd: repoRoot,
-      env: { ...process.env, MAX_SCAN_CYCLES: '3' },
+      env: { ...INHERITED_ENV, MAX_SCAN_CYCLES: '3' },
       encoding: 'utf8',
       windowsHide: true,
       timeout: CLI_TIMEOUT_MS,
@@ -232,7 +247,7 @@ describe('manually promoted run ending', () => {
 
     const result = spawnSync(process.execPath, [CLI, 'shipped', '323'], {
       cwd: repoRoot,
-      env: { ...process.env, MAX_SCAN_CYCLES: '8' },
+      env: { ...INHERITED_ENV, MAX_SCAN_CYCLES: '8' },
       encoding: 'utf8',
       windowsHide: true,
       timeout: CLI_TIMEOUT_MS,


### PR DESCRIPTION
`CORE_ENV` spread `process.env`, so any loop setting present in the shell running the suite reached the CLI under test.

That is not theoretical. shiora's loop was started with `CORE_AUTO_UPDATE=false` as a workaround for #19, and the test asserting the daemon prints `auto-update on` began failing:

```
AssertionError: expected '… Mode  core  auto-update off' to contain 'Mode  core  auto-update on'
```

Every merge in that repository then failed its gate, three in a row, and the loop stopped — from an environment variable, with nothing in the failure pointing at one.

The settings the loop reads are now filtered out of the inherited environment, so only what a test sets deliberately reaches the child. Reproduced by running the suite with `CORE_AUTO_UPDATE=false` set: failing before, 16 passing after.

Verified: typecheck clean, full suite 439 passing.