### PR TITLE
fix: stop the suite from deleting its own dependencies, and refuse a gate that borrows them

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -109,6 +109,13 @@ non-negative integers, with the narrower bounds stated below.
    reduced merge checks, then runs the adapter's cycle suite once at each cycle-gate
    entry. Light-gate attribution cost (a suite break at the gate names no task) is
    accepted and documented; the gate stops the loop rather than promote a failing tip.
+9a. A merge check runs only where its directory satisfies its own declared dependencies.
+    A worktree sits inside the checkout it was cut from, so Node resolves anything the
+    worktree lacks from the parent's `node_modules`: an install that stopped partway
+    produces a run against a dependency tree nobody assembled, and its verdict describes
+    neither tree. Declared dependencies with no `node_modules`, an npm-owned directory
+    with no completed-install record, or any declared dependency absent from
+    `node_modules` fails the check and names what would have been borrowed.
 10. `MAX_CONSECUTIVE_MERGE_FAILURES` (default 3) merge failures in a row stop the loop;
     a completed task remains eligible for merge on later polls, and any successful merge
     resets the count. Re-claiming completed-but-unmerged work requests that merge instead

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -591,7 +591,13 @@ const cmdLoop: Command = async (paths, args) => {
     const child = spawn(process.execPath, [
       packageFile('src', 'cli.ts'), 'loop', '--marker-output', markerLog,
     ], {
-      cwd: packageFile(),
+      // The daemon must work on the repository this launcher was pointed at. Starting it
+      // in the package directory instead made it resolve its own checkout as the
+      // repository, which put the startup dependency install inside the very package the
+      // daemon runs from — `npm ci` deletes node_modules first, so a suite launching a
+      // daemon deleted its own dependencies mid-run. The script path is absolute, so the
+      // working directory is free to be the repository.
+      cwd: paths.repoRoot,
       detached: true,
       stdio: ['ignore', fd, fd],
     })

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -8,6 +8,7 @@ import type { Forge } from './adapters/forge.ts'
 import { operatingSystem } from './adapters/os.ts'
 import type { ProjectAdapter } from './adapters/project.ts'
 import { shortTaskId } from './ids.ts'
+import { verifyModuleIsolation } from './moduleIsolation.ts'
 import {
   branchName, isInspectionTaskId, logFile, packageFile, worktreeDir, PACKAGE_ROOT,
   type OrchPaths,
@@ -277,6 +278,7 @@ function runMergeChecks(
 ): void {
   if (options.testCmd !== undefined && options.testCmd !== '') {
     io.out(`=== Running tests in worktree: ${options.testCmd} ===`)
+    assertModuleIsolation(worktree, 'the worktree', io)
     try {
       io.run(worktree, options.testCmd)
     } catch {
@@ -297,9 +299,25 @@ function runMergeChecks(
     if (install !== undefined && !existsSync(join(worktree, install.path))) {
       ok = io.tryRun(join(worktree, check.cwd), install.command, `${check.label} install`) && ok
     }
+    assertModuleIsolation(join(worktree, check.cwd), check.label, io)
     ok = io.tryRun(join(worktree, check.cwd), check.command, check.label) && ok
   }
   if (!ok) throw new MergeError('Tests failed. Aborting merge.')
+}
+
+/**
+ * Refuse to run a check whose dependencies would come from outside its own directory.
+ * Reaching a parent's node_modules produces a run against a dependency tree nobody
+ * installed, whose result says nothing about the commit under test.
+ */
+function assertModuleIsolation(directory: string, label: string, io: MergeIo): void {
+  const isolation = verifyModuleIsolation(directory)
+  if (isolation.isolated) return
+  io.out(`=== ${label}: dependencies are not installed in place ===`)
+  io.out(isolation.reason ?? '')
+  throw new MergeError(
+    `${label} would resolve dependencies from outside ${directory}: ${isolation.reason}`,
+  )
 }
 
 export function removeTemporaryWorktree(

--- a/src/moduleIsolation.ts
+++ b/src/moduleIsolation.ts
@@ -1,0 +1,87 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// A task worktree lives under the checkout it was cut from, so Node's module resolution
+// walks up into the parent's node_modules for anything the worktree does not have. An
+// install that stopped early therefore does not fail: the run silently mixes the two
+// dependency trees. On 2026-08-13 that mixture ran a suite to a green summary and then
+// crashed the process on teardown, failing three merges in a row while every test passed.
+//
+// Borrowing from the parent is never intended, so a directory that declares dependencies
+// must satisfy them itself. Anything else stops the gate rather than running.
+
+export interface ModuleIsolation {
+  /** Whether the directory can run without reaching outside itself for dependencies. */
+  isolated: boolean
+  /** Why it cannot, phrased for the gate log. Absent when isolated. */
+  reason?: string
+}
+
+interface Manifest {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+const MISSING_NAMES_REPORTED = 5
+
+function declaredDependencies(manifest: Manifest): string[] {
+  return [
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.devDependencies ?? {}),
+  ]
+}
+
+/**
+ * Report whether `directory` satisfies its declared dependencies locally. A directory
+ * that declares none, or that no package manifest describes, has nothing to borrow.
+ */
+export function verifyModuleIsolation(directory: string): ModuleIsolation {
+  const manifestFile = join(directory, 'package.json')
+  if (!existsSync(manifestFile)) return { isolated: true }
+
+  let manifest: Manifest
+  try {
+    manifest = JSON.parse(readFileSync(manifestFile, 'utf8')) as Manifest
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    return { isolated: false, reason: `package.json could not be read: ${detail}` }
+  }
+
+  const declared = declaredDependencies(manifest)
+  if (declared.length === 0) return { isolated: true }
+
+  const modules = join(directory, 'node_modules')
+  if (!existsSync(modules)) {
+    return {
+      isolated: false,
+      reason: `${declared.length} dependencies are declared but node_modules is absent, `
+        + 'so every one of them would resolve from a parent directory',
+    }
+  }
+
+  // npm writes this record only once an install completes, which is what separates a
+  // finished install from one that stopped partway. Other package managers do not write
+  // it, so require it only where a lockfile shows npm owns the directory.
+  if (existsSync(join(directory, 'package-lock.json'))
+    && !existsSync(join(modules, '.package-lock.json'))) {
+    return {
+      isolated: false,
+      reason: 'node_modules carries no completed-install record, so the install did not finish',
+    }
+  }
+
+  const missing = declared.filter((name) => !existsSync(join(modules, name)))
+  if (missing.length > 0) {
+    const listed = missing.slice(0, MISSING_NAMES_REPORTED).join(', ')
+    const rest = missing.length > MISSING_NAMES_REPORTED
+      ? ` and ${missing.length - MISSING_NAMES_REPORTED} more`
+      : ''
+    return {
+      isolated: false,
+      reason: `${missing.length} declared dependencies are not installed here `
+        + `(${listed}${rest}), so they would resolve from a parent directory`,
+    }
+  }
+
+  return { isolated: true }
+}

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -429,6 +429,19 @@ describe('mergeTask', () => {
     expect(outputLines).toContain('check warning')
   })
 
+  it('refuses a check whose dependencies would resolve from the parent checkout', async () => {
+    const taskId = '20260808_000000_013_user-declares-uninstalled-dependency'
+    const worktree = await makeCompletedTask(taskId, { commit: true })
+    writeFileSync(join(worktree, 'package.json'), `${JSON.stringify({
+      name: 'fixture', devDependencies: { 'fixture-dependency': '^1.0.0' },
+    }, null, 2)}\n`)
+    git(worktree, ['add', 'package.json'])
+    git(worktree, ['commit', '-qm', 'test: declare a dependency nobody installed'])
+
+    await expect(mergeTask(paths, taskId, { taskGate: 'light', project: installProject }))
+      .rejects.toThrow(/resolve dependencies from outside/)
+  })
+
   it('skips installation when the merge check dependency path is present', async () => {
     const taskId = '20260808_000000_009_user-has-dependency'
     const worktree = await makeCompletedTask(taskId, { commit: true })

--- a/tests/module-isolation.test.ts
+++ b/tests/module-isolation.test.ts
@@ -1,0 +1,96 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { verifyModuleIsolation } from '../src/moduleIsolation.ts'
+
+describe('verifyModuleIsolation', () => {
+  let root = ''
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orch module-isolation-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  const writeManifest = (manifest: unknown): void => {
+    writeFileSync(join(root, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+  }
+
+  const install = (names: readonly string[], record = true): void => {
+    const modules = join(root, 'node_modules')
+    mkdirSync(modules, { recursive: true })
+    if (record) writeFileSync(join(modules, '.package-lock.json'), '{}\n')
+    for (const name of names) mkdirSync(join(modules, name), { recursive: true })
+  }
+
+  it('accepts a directory that satisfies every declared dependency itself', () => {
+    writeManifest({ devDependencies: { vitest: '^3.0.0' }, dependencies: { zod: '^3.0.0' } })
+    writeFileSync(join(root, 'package-lock.json'), '{}\n')
+    install(['vitest', 'zod'])
+
+    expect(verifyModuleIsolation(root)).toEqual({ isolated: true })
+  })
+
+  it('refuses a partial install, naming what would come from a parent directory', () => {
+    writeManifest({ devDependencies: { vitest: '^3.0.0', typescript: '^5.0.0' } })
+    install(['typescript'])
+
+    const verdict = verifyModuleIsolation(root)
+
+    expect(verdict.isolated).toBe(false)
+    expect(verdict.reason).toContain('vitest')
+    expect(verdict.reason).toContain('resolve from a parent directory')
+  })
+
+  it('refuses an install that never finished, even with every directory present', () => {
+    writeManifest({ devDependencies: { vitest: '^3.0.0' } })
+    writeFileSync(join(root, 'package-lock.json'), '{}\n')
+    install(['vitest'], false)
+
+    const verdict = verifyModuleIsolation(root)
+
+    expect(verdict.isolated).toBe(false)
+    expect(verdict.reason).toContain('completed-install record')
+  })
+
+  it('does not demand npm\'s install record where no npm lockfile owns the directory', () => {
+    writeManifest({ devDependencies: { vitest: '^3.0.0' } })
+    install(['vitest'], false)
+
+    expect(verifyModuleIsolation(root)).toEqual({ isolated: true })
+  })
+
+  it('refuses a declared dependency set with no node_modules at all', () => {
+    writeManifest({ dependencies: { zod: '^3.0.0' } })
+
+    const verdict = verifyModuleIsolation(root)
+
+    expect(verdict.isolated).toBe(false)
+    expect(verdict.reason).toContain('node_modules is absent')
+  })
+
+  it('resolves scoped names against their own directory', () => {
+    writeManifest({ devDependencies: { '@types/node': '^24.0.0' } })
+    install(['@types/node'])
+
+    expect(verifyModuleIsolation(root)).toEqual({ isolated: true })
+  })
+
+  it('accepts a directory that declares nothing and one that no manifest describes', () => {
+    expect(verifyModuleIsolation(root)).toEqual({ isolated: true })
+    writeManifest({ name: 'declares-nothing' })
+    expect(verifyModuleIsolation(root)).toEqual({ isolated: true })
+  })
+
+  it('refuses a manifest it cannot read rather than assuming it declares nothing', () => {
+    writeFileSync(join(root, 'package.json'), '{ not json\n')
+
+    const verdict = verifyModuleIsolation(root)
+
+    expect(verdict.isolated).toBe(false)
+    expect(verdict.reason).toContain('could not be read')
+  })
+})

--- a/tests/runner-survival.test.ts
+++ b/tests/runner-survival.test.ts
@@ -1,9 +1,9 @@
 import { spawnSync } from 'node:child_process'
 import {
-  existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync,
+  existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { expect, it } from 'vitest'
 import { operatingSystem } from '../src/adapters/os.ts'
@@ -15,6 +15,7 @@ const PROJECT_ADAPTER = join(HERE, 'fixtures', 'project-loader-fixture.ts')
 interface SpawnProbe {
   command: string
   args: string[]
+  cwd: string | undefined
   detached: boolean
   hasWindowsHide: boolean
 }
@@ -85,6 +86,7 @@ it('launches the real CLI daemon in the detached console-sharing mode', async ()
       '  appendFileSync(process.env.ORCH_TEST_SPAWN_PROBE, `${JSON.stringify({',
       '    command,',
       '    args,',
+      '    cwd: options?.cwd,',
       '    detached: options?.detached === true,',
       "    hasWindowsHide: Object.hasOwn(options ?? {}, 'windowsHide'),",
       '  })}\\n`)',
@@ -124,6 +126,11 @@ it('launches the real CLI daemon in the detached console-sharing mode', async ()
     const daemonSpawn = probes.find((probe) => probe.command === process.execPath
       && probe.args.includes('--marker-output'))
     expect(daemonSpawn).toMatchObject({ detached: true, hasWindowsHide: false })
+    // The daemon must inherit the repository the launcher was pointed at. Started in the
+    // package directory instead, it resolves its own checkout as the repository and the
+    // startup dependency install reinstalls the package it is running from.
+    expect(resolve(daemonSpawn?.cwd ?? '').toLowerCase())
+      .toBe(realpathSync.native(root).toLowerCase())
 
     mkdirSync(dirname(stopFile), { recursive: true })
     writeFileSync(stopFile, '')


### PR DESCRIPTION
## Features
- None

## Bug Fixes
- [Loop daemon] Start the daemon in the repository the launcher was pointed at, not in
  its own package directory. Starting it in the package made it resolve that package as
  the repository, so `isInside(repoRoot, PACKAGE_ROOT)` in the startup dependency guard
  was true by construction: the daemon ran `npm ci` on the package it was executing from,
  and `npm ci` empties `node_modules` before installing. A suite that launches a daemon
  deleted its own dependencies mid-run — every test passed, the process then died in
  worker teardown, and the merge gate read that as a test failure.
- [Merge gate] Refuse a check whose directory does not satisfy its own declared
  dependencies. A task worktree sits inside the checkout it was cut from, so Node
  resolves anything the worktree lacks from the parent's `node_modules`; an install that
  stopped partway produced a run against a dependency tree nobody assembled instead of
  failing. The gate now stops and names what would have been borrowed.

## Security
- None

## Project Operations
- None

## Risks
- The daemon's working directory changes from the package directory to the repository
  root. Anything that relied on relative resolution from the package directory would now
  resolve differently; the spawned script path is absolute, and the suite covers the
  daemon launch.
- The merge gate gains a precondition. A repository whose checks legitimately run without
  installing — a directory that declares dependencies but is verified by another tool —
  would now fail that check rather than run it. The verification only applies where a
  `package.json` declares dependencies, and npm's completed-install record is required
  only where a `package-lock.json` shows npm owns the directory.
