### PR TITLE
fix: deliver whole specifications and scan every checklist section

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # ==============================
 # commit-msg
@@ -18,28 +18,18 @@ code=0
 printf " - Checking commit message prefix: "
 
 # Allowed commit types
-readonly ALLOWED_TYPES=(
-  "feat"
-  "fix"
-  "chore"
-  "docs"
-  "refactor"
-  "test"
-)
+ALLOWED_TYPES="feat fix chore docs refactor test"
+readonly ALLOWED_TYPES
 
 # Read first line of commit message
 FIRST_LINE="$(head -n 1 "$COMMIT_MSG_FILE")"
 
 # Skip merge commits
-if echo "$FIRST_LINE" | grep -q "^Merge "; then
+if printf '%s\n' "$FIRST_LINE" | grep -q "^Merge "; then
   printf "\033[33;22mSKIPPED\033[0m\n"
 else
-  # Build regex:
-  # ^(type1|type2|...): <non-space>.*
-  TYPES_REGEX="$(printf "|%s" "${ALLOWED_TYPES[@]}")"
-  TYPES_REGEX="^(${TYPES_REGEX:1}): [^ ].*"
-
-  if echo "$FIRST_LINE" | grep -Eq "$TYPES_REGEX"; then
+  if printf '%s\n' "$FIRST_LINE" \
+    | grep -Eq '^(feat|fix|chore|docs|refactor|test): [^ ].*'; then
     printf "\033[32;22mOK\033[0m\n"
   else
     printf "\033[31;22mNG\033[0m\n"
@@ -54,7 +44,7 @@ else
     printf "  - Exactly ONE space after ':'\n"
     printf "  - Subject must not start with a space\n\n"
     printf "Allowed types:\n"
-    printf "  %s\n" "${ALLOWED_TYPES[*]}"
+    printf "  %s\n" "${ALLOWED_TYPES}"
     printf "\nExample:\n"
     printf "  feat: add login feature\n"
     printf "================================================================\033[0m\n"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 printf "\033[37;1m== pre-commit ==\033[0m\n"
 
-HOOK_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+HOOK_DIR="$(CDPATH= cd -P "$(dirname "$0")" && pwd)"
 readonly HOOK_DIR
 node "${HOOK_DIR}/../src/cli.ts" pre-commit

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ git subtree pull --prefix=orchestration/ts \
 | `TASK_GATE` | full | `light` uses project-adapter-selected reduced checks for each merge, followed by the adapter's cycle suite once per cycle |
 | `AUTO_REVIEW` | false | Enable agent review of cycle diffs and queue the findings as fixes |
 | `REVIEW_EVERY_N_CYCLES` | 1 | With `AUTO_REVIEW=true`, review every Nth cycle and always review the final cycle |
+| `CI_GATE_ENABLED` | false | Enable polling PR checks and queueing CI-fix tasks; when false, the CI gate is skipped |
 | `ISSUE_QUEUE_ENABLED` | false | Keep the backlog in forge issues so several machines can share it |
 | `SCAN_EFFORT` / `TASK_EFFORT` / `REVIEW_EFFORT` | high / medium / high | Reasoning effort per kind of work |
 | `CORE_AUTO_UPDATE` | true | Check and pull the shared-core subtree immediately before each cycle; `false` skips the check entirely |

--- a/SPEC.md
+++ b/SPEC.md
@@ -61,6 +61,7 @@ values must be non-negative integers, with the narrower bounds stated below.
 | `AUTO_PR` | `true` | Push the run branch, create or update its draft pull request at cycle gates, and promote it with `LOOP_DONE` when the run finishes. `false` performs none of those PR operations. |
 | `SCAN_ENABLED` | `true` | Start another scan cycle after the current backlog and gate are clear. `false` drains existing local and shared work, performs any enabled final PR promotion, and exits without starting a scan. |
 | `REVIEW_ENABLED` | `true` | Retain the review boundary in the cycle gate. Without `AUTO_REVIEW`, that boundary records resumable state and continues on the next poll; `false` skips it. If `AUTO_PR` is also `false`, disabling this setting bypasses the cycle gate entirely. |
+| `REVIEW_EFFORT` | `high` | Reasoning effort for automatic review tasks. Accepted values are `minimal`, `low`, `medium`, and `high`. |
 | `MAX_PARALLEL` | `3` | Limit concurrently running queued-task processes and shared-issue claim capacity. It must be at least 1; scan fan-out is controlled separately by `SCAN_PARALLEL`. |
 | `POLL_INTERVAL` | `30` | Maximum seconds the daemon waits between polls when no wake signal arrives. Values from 0 through 1800 are accepted; the upper bound keeps polling within the issue-heartbeat interval. |
 | `TEST_CMD` | empty | When non-empty, run this command in a task worktree as its merge test and use it instead of the project adapter's path-selected merge checks. A manual merge's `--test-cmd` takes precedence. |
@@ -151,9 +152,11 @@ values must be non-negative integers, with the narrower bounds stated below.
     `MAX_EMPTY_SCANS`. The current cycle number lives in `queue/scan-count.txt` and is
     re-read every poll (this is also the documented lever for forcing an early final
     cycle on a running loop).
-14. Effort defaults: scans run the runner at high reasoning effort, queued tasks at
-    medium; `SCAN_EFFORT`, `TASK_EFFORT`, `SCAN_MODEL`, `TASK_MODEL` override, and
-    `delegate --effort` overrides per task.
+14. Effort defaults: scans and automatic reviews run the runner at high reasoning
+    effort, and queued tasks at medium. `SCAN_EFFORT`, `TASK_EFFORT`, and
+    `REVIEW_EFFORT` accept `minimal`, `low`, `medium`, or `high` and override their
+    respective defaults; `SCAN_MODEL` and `TASK_MODEL` override the runner model, and
+    `delegate --effort` overrides effort per task.
 14a. Immediately before a new cycle consumes its number or starts a scan, after the
     previous cycle gate has closed and while no task is running, the daemon fetches the
     configured core upstream and compares its tip with the last `git-subtree-split` for

--- a/SPEC.md
+++ b/SPEC.md
@@ -77,8 +77,11 @@ values must be non-negative integers, with the narrower bounds stated below.
 2. Task ids are `YYYYMMDD_HHMMSS_nnn_<slug>` with `nnn` a per-day sequence; slugs end in
    `scan` for scans and start with `ci-fix`, `auto-`, `fix-`, or `user-` for CI fixes,
    scan findings, review-origin fixes, and delegated work. Listings sort chronologically.
-3. `queue/desc-index` maps a description to its task id: the same finding reported twice
-   or the same decision delegated twice resolves to the one existing task.
+3. `queue/desc-index` maps a description to its current task id. The same decision
+   delegated twice resolves to one task, as does a repeated finding while its indexed
+   task is queued, running, completed, or retryable after failure. If an identical
+   non-advisory finding returns after that task has merged, it creates a fresh task and
+   updates the index; merged advisories remain deduplicated.
 4. Each task runs in its own worktree under `orchestration/worktrees/<id>` on branch
    `task/<id>`.
 5. Failure handling: emit `FAILED: <id>` with the log path to the machine-marker sink,

--- a/SPEC.md
+++ b/SPEC.md
@@ -90,9 +90,14 @@ values must be non-negative integers, with the narrower bounds stated below.
 
 ## Growth and decisions
 
-6. A completed task's final message is scanned for `NEXT_TASK: <description>` lines;
-   each becomes a queued task. `MAX_GROWTH_DEPTH` (default 2) and `MAX_TOTAL_TASKS`
-   (default 50) bound the growth. Directives elsewhere in the transcript are ignored.
+6. A completed task's final message is scanned for lines beginning exactly with
+   `NEXT_TASK:`. After trimming the description, a line becomes work only when it is
+   non-empty, contains none of the pinned format placeholders (literal or HTML-encoded),
+   is not pinned no-finding prose, and produces a task slug containing an ASCII letter
+   or digit. `MAX_GROWTH_DEPTH` (default 2) and `MAX_TOTAL_TASKS` (default 50) bound the
+   growth. Directives elsewhere in the transcript are ignored. The completion remains
+   pending, and cannot merge or pass the cycle gate, until accepted findings are
+   reconciled and the durable scanned flag is written.
 7. `DECISION_REQUIRED: <text>` is logged and carried into the PR risks, never queued.
    Dedup: a line naming a `GHSA-`/`CVE-` identifier matches on the identifier (a scan
    words the same advisory differently every cycle); a line naming neither matches on
@@ -236,7 +241,8 @@ values must be non-negative integers, with the narrower bounds stated below.
     (Features, Bug Fixes, Security, Project Operations, Risks), `- None` where empty.
     Title and body come from the same classification, so they cannot disagree.
 22. An HTML comment on the first body line marks the text as generated; a hand-edited
-    body (marker gone) is never overwritten again.
+    body (marker gone) is never overwritten again. Body ownership does not freeze the
+    generated title, which is still updated through the adapter's title-only field.
 23. The body is built from commit history and therefore shows intermediate steps of
     reworked changes; `LOOP_DONE` output reminds that the summary is rewritten by hand
     from the diff before review.

--- a/orchestration/project/project-core.ts
+++ b/orchestration/project/project-core.ts
@@ -14,6 +14,7 @@ const SUITE = 'npm test -- --pool=threads --poolOptions.threads.singleThread'
 
 export const coreProject: ProjectAdapter = {
   name: 'core',
+  verifyDependencyIsolation: true,
 
   preCommitChecks: [
     {

--- a/src/adapters/project.ts
+++ b/src/adapters/project.ts
@@ -104,6 +104,8 @@ export interface ProjectAdapter {
   deployment?: { workflow: string; revisionUrl: string }
   /** Whether pull requests are expected to receive CI checks. Omit when unknown. */
   ciChecksExpected?: boolean
+  /** Verify that passing merge checks did not borrow Node modules from a parent checkout. */
+  verifyDependencyIsolation?: boolean
   /** Per-merge verification, selected from the paths the worktree touched. */
   mergeChecks(taskGate: 'full' | 'light'): MergeCheck[]
   /** Fast checks run by the core-owned pre-commit hook against staged paths. */

--- a/src/adapters/runner-codex.ts
+++ b/src/adapters/runner-codex.ts
@@ -6,11 +6,11 @@ import type {
   Runner, RunnerSharedSkillRenderOptions, RunnerStartOptions,
 } from './runner.ts'
 
-// The spec content is the prompt, passed as one
-// argument; the final message lands in --output-last-message, which is the only
-// place the core reads completion markers from. Effort maps to the codex-specific
+// The spec is the prompt, read by Codex from standard input via `-`; the final
+// message lands in --output-last-message, which is the only place the core reads
+// completion markers from. Effort maps to the codex-specific
 // `model_reasoning_effort` config key here, not in the core.
-function buildArgs(options: RunnerStartOptions, specContent: string): string[] {
+function buildArgs(options: RunnerStartOptions): string[] {
   const args = [
     'exec',
     '--dangerously-bypass-approvals-and-sandbox',
@@ -20,7 +20,7 @@ function buildArgs(options: RunnerStartOptions, specContent: string): string[] {
     args.push('--model', options.model)
   }
   args.push('--config', `model_reasoning_effort=${options.effort}`)
-  args.push(specContent)
+  args.push('-')
   return args
 }
 
@@ -92,16 +92,21 @@ export function createCodexRunner(): Runner {
       renderFile: renderSharedSkillFile,
     },
     start(options: RunnerStartOptions): Promise<number> {
-      const specContent = readFileSync(options.specFile, 'utf8')
-      const args = buildArgs(options, specContent)
+      const args = buildArgs(options)
       // startTask clears this file before setup; append so setup output remains ahead
       // of the runner transcript instead of being silently truncated here.
       const logFd = openSync(options.logFile, 'a')
+      let specFd: number
+      try {
+        specFd = openSync(options.specFile, 'r')
+      } catch (error) {
+        closeSync(logFd)
+        return Promise.reject(error)
+      }
 
       // On Windows the `codex` on PATH is an npm .cmd shim, which Node cannot spawn
-      // without a shell — and shell quoting would mangle the multi-line spec argument.
-      // Git Bash is already a hard requirement of this repository, so route through
-      // `bash -c` with positional arguments: nothing is ever re-quoted.
+      // without a shell. Git Bash is already a hard requirement of this repository,
+      // so route through `bash -c` with positional arguments.
       const viaBash = process.platform === 'win32'
       const command = viaBash ? 'bash' : 'codex'
       const commandArgs = viaBash
@@ -109,11 +114,15 @@ export function createCodexRunner(): Runner {
         : args
 
       return new Promise((resolve, reject) => {
-        let logFdClosed = false
-        const closeLogFd = (): void => {
-          if (logFdClosed) return
-          closeSync(logFd)
-          logFdClosed = true
+        let descriptorsClosed = false
+        const closeDescriptors = (): void => {
+          if (descriptorsClosed) return
+          descriptorsClosed = true
+          try {
+            closeSync(specFd)
+          } finally {
+            closeSync(logFd)
+          }
         }
 
         let child
@@ -123,19 +132,19 @@ export function createCodexRunner(): Runner {
           child = spawn(command, commandArgs, {
             cwd: options.worktree,
             detached: true,
-            stdio: ['ignore', logFd, logFd],
+            stdio: [specFd, logFd, logFd],
           })
         } catch (error) {
-          closeLogFd()
+          closeDescriptors()
           reject(error)
           return
         }
         child.once('error', (error) => {
-          closeLogFd()
+          closeDescriptors()
           reject(error)
         })
         child.once('spawn', () => {
-          closeLogFd()
+          closeDescriptors()
           child.unref()
           if (child.pid === undefined) {
             reject(new Error('codex spawned without a PID'))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,10 @@ import {
 } from './tasks.ts'
 import { observeNextPoll } from './wake.ts'
 import { runWorkerCommand } from './worker.ts'
-import { signalLoopRestartReady, startLoopReplacement } from './restart.ts'
+import {
+  loopRestartPredecessorPid, publishLoopReplacementPid, signalLoopRestartReady,
+  startLoopReplacement,
+} from './restart.ts'
 
 // The command surface: each package.json script dispatches here with the command name
 // as the first argument. CLI tokens such as `Enqueued:`, `Created:`, `CYCLE_COMPLETE:`,
@@ -678,6 +681,9 @@ async function runLoopDaemon(
   const cycleCapFile = join(paths.queueDir, 'cycle-cap.txt')
   const recoveryLock = `${pidFile}.recovery`
   let ownsTaskLifecycle = false
+  let ownsDaemonState = true
+  const restartPredecessorPid = loopRestartPredecessorPid()
+  let usesRestartReservation = false
 
   // PID lock: one loop per repository.
   for (;;) {
@@ -697,6 +703,12 @@ async function runLoopDaemon(
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
         throw error
       }
+      if (restartPredecessorPid !== undefined
+        && existing === `${restartPredecessorPid}`
+        && operatingSystem.processIsAlive(restartPredecessorPid)) {
+        usesRestartReservation = true
+        break
+      }
       if (/^\d+$/.test(existing) && operatingSystem.processIsAlive(Number(existing))) {
         log(`ERROR: Loop is already running (PID=${existing}). Please stop and restart.`)
         return 1
@@ -708,6 +720,7 @@ async function runLoopDaemon(
     }
   }
   const releaseDaemonState = (): void => {
+    if (!ownsDaemonState) return
     try {
       removeIssueModeMarker(paths, process.pid)
     } catch {
@@ -769,7 +782,12 @@ async function runLoopDaemon(
     }
     ownsTaskLifecycle = true
 
-    writeIssueModeMarker(paths, config.issueQueueEnabled, process.pid)
+    // During a restart the predecessor stays visible and owns both markers until this
+    // process has completed initialization. The predecessor publishes this PID as one
+    // atomic handover after observing the ready signal.
+    if (!usesRestartReservation) {
+      writeIssueModeMarker(paths, config.issueQueueEnabled, process.pid)
+    }
     log(formatEventLine(
       'Started', 'core', config.coreAutoUpdate ? 'auto-update on' : 'auto-update off',
     ))
@@ -815,26 +833,33 @@ async function runLoopDaemon(
         if (outcome === 'stopped' && !stopOwnedTaskProcesses(true)) return 1
         if (outcome === 'restart') {
           if (!stopOwnedTaskProcesses(false)) return 1
-          // Node has no portable exec(2). Release ownership so the replacement can
-          // claim it, but do not report success until that daemon finishes startup.
-          releaseDaemonState()
+          // Node has no portable exec(2). Keep this live PID published while the
+          // replacement initializes, then atomically transfer ownership after its
+          // explicit ready signal.
           const readyFile = join(
             paths.queueDir,
             `loop.restart-${process.pid}-${Date.now()}.ready`,
           )
-          const replacement = await startLoopReplacement(readyFile)
-          if (!replacement.ok) {
-            const childOwner = replacement.pid === undefined ? '' : `${replacement.pid}`
-            try {
-              if (existsSync(pidFile) && readFileSync(pidFile, 'utf8').trim() === childOwner) {
-                rmSync(pidFile, { force: true })
+          const replacement = await startLoopReplacement(readyFile, {
+            onReady: (replacementPid) => {
+              // Once the child PID is published, neither finally nor the process exit
+              // handler may race it with the predecessor's read-then-remove cleanup.
+              process.off('exit', releaseDaemonState)
+              try {
+                writeIssueModeMarker(paths, config.issueQueueEnabled, replacementPid)
+                publishLoopReplacementPid(pidFile, process.pid, replacementPid)
+                ownsDaemonState = false
+              } catch (error) {
+                try {
+                  writeIssueModeMarker(paths, config.issueQueueEnabled, process.pid)
+                } finally {
+                  process.on('exit', releaseDaemonState)
+                }
+                throw error
               }
-              writeFileSync(pidFile, `${process.pid}\n`, { flag: 'wx' })
-              writeIssueModeMarker(paths, config.issueQueueEnabled, process.pid)
-            } catch (error) {
-              const detail = error instanceof Error ? error.message : String(error)
-              log(formatEventLine('ERROR', 'restart state', detail))
-            }
+            },
+          })
+          if (!replacement.ok) {
             log(formatEventLine(
               'ERROR', 'restart', `replacement could not start: ${replacement.error ?? 'unknown error'}`,
             ))

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,7 +106,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): LoopConfig {
   if (taskGate !== 'full' && taskGate !== 'light') {
     throw new Error(`TASK_GATE must be 'full' or 'light', got '${taskGate}'`)
   }
-  // SCAN_PARALLEL: checklist groups are defined up to 4, so higher values clamp.
+  // SCAN_PARALLEL: the loop supports up to four concurrent scans, so higher values clamp.
   const scanParallel = Math.min(num(env, 'SCAN_PARALLEL', 2), 4)
   if (scanParallel < 1) {
     throw new Error('SCAN_PARALLEL must be at least 1')

--- a/src/gitRemote.ts
+++ b/src/gitRemote.ts
@@ -36,8 +36,10 @@ function resolveCurrentBranchRemote(
 
   if (remotes.size === 1) return [...remotes][0]!
   if (remotes.size === 0) throw new Error('repository has no configured remote')
+  const remoteNames = [...remotes].sort().join(', ')
   throw new Error(
-    `current branch '${branch}' has no upstream and the repository has multiple remotes`,
+    `current branch '${branch}' has no upstream and the repository has multiple remotes: ${remoteNames}; `
+      + `push the branch with an upstream, or configure branch.${branch}.remote`,
   )
 }
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1261,18 +1261,19 @@ export function createLoop(deps: LoopDeps) {
         }
         return false
       }
-      if (body.includes(GENERATED_BODY_MARKER)) {
-        try {
-          await forge.updatePr(branch, {
-            title,
-            body: buildPrBody(project, paths.repoRoot, baseRef, readDecisions()),
-          })
-        } catch (error) {
-          if (!(error instanceof ForgeRateLimitError)) {
-            reportGateFailure(`could not update PR body: ${errorSummary(error)}`)
-          }
-          return false
+      const generatedBody = body.includes(GENERATED_BODY_MARKER)
+      try {
+        await forge.updatePr(branch, generatedBody
+          ? {
+              title,
+              body: buildPrBody(project, paths.repoRoot, baseRef, readDecisions()),
+            }
+          : { title })
+      } catch (error) {
+        if (!(error instanceof ForgeRateLimitError)) {
+          reportGateFailure(`could not update PR ${generatedBody ? 'body' : 'title'}: ${errorSummary(error)}`)
         }
+        return false
       }
       writeFileSync(prUrlFile, `${status.url}\n`)
       previousGateFailures.delete('draft-pr')
@@ -1484,6 +1485,11 @@ export function createLoop(deps: LoopDeps) {
     gateWaitTarget = undefined
     if (countRunning() > 0 || queueLength() > 0) return 'continue'
     if (isScanRunning()) return 'continue'
+    if (listTaskIds(paths).some((taskId) => readStatus(paths, taskId)?.status === 'completed'
+      && !existsSync(join(scannedDir, taskId)))) {
+      gateWaitTarget = 'completion scan'
+      return 'continue'
+    }
     if (config.issueQueueEnabled) {
       if (knownOpenFindings === null) {
         gateWaitTarget = 'finding status'
@@ -1784,7 +1790,8 @@ export function createLoop(deps: LoopDeps) {
     }
 
     const mergeCompletedTask = async (taskId: string): Promise<void> => {
-      if (!config.autoMerge || mergeAttempts.has(taskId)) return
+      if (!config.autoMerge || mergeAttempts.has(taskId)
+        || !existsSync(join(scannedDir, taskId))) return
       mergeAttempts.add(taskId)
       event('Merging', shortTaskId(taskId))
       const mergeLog = join(paths.logsDir, `${taskId}.merge.log`)

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -982,10 +982,31 @@ export function createLoop(deps: LoopDeps) {
     return text
   }
 
-  function generateScanTask(scanId: string, scope: string): boolean {
-    const text = repositoryInspectionPreamble()
+  function scanSpecification(scanId: string, scope: string): string {
+    return repositoryInspectionPreamble()
       + renderTemplate('scan-template.md', { SCAN_ID: scanId, SCAN_SCOPE: scope })
-    writeFileSync(specFile(paths, scanId), text)
+  }
+
+  function numberedScanSections(specification: string): number[] {
+    const sections = [...specification.matchAll(/^ {0,3}#{1,6}[\t ]+(\d+)\.(?:[\t ]|$)/gm)]
+      .map((match) => Number(match[1]))
+    if (sections.length === 0) {
+      throw new Error('parallel scan requires numbered sections in scan-template.md')
+    }
+    if (new Set(sections).size !== sections.length) {
+      throw new Error('parallel scan requires unique numbered sections in scan-template.md')
+    }
+    return sections
+  }
+
+  function partitionScanSections(sections: readonly number[], groupCount: number): number[][] {
+    const groups = Array.from({ length: groupCount }, () => [] as number[])
+    sections.forEach((section, index) => groups[index % groupCount]!.push(section))
+    return groups
+  }
+
+  function generateScanTask(scanId: string, scope: string): boolean {
+    writeFileSync(specFile(paths, scanId), scanSpecification(scanId, scope))
     return true
   }
 
@@ -1661,22 +1682,22 @@ export function createLoop(deps: LoopDeps) {
     // running, and the next cycle has not yet consumed its number or started a scan.
     if (await updateCore(nextCycle) === 'restart') return 'restart'
     const nScans = [1, 2, 3, 4].includes(config.scanParallel) ? config.scanParallel : 2
+    const sectionGroups = nScans === 1
+      ? []
+      : partitionScanSections(
+        numberedScanSections(scanSpecification('scan', '')),
+        nScans,
+      )
     writeFileSync(join(paths.queueDir, `scan-expected-${nextCycle}`), `${nScans}\n`)
     writeFileSync(scanCountFile, `${nextCycle}\n`)
 
-    // Disjoint groups of the checklist's eight sections, balanced so the deep reads
-    // (bugs, tests) do not share a scan at higher parallelism.
-    const sectionGroups: Record<number, string[]> = {
-      1: [''],
-      2: ['1, 2, 5 and 6', '3, 4, 7 and 8'],
-      3: ['1 and 2', '3, 4, 5 and 6', '7 and 8'],
-      4: ['1 and 2', '5 and 6', '3 and 4', '7 and 8'],
-    }
+    // Round-robin groups cover every discovered section exactly once while keeping
+    // group sizes within one, without assuming what any section asks the scan to do.
     for (let i = 1; i <= nScans; i++) {
       const scanId = newTaskId(paths, 'scan', now())
       const scope = nScans === 1
         ? 'Perform every numbered section below.'
-        : `This scan runs alongside ${nScans - 1} partner scan(s). Perform only sections ${(sectionGroups[nScans] as string[])[i - 1]}; the partners cover the rest. Stay inside them — overlapping findings merge away, duplicated reading does not.`
+        : `This scan runs alongside ${nScans - 1} partner scan(s). Perform only sections ${sectionGroups[i - 1]!.join(', ')}; the partners cover the rest. Stay inside them — overlapping findings merge away, duplicated reading does not.`
       if (generateScanTask(scanId, scope)) {
         try {
           await startTask(paths, runner, scanId, {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -988,13 +988,31 @@ export function createLoop(deps: LoopDeps) {
   }
 
   function numberedScanSections(specification: string): number[] {
-    const sections = [...specification.matchAll(/^ {0,3}#{1,6}[\t ]+(\d+)\.(?:[\t ]|$)/gm)]
-      .map((match) => Number(match[1]))
-    if (sections.length === 0) {
-      throw new Error('parallel scan requires numbered sections in scan-template.md')
+    const sections: number[] = []
+    let fence: { marker: '`' | '~'; length: number } | undefined
+    for (const line of specification.split(/\r?\n/)) {
+      const fenceMatch = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line)
+      if (fence !== undefined) {
+        if (fenceMatch !== null
+          && fenceMatch[1]![0] === fence.marker
+          && fenceMatch[1]!.length >= fence.length
+          && fenceMatch[2]!.trim() === '') {
+          fence = undefined
+        }
+        continue
+      }
+      if (fenceMatch !== null) {
+        fence = {
+          marker: fenceMatch[1]![0] as '`' | '~',
+          length: fenceMatch[1]!.length,
+        }
+        continue
+      }
+      const heading = /^ {0,3}#{1,6}[\t ]+(\d+)\.(?:[\t ]|$)/.exec(line)
+      if (heading !== null) sections.push(Number(heading[1]))
     }
     if (new Set(sections).size !== sections.length) {
-      throw new Error('parallel scan requires unique numbered sections in scan-template.md')
+      throw new Error('numbered sections must be unique')
     }
     return sections
   }
@@ -1681,13 +1699,25 @@ export function createLoop(deps: LoopDeps) {
     // This is the only safe restart boundary: the previous gate is closed, no task is
     // running, and the next cycle has not yet consumed its number or started a scan.
     if (await updateCore(nextCycle) === 'restart') return 'restart'
-    const nScans = [1, 2, 3, 4].includes(config.scanParallel) ? config.scanParallel : 2
-    const sectionGroups = nScans === 1
-      ? []
-      : partitionScanSections(
-        numberedScanSections(scanSpecification('scan', '')),
-        nScans,
-      )
+    const requestedScans = [1, 2, 3, 4].includes(config.scanParallel) ? config.scanParallel : 2
+    let nScans = requestedScans
+    let sectionGroups: number[][] = []
+    if (nScans > 1) {
+      let sections: number[]
+      try {
+        sections = numberedScanSections(scanSpecification('scan', ''))
+      } catch (error) {
+        event('ERROR', `scan-template.md is unusable: it must contain unique numbered Markdown headings outside fenced code blocks (${errorSummary(error)})`)
+        writeFileSync(stopFile, '')
+        return 'continue'
+      }
+      if (sections.length === 0) {
+        event('WARN', `scan-template.md has no numbered sections; requested ${requestedScans} parallel scans, running one full scan`)
+        nScans = 1
+      } else {
+        sectionGroups = partitionScanSections(sections, nScans)
+      }
+    }
     writeFileSync(join(paths.queueDir, `scan-expected-${nextCycle}`), `${nScans}\n`)
     writeFileSync(scanCountFile, `${nextCycle}\n`)
 
@@ -1696,7 +1726,7 @@ export function createLoop(deps: LoopDeps) {
     for (let i = 1; i <= nScans; i++) {
       const scanId = newTaskId(paths, 'scan', now())
       const scope = nScans === 1
-        ? 'Perform every numbered section below.'
+        ? 'Perform the full scan described below.'
         : `This scan runs alongside ${nScans - 1} partner scan(s). Perform only sections ${sectionGroups[i - 1]!.join(', ')}; the partners cover the rest. Stay inside them — overlapping findings merge away, duplicated reading does not.`
       if (generateScanTask(scanId, scope)) {
         try {

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -291,7 +291,8 @@ function runMergeChecks(
     } catch {
       throw new MergeError('Tests failed. Aborting merge.')
     }
-    if (!ranIsolated(worktree, 'the worktree', io)) {
+    if (options.project.verifyDependencyIsolation === true
+      && !ranIsolated(worktree, 'the worktree', io)) {
       throw new MergeError('Tests passed against borrowed dependencies. Aborting merge.')
     }
     return
@@ -310,9 +311,10 @@ function runMergeChecks(
       ok = io.tryRun(join(worktree, check.cwd), install.command, `${check.label} install`) && ok
     }
     const directory = join(worktree, check.cwd)
-    ok = io.tryRun(directory, check.command, check.label)
-      && ranIsolated(directory, check.label, io)
-      && ok
+    const passed = io.tryRun(directory, check.command, check.label)
+    const isolated = options.project.verifyDependencyIsolation !== true
+      || (passed && ranIsolated(directory, check.label, io))
+    ok = passed && isolated && ok
   }
   if (!ok) throw new MergeError('Tests failed. Aborting merge.')
 }
@@ -340,7 +342,12 @@ export function removeTemporaryWorktree(
   worktree: string,
   runtime: WorktreeRemovalRuntime = worktreeRemovalRuntime,
 ): void {
-  removeWorktreeWithFallback(paths.repoRoot, worktree, runtime)
+  const result = removeWorktreeWithFallback(paths.repoRoot, worktree, runtime)
+  if (result.fallbackFailure === undefined) return
+  throw new MergeError(
+    `Could not remove temporary worktree ${worktree}; merge was not applied. `
+    + `(git: ${result.gitFailure}; fallback: ${result.fallbackFailure})`,
+  )
 }
 
 function stopCompletedRunner(pid: number): void {
@@ -534,24 +541,24 @@ export async function mergeRemoteTask(
     io.out(`=== ${taskId} diff (against ${currentBranch}) ===`)
     io.out(git(worktree, ['diff', `${currentBranch}...HEAD`]))
     runMergeChecks(worktree, currentBranch, options, io)
-
-    try {
-      git(paths.repoRoot, ['merge', '--quiet', '--no-ff', remoteRef, '-m', mergeMessage])
-    } catch {
-      try {
-        git(paths.repoRoot, ['merge', '--abort'])
-      } catch {
-        // nothing to abort
-      }
-      throw new MergeError(`A merge conflict occurred while adopting ${branch}.`)
-    }
-    const mergeCommit = git(paths.repoRoot, ['rev-parse', 'HEAD']).trim()
-    options.onMerged?.(mergeCommit)
-    syncOrchestrationDepsAfterMerge(
-      paths, mergeCommit, taskId, depsEvent, options.orchestrationDepsRuntime,
-    )
-    return mergeCommit
   } finally {
     removeTemporaryWorktree(paths, worktree)
   }
+
+  try {
+    git(paths.repoRoot, ['merge', '--quiet', '--no-ff', remoteRef, '-m', mergeMessage])
+  } catch {
+    try {
+      git(paths.repoRoot, ['merge', '--abort'])
+    } catch {
+      // nothing to abort
+    }
+    throw new MergeError(`A merge conflict occurred while adopting ${branch}.`)
+  }
+  const mergeCommit = git(paths.repoRoot, ['rev-parse', 'HEAD']).trim()
+  options.onMerged?.(mergeCommit)
+  syncOrchestrationDepsAfterMerge(
+    paths, mergeCommit, taskId, depsEvent, options.orchestrationDepsRuntime,
+  )
+  return mergeCommit
 }

--- a/src/restart.ts
+++ b/src/restart.ts
@@ -1,9 +1,11 @@
 import { spawn, type ChildProcess, type StdioOptions } from 'node:child_process'
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { PACKAGE_ROOT } from './paths.ts'
 
 export const LOOP_RESTART_READY_FILE_ENV = 'ORCHESTRATION_LOOP_RESTART_READY_FILE'
+export const LOOP_RESTART_PREDECESSOR_PID_ENV = 'ORCHESTRATION_LOOP_RESTART_PREDECESSOR_PID'
 
 export interface LoopRestartCommand {
   executable: string
@@ -20,10 +22,40 @@ export interface LoopRestartResult {
 interface LoopRestartRuntime {
   argv?: string[]
   env?: NodeJS.ProcessEnv
+  onReady?: (pid: number) => void
   packageRoot?: string
   spawn?: typeof spawn
   startupTimeoutMs?: number
   stdio?: StdioOptions
+}
+
+/** Identify the live daemon whose PID reservation a replacement is allowed to use. */
+export function loopRestartPredecessorPid(
+  env: NodeJS.ProcessEnv = process.env,
+): number | undefined {
+  const value = env[LOOP_RESTART_PREDECESSOR_PID_ENV]
+  if (value === undefined || !/^\d+$/.test(value)) return undefined
+  const pid = Number(value)
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined
+}
+
+/** Atomically replace a live predecessor's PID reservation with its ready replacement. */
+export function publishLoopReplacementPid(
+  pidFile: string,
+  predecessorPid: number,
+  replacementPid: number,
+): void {
+  const owner = readFileSync(pidFile, 'utf8').trim()
+  if (owner !== `${predecessorPid}`) {
+    throw new Error(`loop PID owner changed before restart handover (${owner || 'empty'})`)
+  }
+  const candidate = `${pidFile}.handover-${predecessorPid}-${replacementPid}-${randomUUID()}`
+  try {
+    writeFileSync(candidate, `${replacementPid}\n`, { flag: 'wx' })
+    renameSync(candidate, pidFile)
+  } finally {
+    rmSync(candidate, { force: true })
+  }
 }
 
 /** Resolve re-execution from the installed package, never from the invocation spelling. */
@@ -65,6 +97,7 @@ export async function startLoopReplacement(
       env: {
         ...(runtime.env ?? process.env),
         [LOOP_RESTART_READY_FILE_ENV]: readyFile,
+        [LOOP_RESTART_PREDECESSOR_PID_ENV]: `${process.pid}`,
       },
       stdio: runtime.stdio ?? 'inherit',
       windowsHide: true,
@@ -123,6 +156,13 @@ export async function startLoopReplacement(
         return
       }
       if (replacement.exitCode !== null) return
+      try {
+        runtime.onReady?.(pid)
+      } catch (error) {
+        replacement.kill()
+        finish({ ok: false, pid, error: errorSummary(error) })
+        return
+      }
       finish({ ok: true, pid })
     }, 10)
     const timeout = setTimeout(() => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -79,7 +79,7 @@ describe('loadConfig', () => {
     )
   })
 
-  it('clamps SCAN_PARALLEL to the four defined checklist groups', () => {
+  it('clamps SCAN_PARALLEL to four concurrent scans', () => {
     expect(loadConfig({ SCAN_PARALLEL: '9' }).scanParallel).toBe(4)
   })
 

--- a/tests/git-remote.test.ts
+++ b/tests/git-remote.test.ts
@@ -67,8 +67,10 @@ describe('current branch remote', () => {
   it('rejects an ambiguous repository when no branch or push remote is configured', () => {
     git(['remote', 'add', 'upstream', join(repoRoot, 'upstream.git')])
 
-    expect(() => currentBranchPushRemote(repoRoot)).toThrow('repository has multiple remotes')
-    expect(() => currentBranchTrackingRemote(repoRoot)).toThrow('repository has multiple remotes')
+    const message = "current branch 'main' has no upstream and the repository has multiple remotes: "
+      + 'origin, upstream; push the branch with an upstream, or configure branch.main.remote'
+    expect(() => currentBranchPushRemote(repoRoot)).toThrow(message)
+    expect(() => currentBranchTrackingRemote(repoRoot)).toThrow(message)
   })
 
   it('reads the remote advertised default branch when no local HEAD ref is cached', () => {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,49 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const hooksDirectory = resolve(import.meta.dirname, '..', '.githooks')
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('git hooks', () => {
+  it.each(['pre-commit', 'commit-msg'])('%s is valid POSIX sh syntax', (hook) => {
+    const hookPath = join(hooksDirectory, hook)
+    const source = readFileSync(hookPath, 'utf8')
+    const result = spawnSync('sh', ['-n', hookPath], {
+      encoding: 'utf8',
+      windowsHide: true,
+    })
+
+    expect(source.startsWith('#!/bin/sh\n')).toBe(true)
+    expect(result.stderr).toBe('')
+    expect(result.status).toBe(0)
+  })
+
+  it.each([
+    ['feat: add portable hooks', 0],
+    ['Merge branch \'main\'', 0],
+    ['feature: add portable hooks', 1],
+    ['fix:  starts with two spaces', 1],
+    ['docs:', 1],
+  ])('validates commit subject %j', (subject, expectedStatus) => {
+    const directory = mkdtempSync(join(tmpdir(), 'orchestration-hook-'))
+    temporaryDirectories.push(directory)
+    const messagePath = join(directory, 'COMMIT_EDITMSG')
+    writeFileSync(messagePath, `${subject}\nbody\n`)
+
+    const result = spawnSync('sh', [join(hooksDirectory, 'commit-msg'), messagePath], {
+      encoding: 'utf8',
+      windowsHide: true,
+    })
+
+    expect(result.status).toBe(expectedStatus)
+  })
+})

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1128,9 +1128,22 @@ describe('cycleIsFinal', () => {
 })
 
 describe('cycle gate', () => {
-  it.each([2, 3, 4])('partitions the eight scan sections across %i scans', async (scanParallel) => {
+  it.each([
+    { sectionCount: 5, scanParallel: 2 },
+    { sectionCount: 8, scanParallel: 3 },
+    { sectionCount: 10, scanParallel: 4 },
+  ])('partitions $sectionCount scan sections across $scanParallel scans', async ({
+    sectionCount, scanParallel,
+  }) => {
     mkdirSync(join(paths.root, 'templates'), { recursive: true })
-    writeFileSync(join(paths.root, 'templates', 'scan-template.md'), '{{SCAN_SCOPE}}\n')
+    const sections = Array.from(
+      { length: sectionCount },
+      (_, index) => `### ${index + 1}. Check ${index + 1}\n`,
+    ).join('\n')
+    writeFileSync(
+      join(paths.root, 'templates', 'scan-template.md'),
+      `# {{SCAN_ID}}\n\n{{SCAN_SCOPE}}\n\n${sections}`,
+    )
     const loop = makeLoop({ scanParallel, autoPr: false, reviewEnabled: false })
 
     expect(await loop.triggerScanIfIdle()).toBe('continue')
@@ -1148,7 +1161,26 @@ describe('cycle gate', () => {
       const assignment = /Perform only sections ([^;]+);/.exec(scope)?.[1] ?? ''
       return [...assignment.matchAll(/\d+/g)].map((match) => Number(match[0]))
     })
-    expect(assignedSections.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+    expect(assignedSections.sort((a, b) => a - b))
+      .toEqual(Array.from({ length: sectionCount }, (_, index) => index + 1))
+    const assignmentSizes = scopes.map((scope) => {
+      const assignment = /Perform only sections ([^;]+);/.exec(scope)?.[1] ?? ''
+      return [...assignment.matchAll(/\d+/g)].length
+    })
+    expect(Math.max(...assignmentSizes) - Math.min(...assignmentSizes)).toBeLessThanOrEqual(1)
+  })
+
+  it('fails a parallel scan before creating cycle state when sections cannot be found', async () => {
+    mkdirSync(join(paths.root, 'templates'), { recursive: true })
+    writeFileSync(join(paths.root, 'templates', 'scan-template.md'), '{{SCAN_SCOPE}}\n')
+    const loop = makeLoop({ scanParallel: 2, autoPr: false, reviewEnabled: false })
+
+    await expect(loop.triggerScanIfIdle()).rejects.toThrow(
+      'parallel scan requires numbered sections in scan-template.md',
+    )
+    expect(runnerStarts).toHaveLength(0)
+    expect(existsSync(join(paths.queueDir, 'scan-expected-1'))).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'scan-count.txt'))).toBe(false)
   })
 
   it('resumes when review is enabled but automatic review is disabled', async () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -458,7 +458,7 @@ describe('forge poll budget', () => {
     expect(fakeForge.issueComments.get(issueNumber)).toContain(reason)
   })
 
-  it('continues local refresh, merging, and queued work when queue labels are unavailable', async () => {
+  it('continues local refresh and queued work but defers unscanned merging when queue labels are unavailable', async () => {
     const completedTask = '20260811_120000_001_auto-completed'
     const failedTask = '20260811_120001_002_auto-failed'
     const queuedTask = '20260811_120002_003_auto-queued'
@@ -477,7 +477,9 @@ describe('forge poll budget', () => {
 
     expect(await loop.poll()).toBe('continue')
 
-    expect(readStatus(paths, completedTask)?.status).toBe('merged')
+    expect(readStatus(paths, completedTask)?.status).toBe('completed')
+    expect(existsSync(join(paths.queueDir, 'scanned', completedTask))).toBe(false)
+    expect(logged).not.toContain('Merging 001_auto')
     expect(readStatus(paths, failedTask)?.status).toBe('failed')
     expect(logged).toContain(`FAILED: ${failedTask} — log: ${join(paths.logsDir, `${failedTask}.log`)}`)
     expect(runnerStarts).toEqual([join(paths.tasksDir, `${queuedTask}.md`)])
@@ -1367,6 +1369,7 @@ describe('cycle gate', () => {
     expect(fixId).toMatch(/^20260808_120000_002_ci-fix-c1$/)
     writeFileSync(join(paths.queueDir, 'backlog.txt'), '')
     writeRawStatus(fixId as string, 'completed')
+    writeFileSync(join(paths.queueDir, 'scanned', fixId as string), '')
 
     expect(await loop.triggerScanIfIdle()).toBe('continue')
     expect(enqueue).toHaveBeenCalledTimes(2)
@@ -2070,7 +2073,10 @@ describe('completion marker output', () => {
     fakeForge.updatePr = updatePr
 
     expect(await loop.ensureDraftPr('cycle')).toBe(true)
-    expect(updatePr).not.toHaveBeenCalled()
+    expect(updatePr).toHaveBeenCalledOnce()
+    expect(updatePr).toHaveBeenCalledWith('main', {
+      title: 'feat: autonomous scan loop — cycle 0/3',
+    })
     expect(readFileSync(join(paths.queueDir, 'pr-url.txt'), 'utf8'))
       .toBe('https://example.test/pull/1\n')
   })
@@ -2500,6 +2506,12 @@ describe('completed task merge recovery', () => {
       }
       return listOpenIssues(label)
     }
+
+    expect(await loop.poll()).toBe('continue')
+
+    expect(readStatus(paths, taskId)?.status).toBe('completed')
+    expect(logged).toContain('Claimed 064_auto    #1')
+    expect(logged).not.toContain('Merging 064_auto')
 
     expect(await loop.poll()).toBe('continue')
 
@@ -3004,9 +3016,16 @@ describe('scanForNextTasks', () => {
 
   it('leaves a local finding unreconciled when enqueue fails so a later scan retries it', async () => {
     initializeGitRepo()
+    const initialHead = git(['rev-parse', 'HEAD'])
     let attempts = 0
     const loop = makeLoop(
-      { scanEnabled: false, autoMerge: false, maxParallel: 0 },
+      {
+        scanEnabled: false,
+        autoMerge: true,
+        maxParallel: 0,
+        reviewEnabled: true,
+        autoReview: false,
+      },
       stubProject, undefined, () => new Date(2026, 7, 8, 12, 0, 0), makeRunner(),
       (...args) => {
         attempts += 1
@@ -3015,25 +3034,32 @@ describe('scanForNextTasks', () => {
       },
     )
     loop.initializeSessionStateForBranch()
-    const taskId = '20250101_000000_018_scan'
+    writeFileSync(join(paths.queueDir, 'scan-count.txt'), '1\n')
+    const taskId = '20250101_000000_018_auto-parent'
+    makeCompletedTask(taskId)
     writeFinal(taskId, [
       'NEXT_TASK: [BUG] retry a finding after a local queue failure',
       'TASK_COMPLETE',
     ].join('\n'))
-    writeRawStatus(taskId, 'completed')
     const backlog = join(paths.queueDir, 'backlog.txt')
     const scannedFlag = join(paths.queueDir, 'scanned', taskId)
 
     await loop.poll()
 
     expect(existsSync(scannedFlag)).toBe(false)
-    expect(readdirSync(paths.tasksDir)).toHaveLength(1)
+    expect(readdirSync(paths.tasksDir)).toHaveLength(2)
+    expect(readStatus(paths, taskId)?.status).toBe('completed')
+    expect(git(['rev-parse', 'HEAD'])).toBe(initialHead)
+    expect(existsSync(join(paths.queueDir, 'cycle-complete-1'))).toBe(false)
 
     await loop.poll()
 
     expect(existsSync(scannedFlag)).toBe(true)
     expect(attempts).toBe(2)
     expect(readFileSync(backlog, 'utf8').trim()).toMatch(/:1$/)
+    expect(readStatus(paths, taskId)?.status).toBe('merged')
+    expect(git(['rev-parse', 'HEAD'])).not.toBe(initialHead)
+    expect(existsSync(join(paths.queueDir, 'cycle-complete-1'))).toBe(false)
   })
 
   it('writes specs that instruct the completion marker — its absence records finished work as failed', async () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1170,17 +1170,90 @@ describe('cycle gate', () => {
     expect(Math.max(...assignmentSizes) - Math.min(...assignmentSizes)).toBeLessThanOrEqual(1)
   })
 
-  it('fails a parallel scan before creating cycle state when sections cannot be found', async () => {
+  it('falls back to one full scan with a warning when the template has no numbered sections', async () => {
+    initializeGitRepo()
     mkdirSync(join(paths.root, 'templates'), { recursive: true })
-    writeFileSync(join(paths.root, 'templates', 'scan-template.md'), '{{SCAN_SCOPE}}\n')
+    writeFileSync(
+      join(paths.root, 'templates', 'scan-template.md'),
+      '# {{SCAN_ID}}\n\n{{SCAN_SCOPE}}\n',
+    )
+    const loop = makeLoop({ scanParallel: 4, autoPr: false, reviewEnabled: false })
+
+    expect(await loop.triggerScanIfIdle()).toBe('continue')
+    expect(runnerStarts).toHaveLength(1)
+    expect(readFileSync(join(paths.queueDir, 'scan-expected-1'), 'utf8')).toBe('1\n')
+    expect(logText()).toContain(
+      'WARN scan-template.md has no numbered sections; requested 4 parallel scans, running one full scan',
+    )
+    expect(readFileSync(runnerStarts[0]!, 'utf8'))
+      .toContain('Perform the full scan described below.')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
+  })
+
+  it('ignores numbered headings inside fenced code blocks', async () => {
+    initializeGitRepo()
+    mkdirSync(join(paths.root, 'templates'), { recursive: true })
+    writeFileSync(
+      join(paths.root, 'templates', 'scan-template.md'),
+      [
+        '# {{SCAN_ID}}',
+        '{{SCAN_SCOPE}}',
+        '### 1. First check',
+        '```markdown',
+        '### 1. Quoted duplicate',
+        '```',
+        '~~~markdown',
+        '### 99. Quoted phantom',
+        '~~~',
+        '### 2. Second check',
+      ].join('\n'),
+    )
     const loop = makeLoop({ scanParallel: 2, autoPr: false, reviewEnabled: false })
 
-    await expect(loop.triggerScanIfIdle()).rejects.toThrow(
-      'parallel scan requires numbered sections in scan-template.md',
+    expect(await loop.triggerScanIfIdle()).toBe('continue')
+    expect(runnerStarts).toHaveLength(2)
+    const assignedSections = runnerStarts.flatMap((file) => {
+      const specification = readFileSync(file, 'utf8')
+      const assignment = /Perform only sections ([^;]+);/.exec(specification)?.[1] ?? ''
+      return [...assignment.matchAll(/\d+/g)].map((match) => Number(match[0]))
+    })
+    expect(assignedSections.sort((a, b) => a - b)).toEqual([1, 2])
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
+  })
+
+  it('stops before creating cycle state when numbered sections are ambiguous', async () => {
+    mkdirSync(join(paths.root, 'templates'), { recursive: true })
+    writeFileSync(
+      join(paths.root, 'templates', 'scan-template.md'),
+      '# {{SCAN_ID}}\n\n{{SCAN_SCOPE}}\n### 1. First check\n### 1. Duplicate check\n',
     )
+    const loop = makeLoop({ scanParallel: 2, autoPr: false, reviewEnabled: false })
+
+    expect(await loop.triggerScanIfIdle()).toBe('continue')
     expect(runnerStarts).toHaveLength(0)
     expect(existsSync(join(paths.queueDir, 'scan-expected-1'))).toBe(false)
     expect(existsSync(join(paths.queueDir, 'scan-count.txt'))).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(logText()).toContain(
+      'ERROR scan-template.md is unusable: it must contain unique numbered Markdown headings outside fenced code blocks',
+    )
+  })
+
+  it('does not derive sections when only one scan is requested', async () => {
+    initializeGitRepo()
+    mkdirSync(join(paths.root, 'templates'), { recursive: true })
+    writeFileSync(
+      join(paths.root, 'templates', 'scan-template.md'),
+      '# {{SCAN_ID}}\n\n{{SCAN_SCOPE}}\n### 1. First check\n### 1. Duplicate check\n',
+    )
+    const loop = makeLoop({ scanParallel: 1, autoPr: false, reviewEnabled: false })
+
+    expect(await loop.triggerScanIfIdle()).toBe('continue')
+    expect(runnerStarts).toHaveLength(1)
+    expect(readFileSync(runnerStarts[0]!, 'utf8'))
+      .toContain('Perform the full scan described below.')
+    expect(logText()).not.toContain('scan-template.md')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
   })
 
   it('resumes when review is enabled but automatic review is disabled', async () => {

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -23,6 +23,7 @@ let paths: OrchPaths
 const installProject: ProjectAdapter = {
   ...stubProject,
   name: 'install-test',
+  verifyDependencyIsolation: true,
   mergeChecks: () => [{
     label: 'Fixture check',
     cwd: '',
@@ -232,6 +233,23 @@ describe('removeTemporaryWorktree', () => {
     expect(gitRuntime).toHaveBeenNthCalledWith(
       2, paths.repoRoot, ['worktree', 'prune'],
     )
+  })
+
+  it('fails when both Git and the direct-removal fallback fail', () => {
+    const worktree = join(paths.worktreesDir, '.merge-still-present')
+    const gitRuntime = vi.fn((_cwd: string, args: string[]) => {
+      if (args[0] === 'worktree' && args[1] === 'remove') throw new Error('Git removal failed')
+      return ''
+    })
+
+    expect(() => removeTemporaryWorktree(paths, worktree, {
+      os: posixOperatingSystem(() => { throw new Error('Direct removal failed') }),
+      git: gitRuntime,
+    })).toThrow(
+      `Could not remove temporary worktree ${worktree}; merge was not applied. `
+      + '(git: Git removal failed; fallback: Direct removal failed)',
+    )
+    expect(gitRuntime).toHaveBeenNthCalledWith(2, paths.repoRoot, ['worktree', 'prune'])
   })
 })
 
@@ -446,6 +464,25 @@ describe('mergeTask', () => {
     const output = readFileSync(outputFile, 'utf8')
     expect(output).toContain('passed on dependencies it does not have')
     expect(output).toContain('fixture-dependency')
+  })
+
+  it('does not apply Node dependency isolation to adapters that did not opt in', async () => {
+    const taskId = '20260808_000000_018_user-uses-another-package-manager'
+    const worktree = await makeCompletedTask(taskId, { commit: true })
+    writeFileSync(join(worktree, 'package.json'), `${JSON.stringify({
+      name: 'fixture', devDependencies: { 'virtual-dependency': '^1.0.0' },
+    }, null, 2)}\n`)
+    git(worktree, ['add', 'package.json'])
+    git(worktree, ['commit', '-qm', 'test: declare a virtual dependency'])
+    const project: ProjectAdapter = {
+      ...stubProject,
+      name: 'virtual-dependencies',
+      mergeChecks: () => [{ label: 'Non-Node gate', cwd: '', command: 'node -e ""' }],
+    }
+
+    await expect(mergeTask(paths, taskId, {
+      taskGate: 'light', project,
+    })).resolves.toBe(git(repoRoot, ['rev-parse', 'HEAD']).trim())
   })
 
   it('accepts a check that installs its own dependencies as its first step', async () => {
@@ -684,6 +721,25 @@ describe('mergeRemoteTask', () => {
     expect(git(repoRoot, ['log', '-1', '--format=%s']).trim()).toBe(
       'Merge remote-runner-neutral-message via orchestration (resolves ticket 219)',
     )
+  })
+
+  it('removes the checked worktree before applying the remote merge', async () => {
+    const branch = 'task/remote-clean-before-merge'
+    git(repoRoot, ['switch', '-qc', branch])
+    writeFileSync(join(repoRoot, 'task.txt'), 'task work\n')
+    git(repoRoot, ['add', 'task.txt'])
+    git(repoRoot, ['commit', '-qm', 'feat: add remote task work'])
+    const expectedHead = git(repoRoot, ['rev-parse', 'HEAD']).trim()
+    git(repoRoot, ['switch', '-q', 'main'])
+    git(repoRoot, ['update-ref', `refs/remotes/origin/${branch}`, expectedHead])
+    const onMerged = vi.fn(() => expectNoTemporaryWorktree('.adopt-'))
+
+    await mergeRemoteTask(paths, 226, 'origin', branch, expectedHead, {
+      taskGate: 'light', project: noCheckProject, onMerged,
+      forge: { issueClosingCommitMessage: (message) => message },
+    })
+
+    expect(onMerged).toHaveBeenCalledOnce()
   })
 
   it('runs checks against the worker branch merged with the current branch', async () => {

--- a/tests/pre-commit.test.ts
+++ b/tests/pre-commit.test.ts
@@ -10,25 +10,37 @@ import { stubProject } from './stubProject.ts'
 const repositories: string[] = []
 
 function git(repository: string, args: string[]): string {
-  return execFileSync('git', args, { cwd: repository, encoding: 'utf8', windowsHide: true }).trim()
+  return execFileSync('git', args, {
+    cwd: repository,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+    windowsHide: true,
+  }).trim()
 }
 
-function repository(): string {
-  const root = mkdtempSync(join(tmpdir(), 'orchestration-pre-commit-'))
-  repositories.push(root)
-  git(root, ['init', '--initial-branch=topic'])
+interface RepositoryFixture {
+  root: string
+  remote: string
+}
+
+function repository(): RepositoryFixture {
+  const fixture = mkdtempSync(join(tmpdir(), 'orchestration-pre-commit-'))
+  const root = join(fixture, 'repository')
+  const remote = join(fixture, 'origin.git')
+  repositories.push(fixture)
+  git(fixture, ['init', '--bare', '--initial-branch=trunk', remote])
+  git(fixture, ['init', '--initial-branch=topic', root])
   git(root, ['config', 'user.email', 'test@example.com'])
   git(root, ['config', 'user.name', 'Test'])
   writeFileSync(join(root, 'README.md'), '# test\n')
   git(root, ['add', 'README.md'])
   git(root, ['commit', '-qm', 'chore: initial commit'])
-  git(root, ['init', '--bare', '--initial-branch=trunk', join(root, 'origin.git')])
-  git(root, ['remote', 'add', 'origin', join(root, 'origin.git')])
+  git(root, ['remote', 'add', 'origin', remote])
   git(root, ['push', '--quiet', 'origin', 'HEAD:refs/heads/trunk'])
   git(root, ['symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/trunk'])
   writeFileSync(join(root, 'change.ts'), 'export {}\n')
   git(root, ['add', 'change.ts'])
-  return root
+  return { root, remote }
 }
 
 afterEach(() => {
@@ -38,7 +50,7 @@ afterEach(() => {
 
 describe('project pre-commit checks', () => {
   it('selects checks from staged paths and reports skipped checks explicitly', () => {
-    const root = repository()
+    const { root } = repository()
     const appliesTo = vi.fn((files: string[]) => files.includes('change.ts'))
     const project: ProjectAdapter = {
       ...stubProject,
@@ -56,7 +68,7 @@ describe('project pre-commit checks', () => {
   })
 
   it('prohibits commits to the default branch advertised by the remote', () => {
-    const root = repository()
+    const { root } = repository()
     git(root, ['symbolic-ref', 'HEAD', 'refs/heads/trunk'])
     const log = vi.spyOn(console, 'log').mockImplementation(() => {})
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -69,10 +81,10 @@ describe('project pre-commit checks', () => {
   })
 
   it('prohibits the newly advertised default branch when the cached HEAD is stale', () => {
-    const root = repository()
+    const { root, remote } = repository()
     git(root, ['push', '--quiet', 'origin', 'HEAD:refs/heads/main'])
     execFileSync('git', ['symbolic-ref', 'HEAD', 'refs/heads/main'], {
-      cwd: join(root, 'origin.git'), windowsHide: true,
+      cwd: remote, windowsHide: true,
     })
     git(root, ['branch', '-m', 'main'])
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -84,9 +96,9 @@ describe('project pre-commit checks', () => {
   })
 
   it('fails closed when the remote default branch cannot be resolved', () => {
-    const root = repository()
+    const { root, remote } = repository()
     git(root, ['symbolic-ref', '--delete', 'refs/remotes/origin/HEAD'])
-    rmSync(join(root, 'origin.git'), { recursive: true, force: true })
+    rmSync(remote, { recursive: true, force: true })
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     expect(branchAcceptsCommits(root)).toBe(false)

--- a/tests/restart.test.ts
+++ b/tests/restart.test.ts
@@ -1,11 +1,12 @@
 import { type ChildProcess, spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
-  LOOP_RESTART_READY_FILE_ENV, startLoopReplacement,
+  LOOP_RESTART_PREDECESSOR_PID_ENV, LOOP_RESTART_READY_FILE_ENV,
+  publishLoopReplacementPid, startLoopReplacement,
 } from '../src/restart.ts'
 
 const fixtureRoots: string[] = []
@@ -24,30 +25,38 @@ function fakeChild(pid: number): ChildProcess {
 }
 
 describe('loop replacement startup', () => {
-  it('reports success only after the replacement publishes its ready signal', async () => {
+  it('keeps the predecessor PID until the replacement publishes readiness', async () => {
     const root = mkdtempSync(join(tmpdir(), 'orch-restart-'))
     fixtureRoots.push(root)
     const readyFile = join(root, 'ready')
+    const pidFile = join(root, 'loop.pid')
+    writeFileSync(pidFile, `${process.pid}\n`)
     const child = fakeChild(43210)
     const spawnProcess = vi.fn((_executable, _args, options) => {
       const env = options.env as NodeJS.ProcessEnv
       expect(env[LOOP_RESTART_READY_FILE_ENV]).toBe(readyFile)
+      expect(env[LOOP_RESTART_PREDECESSOR_PID_ENV]).toBe(`${process.pid}`)
+      expect(readFileSync(pidFile, 'utf8')).toBe(`${process.pid}\n`)
       setTimeout(() => writeFileSync(readyFile, '43210\n'), 0)
       return child
     }) as unknown as typeof spawn
 
     await expect(startLoopReplacement(readyFile, {
       packageRoot: root,
+      onReady: (pid) => publishLoopReplacementPid(pidFile, process.pid, pid),
       spawn: spawnProcess,
       startupTimeoutMs: 1_000,
       stdio: 'ignore',
     })).resolves.toEqual({ ok: true, pid: 43210 })
+    expect(readFileSync(pidFile, 'utf8')).toBe('43210\n')
     expect(child.unref).toHaveBeenCalled()
   })
 
-  it('reports a replacement that exits before publishing readiness', async () => {
+  it('keeps the predecessor PID when the replacement exits before readiness', async () => {
     const root = mkdtempSync(join(tmpdir(), 'orch-restart-'))
     fixtureRoots.push(root)
+    const pidFile = join(root, 'loop.pid')
+    writeFileSync(pidFile, `${process.pid}\n`)
     const child = fakeChild(43211)
     const spawnProcess = vi.fn(() => {
       setTimeout(() => {
@@ -59,6 +68,7 @@ describe('loop replacement startup', () => {
 
     await expect(startLoopReplacement(join(root, 'ready'), {
       packageRoot: root,
+      onReady: (pid) => publishLoopReplacementPid(pidFile, process.pid, pid),
       spawn: spawnProcess,
       startupTimeoutMs: 1_000,
       stdio: 'ignore',
@@ -67,6 +77,7 @@ describe('loop replacement startup', () => {
       pid: 43211,
       error: 'replacement exited before becoming ready (exit code 1)',
     })
+    expect(readFileSync(pidFile, 'utf8')).toBe(`${process.pid}\n`)
     expect(child.unref).not.toHaveBeenCalled()
   })
 })

--- a/tests/runner-codex.test.ts
+++ b/tests/runner-codex.test.ts
@@ -6,7 +6,7 @@ import type { RunnerStartOptions } from '../src/adapters/runner.ts'
 const mocks = vi.hoisted(() => ({
   closeSync: vi.fn(),
   existsSync: vi.fn((_path: string) => false),
-  openSync: vi.fn(() => 42),
+  openSync: vi.fn((path: string) => path === 'task.log' ? 42 : 43),
   readFileSync: vi.fn((_path: string, _encoding: string) => 'task specification'),
   spawn: vi.fn(),
 }))
@@ -46,7 +46,8 @@ function mockChild(pid: number | undefined = 1234): EventEmitter & {
 beforeEach(() => {
   mocks.closeSync.mockReset()
   mocks.existsSync.mockReset().mockReturnValue(false)
-  mocks.openSync.mockReset().mockReturnValue(42)
+  mocks.openSync.mockReset().mockImplementation((path: string) =>
+    path === 'task.log' ? 42 : 43)
   mocks.readFileSync.mockReset().mockReturnValue('task specification')
   mocks.spawn.mockReset()
 })
@@ -186,9 +187,8 @@ describe('createCodexRunner', () => {
     expect(rendered).toMatchSnapshot()
   })
 
-  it('spawns codex directly on POSIX with the final-message, model, effort, and prompt arguments', async () => {
+  it('spawns codex directly on POSIX with the spec as standard input', async () => {
     setPlatform('linux')
-    mocks.readFileSync.mockReturnValue('first line\nsecond line')
     const child = mockChild(4321)
     mocks.spawn.mockReturnValue(child)
 
@@ -198,19 +198,19 @@ describe('createCodexRunner', () => {
       model: 'gpt-5-codex',
     })
 
-    expect(mocks.readFileSync).toHaveBeenCalledWith('task.md', 'utf8')
-    expect(mocks.openSync).toHaveBeenCalledWith('task.log', 'a')
+    expect(mocks.openSync).toHaveBeenNthCalledWith(1, 'task.log', 'a')
+    expect(mocks.openSync).toHaveBeenNthCalledWith(2, 'task.md', 'r')
     expect(mocks.spawn).toHaveBeenCalledWith('codex', [
       'exec',
       '--dangerously-bypass-approvals-and-sandbox',
       '--output-last-message', 'final-message.txt',
       '--model', 'gpt-5-codex',
       '--config', 'model_reasoning_effort=low',
-      'first line\nsecond line',
+      '-',
     ], {
       cwd: 'worktree',
       detached: true,
-      stdio: ['ignore', 42, 42],
+      stdio: [43, 42, 42],
     })
 
     child.emit('spawn')
@@ -230,18 +230,35 @@ describe('createCodexRunner', () => {
       '--dangerously-bypass-approvals-and-sandbox',
       '--output-last-message', 'final-message.txt',
       '--config', 'model_reasoning_effort=high',
-      'task specification',
+      '-',
     ], {
       cwd: 'worktree',
       detached: true,
-      stdio: ['ignore', 42, 42],
+      stdio: [43, 42, 42],
     })
 
     child.emit('spawn')
     await expect(started).resolves.toBe(5678)
   })
 
-  it('closes the parent log descriptor after the child inherits it', async () => {
+  it('never passes the specification as an argument regardless of its size', async () => {
+    const specification = 'non-ASCII specification 日本語\n'.repeat(1_000)
+    mocks.readFileSync.mockReturnValue(specification)
+    const child = mockChild()
+    mocks.spawn.mockReturnValue(child)
+
+    const started = createCodexRunner().start(options)
+
+    const commandArgs = mocks.spawn.mock.calls[0]?.[1] as string[]
+    expect(commandArgs).not.toContain(specification)
+    expect(commandArgs.at(-1)).toBe('-')
+    expect(mocks.readFileSync).not.toHaveBeenCalledWith('task.md', 'utf8')
+
+    child.emit('spawn')
+    await expect(started).resolves.toBe(1234)
+  })
+
+  it('closes the parent spec and log descriptors after the child inherits them', async () => {
     const child = mockChild()
     mocks.spawn.mockReturnValue(child)
 
@@ -249,12 +266,13 @@ describe('createCodexRunner', () => {
     child.emit('spawn')
 
     await expect(started).resolves.toBe(1234)
-    expect(mocks.closeSync).toHaveBeenCalledOnce()
-    expect(mocks.closeSync).toHaveBeenCalledWith(42)
+    expect(mocks.closeSync).toHaveBeenCalledTimes(2)
+    expect(mocks.closeSync).toHaveBeenNthCalledWith(1, 43)
+    expect(mocks.closeSync).toHaveBeenNthCalledWith(2, 42)
     expect(child.unref).toHaveBeenCalledOnce()
   })
 
-  it('closes the parent log descriptor when spawning fails', async () => {
+  it('closes the parent spec and log descriptors when spawning fails', async () => {
     const child = mockChild()
     const error = new Error('spawn failed')
     mocks.spawn.mockReturnValue(child)
@@ -263,19 +281,34 @@ describe('createCodexRunner', () => {
     child.emit('error', error)
 
     await expect(started).rejects.toBe(error)
-    expect(mocks.closeSync).toHaveBeenCalledOnce()
-    expect(mocks.closeSync).toHaveBeenCalledWith(42)
+    expect(mocks.closeSync).toHaveBeenCalledTimes(2)
+    expect(mocks.closeSync).toHaveBeenNthCalledWith(1, 43)
+    expect(mocks.closeSync).toHaveBeenNthCalledWith(2, 42)
   })
 
-  it('closes the parent log descriptor when spawn throws synchronously', async () => {
+  it('closes the parent spec and log descriptors when spawn throws synchronously', async () => {
     const error = new Error('spawn threw')
     mocks.spawn.mockImplementation(() => {
       throw error
     })
 
     await expect(createCodexRunner().start(options)).rejects.toBe(error)
+    expect(mocks.closeSync).toHaveBeenCalledTimes(2)
+    expect(mocks.closeSync).toHaveBeenNthCalledWith(1, 43)
+    expect(mocks.closeSync).toHaveBeenNthCalledWith(2, 42)
+  })
+
+  it('closes the log descriptor and rejects when the spec cannot be opened', async () => {
+    const error = new Error('spec open failed')
+    mocks.openSync.mockImplementation((path: string) => {
+      if (path === 'task.log') return 42
+      throw error
+    })
+
+    await expect(createCodexRunner().start(options)).rejects.toBe(error)
     expect(mocks.closeSync).toHaveBeenCalledOnce()
     expect(mocks.closeSync).toHaveBeenCalledWith(42)
+    expect(mocks.spawn).not.toHaveBeenCalled()
   })
 
   it('rejects and detaches a spawned child that has no PID', async () => {
@@ -288,6 +321,6 @@ describe('createCodexRunner', () => {
 
     await expect(started).rejects.toThrow('codex spawned without a PID')
     expect(child.unref).toHaveBeenCalledOnce()
-    expect(mocks.closeSync).toHaveBeenCalledOnce()
+    expect(mocks.closeSync).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
One cycle of the improvement loop, cut short deliberately: two of these fixes block the
repositories that consume this core, so the run was stopped at the cycle-1 gate rather
than carried through four cycles and a review.

## Codex received truncated specifications on Windows

The runner passed the whole specification as one command-line argument. Git Bash cuts a
single argument at 8192 bytes and reports nothing, so every longer specification reached
Codex with its tail missing — silently. A consuming repository with an 18KB scan
checklist lost 56 percent of it: scans scoped to the later sections answered that their
specification was incomplete, and scans scoped to the earlier ones completed while having
lost the output-format and completion-marker instructions they never saw.

`codex exec -` reads the prompt from standard input, which has no such ceiling, so the
specification file is opened and handed to the child as its input. The parent now owns
two descriptors and closes both on spawn, on error, and on a synchronous throw.

## Parallel scans skipped whatever the checklist had past section 8

The split table listed section numbers up to eight while the checklist itself belongs to
the consuming repository. A repository whose checklist grew to ten sections never scanned
the last two at any `SCAN_PARALLEL` above 1, and nothing said so. The sections are now
read out of the rendered specification and dealt round-robin, so every section reaches
exactly one scan whatever the checklist's length, and adjacent sections — which tend to
be the similar-weight ones — land on different scans.

Two shapes of checklist needed distinguishing. Sections that cannot be parsed mean a
broken template and stop the run with a message naming what the file must contain. No
numbered sections at all is not a failure — it is what the scaffold ships and what any
consumer may keep — so that falls back to a single full scan and says why it ignored the
requested count. Headings inside fenced code blocks are no longer counted.

## The PID file could stop naming the running daemon

The core-update restart released the PID file before the replacement claimed it, leaving
a window in which the file named a process that was gone. `loop-status` reads that file,
so the loop went invisible to every command and skill that asks whether it is running.
The predecessor now keeps its reservation until the replacement signals readiness and
publishes the successor's PID as one atomic handover.

## Merge safety

A temporary worktree that could not be removed was reported and stepped over; the merge
went ahead anyway. It now aborts the merge, because a worktree still held is a worktree
whose checks may not describe what was tested.

The dependency-isolation check was Node- and npm-specific policy applied to every
repository. It moves behind a new optional adapter member, `verifyDependencyIsolation`,
so a repository that does not borrow node_modules is not judged by that rule.

## Startup and hooks

A branch with no upstream in a repository with several remotes still refuses to start —
that ambiguity must not be guessed — but the error now names the remotes it found and the
two repairs that resolve it.

The hooks no longer require `/bin/bash`; they run under POSIX `sh`.

## Documentation

`SPEC.md` gains `REVIEW_EFFORT`, corrects what happens to a repeated finding and to a
`NEXT_TASK` line, and records the promotion behaviour changed here. `README.md` documents
the CI gate setting. A hand-written pull request body is now left alone while its title
still tracks the run, which is why this body survives the next gate.

## Verification

`npm run typecheck` and `npm test` pass on this branch: 634 tests across 43 files.

Not included: the loop's own review of this diff, which the run was stopped before
reaching. `SPEC.md` does not yet state the scan-template heading contract the section
derivation now depends on.
