### PR TITLE
fix: unblock the merge gate, and give a task's PID the lifetime of its process

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -109,13 +109,15 @@ non-negative integers, with the narrower bounds stated below.
    reduced merge checks, then runs the adapter's cycle suite once at each cycle-gate
    entry. Light-gate attribution cost (a suite break at the gate names no task) is
    accepted and documented; the gate stops the loop rather than promote a failing tip.
-9a. A merge check runs only where its directory satisfies its own declared dependencies.
-    A worktree sits inside the checkout it was cut from, so Node resolves anything the
-    worktree lacks from the parent's `node_modules`: an install that stopped partway
-    produces a run against a dependency tree nobody assembled, and its verdict describes
-    neither tree. Declared dependencies with no `node_modules`, an npm-owned directory
-    with no completed-install record, or any declared dependency absent from
-    `node_modules` fails the check and names what would have been borrowed.
+9a. A merge check that passes counts only where its directory satisfies its own declared
+    dependencies. A worktree sits inside the checkout it was cut from, so Node resolves
+    anything the worktree lacks from the parent's `node_modules`: an install that stopped
+    partway produces a pass against a dependency tree nobody assembled, and that verdict
+    describes neither tree. Declared dependencies with no `node_modules`, an npm-owned
+    directory with no completed-install record, or any declared dependency absent from
+    `node_modules` turns the pass into a failure that names what was borrowed. The
+    verification follows the check rather than preceding it, because a check may install
+    as its own first step.
 10. `MAX_CONSECUTIVE_MERGE_FAILURES` (default 3) merge failures in a row stop the loop;
     a completed task remains eligible for merge on later polls, and any successful merge
     resets the count. Re-claiming completed-but-unmerged work requests that merge instead
@@ -246,6 +248,14 @@ non-negative integers, with the narrower bounds stated below.
     task status also blocks startup and is reported with an OS-specific handle diagnostic.
     A run which publishes work also refuses to start when its branch has no unambiguous
     push target, logging `ERROR` and writing the stop file before task or issue work.
+24a. A task's runner PID is held in `queue/pids/<task-id>`, not in its status record, so
+    the identifier lasts exactly as long as what it describes. Stopping a task's process
+    tree releases its entry in the same step; a tree that resisted termination keeps
+    its entry, because something still runs under that number. An entry written before
+    the running system booted is not believed and is dropped as it is read: identifiers
+    are reassigned across a restart, and a survivor would otherwise refuse a startup or
+    direct a termination at a stranger. A PID left in an older status record is never
+    read back.
 25. The stop file (`queue/stop`) is checked at the top of every poll. `stop`, daemon stop
     outcomes, and daemon termination signals stop every live task process tree (`taskkill
     /T /F` on Windows and the detached process group on POSIX), retain task state for

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -180,9 +180,17 @@ export function syncOrchestrationDepsAtStartup(
   runtime: OrchestrationDepsRuntime = orchestrationDepsRuntime,
 ): void {
   const root = runtime.packageRoot ?? PACKAGE_ROOT
-  // Installing is for the copy this repository carries. A CLI pointed at some other
-  // checkout — a test fixture, another clone — must not reinstall the package it is
-  // itself running from.
+  // Only the repository this loop was started against gets its package synchronized. A
+  // package outside it belongs to someone else's checkout, and installing there would
+  // rewrite dependencies nobody here asked about.
+  //
+  // The package may equally be the repository — that is how this repository runs itself,
+  // and a core that updates its own source has no one else to install the lockfile it
+  // just pulled. `npm ci` empties node_modules before refilling it, so this is safe only
+  // because it happens at startup, before any task or suite depends on that directory.
+  // What must never happen is a process reaching this from somewhere else and pointing it
+  // at its own package: that is why the daemon starts in the repository it was given
+  // rather than in the package directory (see `cmdLoop`).
   if (!isInside(paths.repoRoot, root)) return
   if (!orchestrationDepsMissing(root)) return
   installOrchestrationDeps('at startup', event, runtime)
@@ -278,11 +286,13 @@ function runMergeChecks(
 ): void {
   if (options.testCmd !== undefined && options.testCmd !== '') {
     io.out(`=== Running tests in worktree: ${options.testCmd} ===`)
-    assertModuleIsolation(worktree, 'the worktree', io)
     try {
       io.run(worktree, options.testCmd)
     } catch {
       throw new MergeError('Tests failed. Aborting merge.')
+    }
+    if (!ranIsolated(worktree, 'the worktree', io)) {
+      throw new MergeError('Tests passed against borrowed dependencies. Aborting merge.')
     }
     return
   }
@@ -299,25 +309,30 @@ function runMergeChecks(
     if (install !== undefined && !existsSync(join(worktree, install.path))) {
       ok = io.tryRun(join(worktree, check.cwd), install.command, `${check.label} install`) && ok
     }
-    assertModuleIsolation(join(worktree, check.cwd), check.label, io)
-    ok = io.tryRun(join(worktree, check.cwd), check.command, check.label) && ok
+    const directory = join(worktree, check.cwd)
+    ok = io.tryRun(directory, check.command, check.label)
+      && ranIsolated(directory, check.label, io)
+      && ok
   }
   if (!ok) throw new MergeError('Tests failed. Aborting merge.')
 }
 
 /**
- * Refuse to run a check whose dependencies would come from outside its own directory.
- * Reaching a parent's node_modules produces a run against a dependency tree nobody
- * installed, whose result says nothing about the commit under test.
+ * Whether a check that just passed did so on dependencies of its own. A worktree sits
+ * inside the checkout it was cut from, so Node resolves whatever the directory lacks from
+ * the parent's node_modules: a half-finished install produces a pass against a dependency
+ * tree nobody assembled, describing neither tree.
+ *
+ * This runs after the command, not before it, because a check may install as its own
+ * first step — the core's own gate is `npm ci && tsc && npm test` in one command, and
+ * judging it beforehand condemns every gate for a worktree that has not installed yet.
  */
-function assertModuleIsolation(directory: string, label: string, io: MergeIo): void {
+function ranIsolated(directory: string, label: string, io: MergeIo): boolean {
   const isolation = verifyModuleIsolation(directory)
-  if (isolation.isolated) return
-  io.out(`=== ${label}: dependencies are not installed in place ===`)
+  if (isolation.isolated) return true
+  io.out(`=== ${label}: passed on dependencies it does not have ===`)
   io.out(isolation.reason ?? '')
-  throw new MergeError(
-    `${label} would resolve dependencies from outside ${directory}: ${isolation.reason}`,
-  )
+  return false
 }
 
 export function removeTemporaryWorktree(

--- a/src/processRegistry.ts
+++ b/src/processRegistry.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, rmSync, statSync, readFileSync, writeFileSync } from 'node:fs'
+import { uptime } from 'node:os'
+import { join } from 'node:path'
+import type { OrchPaths } from './paths.ts'
+
+// A process identifier is true only while that process runs, but a task's status record
+// outlives it. Recording the PID inside that durable record made a dead task's number
+// survive a stop and a reboot, and the operating system hands the number to something
+// else — after a restart it starts handing out low numbers again. Whoever then read the
+// record could refuse to start ("a task is already running"), or terminate a process
+// tree that belongs to a stranger.
+//
+// So a PID lives here instead, in a store whose lifetime matches what it describes: the
+// entry is removed when the process is stopped, and an entry written before the current
+// boot is not believed. Nothing migrates — a PID left in an old status record is simply
+// no longer read, which is the same verdict this store would give it.
+
+/** Clock granularity between a recorded time and the boot time derived from uptime. */
+const BOOT_COMPARISON_TOLERANCE_MS = 5_000
+
+function registryDir(paths: OrchPaths): string {
+  return join(paths.queueDir, 'pids')
+}
+
+function registryFile(paths: OrchPaths, taskId: string): string {
+  return join(registryDir(paths), taskId)
+}
+
+/** When the running system started, in epoch milliseconds. */
+export function bootedAt(now: () => number = Date.now, up: () => number = uptime): number {
+  return now() - up() * 1000
+}
+
+/** Record the process now running `taskId`. Replaces any earlier entry. */
+export function recordTaskProcess(paths: OrchPaths, taskId: string, pid: number): void {
+  mkdirSync(registryDir(paths), { recursive: true })
+  writeFileSync(registryFile(paths, taskId), `${pid}\n`)
+}
+
+/** Forget the process for `taskId`. Safe to call when nothing was recorded. */
+export function forgetTaskProcess(paths: OrchPaths, taskId: string): void {
+  rmSync(registryFile(paths, taskId), { force: true })
+}
+
+/**
+ * The process recorded for `taskId`, or undefined when none is or a recorded one predates
+ * this boot. A stale entry is dropped as it is read, so the answer does not change again.
+ */
+export function taskProcessPid(
+  paths: OrchPaths,
+  taskId: string,
+  boot: () => number = bootedAt,
+): number | undefined {
+  const file = registryFile(paths, taskId)
+  let recorded: string
+  let writtenAt: number
+  try {
+    recorded = readFileSync(file, 'utf8').trim()
+    writtenAt = statSync(file).mtimeMs
+  } catch {
+    return undefined
+  }
+
+  if (!/^[1-9][0-9]*$/.test(recorded)) {
+    forgetTaskProcess(paths, taskId)
+    return undefined
+  }
+  if (writtenAt + BOOT_COMPARISON_TOLERANCE_MS < boot()) {
+    forgetTaskProcess(paths, taskId)
+    return undefined
+  }
+  return Number(recorded)
+}

--- a/src/status.ts
+++ b/src/status.ts
@@ -4,6 +4,7 @@ import {
 import { join } from 'node:path'
 import { operatingSystem } from './adapters/os.ts'
 import { branchName, statusFile, worktreeDir, type OrchPaths } from './paths.ts'
+import { forgetTaskProcess, recordTaskProcess, taskProcessPid } from './processRegistry.ts'
 
 // A task reads `running` while its runner process is alive, `completed` once the
 // completion marker appears in its final-message file, and `failed` when the process is
@@ -33,12 +34,16 @@ interface StatusMetadata {
 }
 
 export function readStatus(paths: OrchPaths, taskId: string): TaskStatus | undefined {
+  let record: TaskStatus
   try {
-    return JSON.parse(readFileSync(statusFile(paths, taskId), 'utf8')) as TaskStatus
+    record = JSON.parse(readFileSync(statusFile(paths, taskId), 'utf8')) as TaskStatus
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
     throw error
   }
+  // The record is durable; the process it named is not. The registry answers for the
+  // process, so a number left in an old record is not read back as a live task.
+  return { ...record, pid: taskProcessPid(paths, taskId) ?? null }
 }
 
 function lockDir(paths: OrchPaths, taskId: string): string {
@@ -125,6 +130,10 @@ function writeStatusUnlocked(
   const file = statusFile(paths, taskId)
   const temporaryFile = join(paths.statusDir, `.${taskId}.${process.pid}.tmp`)
   const existing = readStatus(paths, taskId)
+  // The registry, not the record, is what later readers believe. Publish there first so
+  // no window exists in which the record claims a process the registry does not have.
+  if (pid !== undefined && Number.isInteger(pid)) recordTaskProcess(paths, taskId, pid)
+  else forgetTaskProcess(paths, taskId)
   const now = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
   const record: TaskStatus = {
     task_id: taskId,

--- a/src/taskProcesses.ts
+++ b/src/taskProcesses.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { operatingSystem, type OperatingSystem } from './adapters/os.ts'
 import { type OrchPaths } from './paths.ts'
+import { forgetTaskProcess } from './processRegistry.ts'
 import { listTaskIds } from './refresh.ts'
 import { readStatus } from './status.ts'
 
@@ -42,6 +43,10 @@ export function terminateLiveTaskProcesses(
   for (const task of liveTaskProcesses(paths, os)) {
     try {
       if (os.terminateProcessTree(task.pid)) result.terminated.push(task)
+      // Stopping is what makes the recorded number false, so it is dropped here rather
+      // than left for whoever reads next. A tree that resisted termination keeps its
+      // entry: something is still running under that number.
+      forgetTaskProcess(paths, task.taskId)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       result.failures.push({ ...task, error: message })

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../src/adapters/os-windows.ts'
 import { cleanupTask, type CleanupRuntime } from '../src/cleanup.ts'
 import { finalMessageFile, orchPaths, statusFile, worktreeDir, type OrchPaths } from '../src/paths.ts'
+import { recordTaskProcess } from '../src/processRegistry.ts'
 
 let repoRoot: string
 let paths: OrchPaths
@@ -24,6 +25,8 @@ function seedTask(pid: number | null): void {
   mkdirSync(worktree, { recursive: true })
   mkdirSync(join(paths.queueDir, 'scanned'), { recursive: true })
   writeFileSync(statusFile(paths, taskId), JSON.stringify({ task_id: taskId, pid }))
+  // A task's process lives in the registry, not in the record.
+  if (pid !== null) recordTaskProcess(paths, taskId, pid)
   writeFileSync(finalMessageFile(paths, taskId), 'TASK_COMPLETE\n')
   writeFileSync(join(paths.queueDir, 'scanned', taskId), '')
   writeFileSync(join(paths.queueDir, 'scanned', `${taskId}.failed`), '')

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -9,6 +9,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { recordIssueForTask } from '../src/issueQueue.ts'
 import { branchName, orchPaths, statusFile, worktreeDir } from '../src/paths.ts'
+import { recordTaskProcess } from '../src/processRegistry.ts'
 import { writeStatus } from '../src/status.ts'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
@@ -351,6 +352,8 @@ describe('loop daemon ownership', () => {
       status: 'running',
       pid: process.pid,
     }))
+    // A task's process lives in the registry, not in the record.
+    recordTaskProcess(paths, taskId, process.pid)
 
     const result = spawnSync(process.execPath, [CLI, 'loop'], {
       cwd: repoRoot,

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../src/issueQueue.ts'
 import { existingTaskIdForDesc } from '../src/ids.ts'
 import { orchPaths, type OrchPaths } from '../src/paths.ts'
+import { recordTaskProcess } from '../src/processRegistry.ts'
 import { specFile } from '../src/tasks.ts'
 import { makeFakeForge, type FakeForge } from './fakeForge.ts'
 import { fakeRunnerSharedSkills } from './fakeRunner.ts'
@@ -1479,6 +1480,7 @@ describe('loop integration in issue mode', () => {
     recordIssueForTask(paths, 'task-running', linked)
     writeFileSync(join(paths.statusDir, 'task-running.json'),
       JSON.stringify({ task_id: 'task-running', status: 'running', pid: process.pid }))
+    recordTaskProcess(paths, 'task-running', process.pid)
     forge.clock = () => new Date('2026-08-08T12:00:00Z')
 
     const { createLoop } = await import('../src/loop.ts')
@@ -1516,6 +1518,7 @@ describe('loop integration in issue mode', () => {
     recordIssueForTask(paths, 'task-running', issueNumber)
     writeFileSync(join(paths.statusDir, 'task-running.json'),
       JSON.stringify({ task_id: 'task-running', status: 'running', pid: process.pid }))
+    recordTaskProcess(paths, 'task-running', process.pid)
     forge.clock = () => new Date('2026-08-08T12:00:00Z')
     forge.commentIssue = async () => { throw new Error('forge unavailable') }
     const logged: string[] = []

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -21,6 +21,7 @@ import {
 import {
   branchName, finalMessageFile, orchPaths, statusFile, worktreeDir, type OrchPaths,
 } from '../src/paths.ts'
+import { forgetTaskProcess, recordTaskProcess } from '../src/processRegistry.ts'
 import { GENERATED_BODY_MARKER } from '../src/prbody.ts'
 import { readStatus } from '../src/status.ts'
 import { enqueueTask } from '../src/tasks.ts'
@@ -106,6 +107,9 @@ function writeFinal(taskId: string, content: string): void {
 function writeRawStatus(taskId: string, status: string, pid: number | null = null): void {
   writeFileSync(statusFile(paths, taskId),
     JSON.stringify({ task_id: taskId, status, pid }))
+  // A running task's process lives in the registry, not in the record.
+  if (pid === null) forgetTaskProcess(paths, taskId)
+  else recordTaskProcess(paths, taskId, pid)
 }
 
 function logText(): string {

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -429,7 +429,7 @@ describe('mergeTask', () => {
     expect(outputLines).toContain('check warning')
   })
 
-  it('refuses a check whose dependencies would resolve from the parent checkout', async () => {
+  it('rejects a check that passed on dependencies it does not have', async () => {
     const taskId = '20260808_000000_013_user-declares-uninstalled-dependency'
     const worktree = await makeCompletedTask(taskId, { commit: true })
     writeFileSync(join(worktree, 'package.json'), `${JSON.stringify({
@@ -437,9 +437,42 @@ describe('mergeTask', () => {
     }, null, 2)}\n`)
     git(worktree, ['add', 'package.json'])
     git(worktree, ['commit', '-qm', 'test: declare a dependency nobody installed'])
+    const outputFile = join(repoRoot, 'merge-check.log')
 
-    await expect(mergeTask(paths, taskId, { taskGate: 'light', project: installProject }))
-      .rejects.toThrow(/resolve dependencies from outside/)
+    await expect(mergeTask(paths, taskId, {
+      taskGate: 'light', project: installProject, outputFile,
+    })).rejects.toThrow(/Tests failed/)
+
+    const output = readFileSync(outputFile, 'utf8')
+    expect(output).toContain('passed on dependencies it does not have')
+    expect(output).toContain('fixture-dependency')
+  })
+
+  it('accepts a check that installs its own dependencies as its first step', async () => {
+    const taskId = '20260808_000000_014_user-installs-inside-the-check'
+    const worktree = await makeCompletedTask(taskId, { commit: true })
+    writeFileSync(join(worktree, 'package.json'), `${JSON.stringify({
+      name: 'fixture', devDependencies: { 'fixture-dependency': '^1.0.0' },
+    }, null, 2)}\n`)
+    git(worktree, ['add', 'package.json'])
+    git(worktree, ['commit', '-qm', 'test: declare a dependency the check installs'])
+    // The core's own gate is `npm ci && tsc && npm test` in one command: nothing is
+    // installed when the check starts, and everything is by the time it ends.
+    const installingProject: ProjectAdapter = {
+      ...stubProject,
+      name: 'installs-inside-check',
+      mergeChecks: () => [{
+        label: 'Fixture gate',
+        cwd: '',
+        command: 'node -e "const {mkdirSync,writeFileSync}=require(\'fs\');'
+          + "mkdirSync('node_modules/fixture-dependency',{recursive:true});"
+          + "writeFileSync('node_modules/.package-lock.json','{}')\"",
+      }],
+    }
+
+    await mergeTask(paths, taskId, { taskGate: 'light', project: installingProject })
+
+    expect(git(repoRoot, ['log', '-1', '--pretty=%s'])).toContain(taskId)
   })
 
   it('skips installation when the merge check dependency path is present', async () => {

--- a/tests/process-registry.test.ts
+++ b/tests/process-registry.test.ts
@@ -1,0 +1,82 @@
+import { existsSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { orchPaths, type OrchPaths } from '../src/paths.ts'
+import {
+  bootedAt, forgetTaskProcess, recordTaskProcess, taskProcessPid,
+} from '../src/processRegistry.ts'
+
+describe('task process registry', () => {
+  let repoRoot = ''
+  let paths: OrchPaths
+  const taskId = '20260813_120000_001_auto-registry'
+
+  beforeEach(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'orch process-registry-'))
+    paths = orchPaths(repoRoot)
+  })
+
+  afterEach(() => {
+    rmSync(repoRoot, { recursive: true, force: true })
+  })
+
+  const registryFile = (): string => join(paths.queueDir, 'pids', taskId)
+
+  it('answers with the process it recorded', () => {
+    recordTaskProcess(paths, taskId, 4321)
+
+    expect(taskProcessPid(paths, taskId)).toBe(4321)
+  })
+
+  it('answers with nothing for a task it never recorded', () => {
+    expect(taskProcessPid(paths, taskId)).toBeUndefined()
+  })
+
+  it('releases the process on stop', () => {
+    recordTaskProcess(paths, taskId, 4321)
+
+    forgetTaskProcess(paths, taskId)
+
+    expect(taskProcessPid(paths, taskId)).toBeUndefined()
+    expect(existsSync(registryFile())).toBe(false)
+  })
+
+  it('forgetting a task that was never recorded is not an error', () => {
+    expect(() => forgetTaskProcess(paths, taskId)).not.toThrow()
+  })
+
+  it('releases a process recorded before this boot, and drops the entry as it reads', () => {
+    recordTaskProcess(paths, taskId, 4321)
+    // The operating system reassigns identifiers across a restart, so a number written
+    // before the machine came up cannot name the process it was written for.
+    const beforeBoot = new Date(Date.now() - 60 * 60 * 1000)
+    utimesSync(registryFile(), beforeBoot, beforeBoot)
+    const bootedAnHourAfterThat = (): number => Date.now() - 30 * 60 * 1000
+
+    expect(taskProcessPid(paths, taskId, bootedAnHourAfterThat)).toBeUndefined()
+    expect(existsSync(registryFile())).toBe(false)
+  })
+
+  it('keeps a process recorded after this boot', () => {
+    recordTaskProcess(paths, taskId, 4321)
+    const bootedAnHourAgo = (): number => Date.now() - 60 * 60 * 1000
+
+    expect(taskProcessPid(paths, taskId, bootedAnHourAgo)).toBe(4321)
+  })
+
+  it('drops an entry that does not name a process', () => {
+    recordTaskProcess(paths, taskId, 4321)
+    writeFileSync(registryFile(), 'not-a-pid\n')
+
+    expect(taskProcessPid(paths, taskId)).toBeUndefined()
+    expect(existsSync(registryFile())).toBe(false)
+  })
+
+  it('derives the boot time from how long the system has been up', () => {
+    const now = (): number => 1_000_000
+    const upFiveMinutes = (): number => 300
+
+    expect(bootedAt(now, upFiveMinutes)).toBe(1_000_000 - 300_000)
+  })
+})

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { operatingSystem } from '../src/adapters/os.ts'
 import { finalMessageFile, orchPaths, statusFile, type OrchPaths } from '../src/paths.ts'
+import { recordTaskProcess } from '../src/processRegistry.ts'
 import { completionMarkerPresent, refreshAll, refreshTask } from '../src/refresh.ts'
 
 let repoRoot: string
@@ -22,6 +23,10 @@ afterEach(() => {
 function writeRawStatus(taskId: string, content: string): string {
   const file = statusFile(paths, taskId)
   writeFileSync(file, content)
+  // A running task's process lives in the registry, not in the record. A fixture that
+  // names one has to put it where the reader looks.
+  const pid = (JSON.parse(content) as { pid?: number | null }).pid
+  if (typeof pid === 'number') recordTaskProcess(paths, taskId, pid)
   return file
 }
 

--- a/tests/start.test.ts
+++ b/tests/start.test.ts
@@ -7,6 +7,7 @@ import type { Runner } from '../src/adapters/runner.ts'
 import {
   branchName, logFile, orchPaths, statusFile, worktreeDir, type OrchPaths,
 } from '../src/paths.ts'
+import { recordTaskProcess } from '../src/processRegistry.ts'
 import { startTask, worktreeAddArgs } from '../src/start.ts'
 import { readStatus } from '../src/status.ts'
 import { specFile } from '../src/tasks.ts'
@@ -77,6 +78,8 @@ describe('startTask', () => {
     writeFileSync(statusFile(paths, taskId), JSON.stringify({
       task_id: taskId, status: 'running', pid: process.pid,
     }))
+    // A task's process lives in the registry, not in the record.
+    recordTaskProcess(paths, taskId, process.pid)
     const start = vi.fn(async () => process.pid)
 
     await expect(startTask(

--- a/tests/task-processes.test.ts
+++ b/tests/task-processes.test.ts
@@ -12,6 +12,7 @@ import {
   type WindowsOperatingSystemRuntime,
 } from '../src/adapters/os-windows.ts'
 import { orchPaths, statusFile, type OrchPaths } from '../src/paths.ts'
+import { recordTaskProcess, taskProcessPid } from '../src/processRegistry.ts'
 import {
   orphanedWorktreeDirectories, terminateLiveTaskProcesses, worktreeHolderHint,
 } from '../src/taskProcesses.ts'
@@ -21,6 +22,7 @@ let paths: OrchPaths
 
 function writeRunningTask(taskId: string, pid: number): void {
   writeFileSync(statusFile(paths, taskId), JSON.stringify({ task_id: taskId, status: 'running', pid }))
+  recordTaskProcess(paths, taskId, pid)
 }
 
 function gone(): NodeJS.ErrnoException {
@@ -67,6 +69,10 @@ describe('terminateLiveTaskProcesses', () => {
     expect(result.failures).toEqual([{
       taskId: 'first-task', pid: 101, error: 'Could not stop process tree 101.',
     }])
+    // Stopping is what makes a recorded identifier false, so a stopped task releases it
+    // and one that resisted keeps it: something is still running under that number.
+    expect(taskProcessPid(paths, 'second-task')).toBeUndefined()
+    expect(taskProcessPid(paths, 'first-task')).toBe(101)
   })
 })
 


### PR DESCRIPTION
## Features
- None

## Bug Fixes
- [Merge gate] Judge a check's dependencies after it runs rather than before. A check may
  install as its own first step — the core's own gate is `npm ci && tsc && npm test` in one
  command — so verifying beforehand condemned every gate whose worktree had not installed
  yet. It stopped the loop after three refusals in forty seconds. A pass obtained against a
  parent's `node_modules` is still refused; a directory that has not installed yet has not
  claimed anything.

## Security
- None

## Project Operations
- [Task state] A task's runner PID moves from its durable status record into
  `queue/pids/<task-id>`, so the identifier lasts exactly as long as the process it names.
  Stopping a task's tree releases the entry in the same step; a tree that resisted keeps it.
  An entry written before the current boot is not believed and is dropped as it is read.
- [Docs] `syncOrchestrationDepsAtStartup` said it refuses to reinstall the package the
  process runs from. It does not, and must not: that is how this repository keeps its own
  dependencies after updating its own source. The comment now says what the guard actually
  covers and points at the daemon working directory that made it reachable from elsewhere.

## Risks
- A PID recorded in a status record written by an older version is no longer read. The
  effect is that such a task reads as having no process — the same verdict the new store
  gives an entry it cannot vouch for, and the conservative one.
- Test fixtures that wrote a running task by hand now record the PID where the reader looks.
  Seven suites were updated; a fixture that forgets will read as a task with no process
  rather than failing loudly.
- The boot comparison allows five seconds of tolerance between a file's recorded time and
  the boot time derived from uptime. A process recorded within five seconds before a
  shutdown could survive that comparison; it would still have to survive the liveness probe
  that follows.
