### PR TITLE
chore: decide line endings in the repository, not in each checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# Line endings are decided here rather than by each checkout's core.autocrlf, so that a
+# file copied out of a working tree — mounted into a container, installed by `init` —
+# behaves the same as one Git checked out. A shell script with CRLF fails on Linux with
+# `$'\r': command not found`, and this package ships hooks that consumers execute.
+* text=auto eol=lf
+
+# Source and configuration — always LF
+*.ts text eol=lf
+*.mjs text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf
+.gitignore text eol=lf
+.gitattributes text eol=lf
+
+# Executed as shell scripts, on whichever platform — always LF
+*.sh text eol=lf
+.githooks/* text eol=lf
+
+# Interpreted by cmd.exe, which requires CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# No conversion
+*.png binary
+*.ico binary
+*.woff2 binary


### PR DESCRIPTION
core is the only one of the three repositories without a `.gitattributes`; react-ko and shiora both have one.

The index is already LF, so this changes no stored content — `git add --renormalize .` touched nothing but the new file. What it changes is the **working tree on Windows**, which `core.autocrlf=true` currently fills with CRLF.

That matters here more than it usually does, because this package's files are used from the working tree and not only through a Git checkout:

- `init` installs the hooks this package ships. A hook with CRLF fails on Linux with `$'\r': command not found` — reproduced by mounting `.githooks/` into a container.
- `npm run test:linux` exports `HEAD`, so it is unaffected — but anything that copies rather than exports would carry CRLF into Linux.

It also removes the "LF will be replaced by CRLF" warning printed on every commit, and the class of failure where a scripted edit does not match because the file on disk has different line endings than the pattern.

Mirrors shiora's file, narrowed to the extensions this repository actually contains.