### PR TITLE
fix: render shared skills for every agent that reads them

### DIFF
--- a/.claude/skills/.orchestration-core-sync.json
+++ b/.claude/skills/.orchestration-core-sync.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "skills": {
+    "git-commit": "9227c69fd20f4abb33d31b06a3923a1e0893af7459adf362890a09da5c8f4f66",
+    "git-merge": "f48b624ddfe2aa3ae2bd2a7ad4ea166cd2c9290904f9a8a6ca41b26fe362653f",
+    "git-pr": "b631462e5fd0ea3d9b6d974d17fa02f38aee09f336d9d401616ef5d9c96c536a",
+    "git-review": "c71b70fc4064c1bd626b43b40b94530daadcaf8cd3af5ecd65fbb1739f423b61",
+    "loop-delegate": "9f32215042f497eb3c0def1d841a109d190bda8d1614925686ec9ef185fec285",
+    "loop-setup": "3241c77cf74cc2591cb7cf2e694e904baf7f6225f8e151d184e867128d8da26a",
+    "loop-start": "7c0f00fbcca9c0c2d4a1cd8e6c5f230ce2a7b1d23fb93603f6df9bfe637064aa",
+    "loop-stop": "1574efbe1187d48675c9cb3244af16daa6e13d72ec75190f97b830de7c6e059c",
+    "skill-create": "6657e1650e63fc255cb3b2b286b1f2a5161d4dfe126a170504b6df1d8b4fc09e"
+  }
+}

--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: git-commit
+description: Turns a dirty working tree into well-formed commits, splitting the changes when they serve more than one purpose. Use when asked to commit work that is already written, including edits made by hand.
+allowed-tools: Bash, Read
+---
+
+# Committing existing work
+
+Working tree:
+
+!`git status --short`
+
+Unstaged:
+
+!`git diff --stat`
+
+Staged:
+
+!`git diff --cached --stat`
+
+## Decide what belongs in the commit
+
+The changes above were not necessarily written in one sitting or for one reason. Read
+them before staging anything — `git diff` for what is unstaged, `git diff --cached` for
+what is already staged.
+
+Group them by purpose, not by file. If they serve one purpose, commit them together. If
+they serve two, make two commits: stage the paths for the first, commit, then the rest.
+Where a single file contains both, say so rather than splitting it silently — deciding
+what ships together is the author's call.
+
+Leave out anything that is not part of the work: stray debug output, an editor's
+reformatting of untouched lines, a file that was only opened.
+
+## Write the message
+
+The prefix list and the one-purpose rule are in `CLAUDE.md`. What matters here is the
+body: state why the change was made, not a prose restatement of the diff. A reader can
+see what changed; they cannot see what it was for.
+
+## Before committing
+
+Run `/verify-changes` unless it has already passed on this tree. A commit that fails the
+build is worse than an uncommitted one, because it hides the failure behind a green
+history.
+
+The commit-msg hook rejects a subject without a recognised prefix, so a rejected commit
+is a typo, not a reason to reword the change.

--- a/.claude/skills/git-merge/SKILL.md
+++ b/.claude/skills/git-merge/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: git-merge
+description: Merges a pull request once CI and review allow it, then deletes the branch and returns to main. Use when asked to merge a PR.
+argument-hint: "[pr-number]"
+allowed-tools: Bash, Read
+---
+
+# Pull Request Merge
+
+Merge a PR following the Git conventions in `CLAUDE.md`.
+
+## PR Context
+
+**PR details:**
+!`gh pr view $ARGUMENTS --json number,title,state,mergeable,reviewDecision,author,statusCheckRollup,reviews`
+
+**Current user:**
+!`gh api user --jq .login`
+
+## Pre-merge Checks
+
+1. PR is open and mergeable
+2. **Branch freshness**: CI tests the merge of the PR into main as main stood when CI
+   ran, and main no longer re-runs the suites after the merge — so a PR behind main has
+   green checks that describe a tree that will never exist. If main has advanced since
+   the PR's checks ran, run `gh pr update-branch <number>`, wait for the re-run to go
+   green, and only then merge. Branch protection enforces this; do not bypass it.
+3. CI: all checks pass (`statusCheckRollup`; empty = no CI configured)
+4. Review: see workflow below
+5. No requested changes pending
+
+## Merge Workflow
+
+**Self-PR**: Require review comment via `/git-review` → merge (skip approval requirement)
+
+**Others' PR**: Require at least one APPROVED review → **STOP** if none
+
+## Policy
+
+- Always use `--merge` (not `--squash`) when merging to main
+- Delete branch after merge: `gh pr merge <number> --merge --delete-branch`
+- Switch to main and pull: `git switch main && git pull --ff-only`
+
+## Output
+
+```
+## Verification
+- PR: #<number> merged
+- reviews: [count] approved
+- strategy: merge
+- branch: <branch-name> deleted
+- current: main (up to date)
+```

--- a/.claude/skills/git-pr/SKILL.md
+++ b/.claude/skills/git-pr/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: git-pr
+description: Opens a pull request for the current branch, with the body in the repository section format. Use when asked to raise a PR.
+allowed-tools: Bash, Read
+---
+
+# Pull Request Creation
+
+Create a PR following the Git conventions in `CLAUDE.md`.
+
+## Current State
+
+**Branch:**
+!`git branch --show-current`
+
+**Commits (vs main):**
+!`git log main..HEAD --oneline`
+
+**Remote status:**
+!`git status -sb`
+
+## PR Description
+
+Write in English. Every section appears even when it has nothing, marked `- None`.
+
+```markdown
+## Features
+## Bug Fixes
+## Security
+## Project Operations
+## Risks
+```
+
+Entries read `- [Screen] what changed`, with the screen named for anything a user sees.
+No summary section — the headings and their bullets are the summary.
+
+Describe what the branch delivers, not the route it took there: a change reworked several
+times appears once, in its final form. `## Risks` carries what the diff actually shows —
+a new migration, an altered API contract, a change to how data is scoped, deleted tests —
+and `None identified` when there is none. Do not pad it with generic caution.
+
+## Output
+
+Return the PR URL when complete.

--- a/.claude/skills/git-review/SKILL.md
+++ b/.claude/skills/git-review/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: git-review
+description: Reviews a pull request diff and submits the result as a GitHub review. Use when asked to review a PR, including one you opened yourself.
+argument-hint: "<pr-number>"
+allowed-tools: Bash, Read
+---
+
+# Pull Request Review
+
+Review PR code changes and submit approval or feedback.
+
+## PR Context
+
+**PR details:**
+!`gh pr view $ARGUMENTS --json number,title,author,state,additions,deletions,changedFiles`
+
+**Current user:**
+!`gh api user --jq .login`
+
+**Changed files:**
+!`gh pr diff $ARGUMENTS --name-only`
+
+## Self-PR Handling
+
+GitHub does not allow self-approval. For self-PRs:
+- Perform full review analysis
+- Submit as **comment** (`gh pr review <number> --comment`) instead of approval
+- Include "Verdict: APPROVED (self-review)" in comment
+
+## Review Process
+
+1. Read the full diff: `gh pr diff <number>`
+2. Analyze each changed file for bugs, security issues, convention violations
+3. Submit review with appropriate action (`--approve`, `--comment`, or `--request-changes`)
+
+## Output
+
+```
+## Verification
+- PR: #<number> reviewed
+- files: [count] files analyzed
+- result: [APPROVED/COMMENTED/CHANGES_REQUESTED]
+- issues: [count] issues found (if any)
+```

--- a/.claude/skills/loop-delegate/SKILL.md
+++ b/.claude/skills/loop-delegate/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: loop-delegate
+description: Turns a decision from the conversation into a queued orchestration task, safe to do while the loop runs. Use when asked to hand work to Codex, queue an improvement for the loop, or capture something just decided as the next loop target.
+argument-hint: "[what was decided]"
+allowed-tools: Bash, Read
+---
+
+# Delegating a decision to the loop
+
+Current state:
+
+!`npm run loop-status`
+
+## What qualifies
+
+Delegate decisions, not open questions. The task must be able to run unattended:
+it depends on no other task's output, it can be specified so that no judgement
+call is left to the implementer, and it is larger than the cost of writing that
+specification. Anything still being discussed gets settled in the conversation
+first; anything smaller than its own specification is faster done directly.
+
+## Writing the description
+
+The description becomes the task's requirement verbatim, so carry the decision
+over from the conversation completely — the implementer has none of its context:
+
+- Name the files and directories the change touches.
+- State the requirement so nothing is left to interpretation. Where the
+  conversation weighed options and picked one, state the pick, not the debate.
+- Give a completion condition that can be run: a test name, a command.
+
+## Delegating
+
+```bash
+npm run delegate -- "<description>"
+```
+
+The description may span multiple lines inside one quoted argument. Add
+`--effort high` when the work needs deep reasoning; without it the task runs at
+the loop's standard effort (`TASK_EFFORT`, default medium).
+
+Delegating the same description twice is safe — the description index maps it
+back to the one existing task. Ids follow `YYYYMMDD_HHMMSS_nnn_user-<slug>`.
+
+## What happens next
+
+- **Loop running** — the task starts within one poll (`POLL_INTERVAL`, default
+  30s), ahead of any future scan, and is merged automatically. If the loop was
+  waiting at a cycle gate, the gate pushes again and re-checks CI after the
+  merge.
+- **Loop not running** — the task waits in the backlog until `/loop-start`, or
+  `npm run start -- <task-id>` runs it on its own.
+
+## Report
+
+State the task id and the specification path, whether the loop will pick it up
+or the backlog is holding it, and how to follow it:
+`npm run logs -- <task-id> -f`.

--- a/.claude/skills/loop-setup/SKILL.md
+++ b/.claude/skills/loop-setup/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: loop-setup
+description: Adopts the shared orchestration core in a repository and verifies the result. Use when installing this core for the first time, repairing its scaffold or hooks, or completing a repository's project adapter.
+---
+
+# Set up the loop
+
+Treat the subtree import as a deliberate user action. If `orchestration/ts/package.json`
+does not exist, show this command and pause until the user runs it:
+
+```bash
+git subtree add --prefix=orchestration/ts https://github.com/menimani/orchestration-core.git main --squash
+```
+
+Do not run `git subtree add` on the user's behalf.
+
+## Collect repository decisions
+
+Read the contributor guidance and manifests, then confirm with the user:
+
+- the project name;
+- fast staged-path checks for `preCommitChecks`;
+- full and light `mergeChecks`, including each check's path predicate;
+- the cycle suite;
+- pull-request categories, path classification, and risk signals;
+- optional CI, scan-worktree, Docker, infrastructure, and deployment declarations.
+
+Use repository-relative paths and commands the repository already documents. Do not
+invent a gate from a tool merely being present.
+
+## Initialize and write the adapter
+
+Run:
+
+```bash
+npm ci --prefix orchestration/ts
+node orchestration/ts/src/cli.ts init <project-name>
+```
+
+Record every `CREATED`, `EXISTS`, `DIVERGED`, `PASS`, and `FAIL` line. Init never
+overwrites an existing project-owned file or a different `core.hooksPath` value.
+
+Edit the generated `orchestration/project/project-<name>.ts` from the decisions above
+only when init created it in this run. If an adapter already existed, report it and ask
+before changing it; deliberate divergence is not a repair target.
+
+Keep `preCommitChecks` fast. The core-owned hook supplies the default-branch guard and
+selects these checks from staged paths. Do not create repository-owned hook scripts.
+
+## Verify
+
+Run:
+
+```bash
+node orchestration/ts/src/cli.ts verify-setup
+```
+
+Report each check exactly as `PASS`, `FAIL`, or `SKIP` with its reason. The verifier
+checks the core TypeScript compilation, the adapter's cycle suite, real `loadProject`
+discovery by name, every adapter-referenced path, the current branch's pushable upstream,
+`core.hooksPath`, and all `loop:*` labels. Never summarize a skipped check as passed.
+
+Do not declare setup complete while any check says `FAIL`. Do not create or change a
+remote/upstream merely to clear that failure without the user's approval.

--- a/.claude/skills/loop-setup/agents/openai.yaml
+++ b/.claude/skills/loop-setup/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Loop Setup"
+  short_description: "Adopt and verify the shared orchestration core"
+  default_prompt: "Use $loop-setup to adopt the shared orchestration core in this repository."

--- a/.claude/skills/loop-start/SKILL.md
+++ b/.claude/skills/loop-start/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: loop-start
+description: Starts the autonomous improvement loop in the background, after checking nothing is already running. Use when asked to begin a scan-and-fix run, or to resume one that was stopped.
+argument-hint: "[MAX_SCAN_CYCLES=n] [MAX_PARALLEL=n]"
+allowed-tools: Bash, Read
+---
+
+# Starting the loop
+
+Current state:
+
+!`npm run loop-status`
+
+## Before starting
+
+A second loop against the same repository will fight the first over the queue and the
+worktrees. If `orchestration/queue/loop.pid` names a live process, stop rather than start.
+
+The loop commits and merges on its own, so start it on a topic branch, never on `main`.
+
+## Starting
+
+```bash
+npm run loop -- --daemon
+```
+
+`--daemon` is what puts it in the background; without it the loop holds the terminal.
+Settings go in front of the command:
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `MAX_SCAN_CYCLES` | 3 | How many scan-and-fix rounds before it promotes the PR and exits |
+| `MAX_PARALLEL` | 3 | Codex processes at once |
+| `MAX_EMPTY_SCANS` | 2 | Scans finding nothing before it stops early |
+| `REVIEW_ENABLED` | true | Wait for a review flag between cycles instead of continuing |
+| `AUTO_REVIEW` | false | Review each cycle's diff automatically; findings become fix tasks |
+| `MAX_REVIEW_ROUNDS` | 2 | Review rounds per cycle before resuming with findings outstanding |
+| `REVIEW_EVERY_N_CYCLES` | 1 | Review every Nth cycle (the final cycle is always reviewed) |
+| `MAX_FINAL_REVIEW_ROUNDS` | 4 | Final-cycle rounds before the loop stops instead of promoting unresolved findings |
+| `MAX_BURST_FAILURES` | 3 | Task failures in one poll before the loop stops and blames the environment |
+| `ISSUE_QUEUE_ENABLED` | false | Findings become claimable forge issues instead of local queue entries (each concurrent worker requires a distinct forge account) |
+| `ISSUE_LEASE_HOURS` | 3 | Hours a claimed issue may sit untouched before its lease is reaped back to ready |
+| `CI_GATE_ENABLED` | false | Whether the gate waits for CI — a draft PR has no checks, so waiting would hang |
+| `MAX_CONSECUTIVE_MERGE_FAILURES` | 3 | Merges failing in a row before it stops — the task finished, its verification did not |
+| `SCAN_ENABLED` | true | Set false to work the existing queue without scanning |
+| `SCAN_PARALLEL` | 2 | Scans per cycle, splitting the checklist between them (1 = single full scan, up to 4) |
+| `SCAN_EFFORT` | high | Codex reasoning effort for scan tasks |
+| `TASK_EFFORT` | medium | Codex reasoning effort for queued tasks (`delegate --effort` overrides per task) |
+| `REVIEW_EFFORT` | high | Codex reasoning effort for automatic review tasks |
+| `TASK_GATE` | full | `light` runs compile/lint per task and the full suites once at each cycle gate — faster, but a suite break names no task |
+
+## While it runs
+
+Work can be handed to a running loop without stopping it — `/loop-delegate`
+turns a decision from the conversation into a queued task the loop picks up on
+its next poll, ahead of any future scan.
+
+The daemon holds the code it started with. **Editing the loop source under `src` changes
+nothing until the loop is restarted**, and reporting that a fix took effect without
+restarting is how a fix gets credited that never ran.
+
+Follow it with `npm run queue`, or read
+`orchestration/logs/loop.log`. Per-task output is in `orchestration/logs/<task-id>.log`,
+and merge output — including the tests run before each merge — in `<task-id>.merge.log`.
+
+## When it finishes
+
+It prints `LOOP_DONE: <PR URL>` and exits. The PR body it leaves behind is built from the
+commit log, so a change reworked across cycles appears as every intermediate step,
+including ones later reverted. **Rewrite the body from the diff before anyone reviews
+it** — `/git-pr` describes the format.

--- a/.claude/skills/loop-stop/SKILL.md
+++ b/.claude/skills/loop-stop/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: loop-stop
+description: Stops the autonomous improvement loop and reports what was still in flight when it stopped. Use when asked to halt a running loop, or before switching branches while one is running.
+allowed-tools: Bash, Read
+---
+
+# Stopping the loop
+
+Current state:
+
+!`npm run loop-status`
+
+## Stopping
+
+```bash
+npm run stop
+```
+
+This writes a stop file. The loop notices it on its next poll, so it exits within
+`POLL_INTERVAL` seconds — 30 by default. The command also terminates every live task
+process tree immediately and reports each task and PID. If a process tree cannot be
+terminated, the command reports the failure and exits non-zero.
+
+## What stopping retains
+
+Task specifications, logs, status files, worktrees, and branches are retained for
+recovery. No terminated agent continues working after `stop` returns.
+
+For a task that completed before the stop, inspect its log and merge it by hand:
+
+```bash
+npm run logs -- <task-id>
+npm run merge -- <task-id> --yes
+```
+
+For a task that was terminated while running, inspect its log and worktree before doing
+anything destructive. It has no automatic retry. Preserve any useful changes manually,
+then clean up and re-enqueue the retained specification:
+
+```bash
+npm run logs -- <task-id>
+npm run cleanup -- <task-id>
+npm run enqueue -- <task-id>
+```
+
+`cleanup` removes the worktree and its branch. Look at the log first — a task that
+produced useful uncommitted or unmerged work loses it here.
+
+## Report
+
+Say that the loop is stopping, list the task process trees it terminated, and identify
+the retained worktrees that need recovery or cleanup.

--- a/.claude/skills/skill-create/SKILL.md
+++ b/.claude/skills/skill-create/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: skill-create
+description: Writes and revises repository skills against the Agent Skills format and runner-specific conventions. Use when creating a skill, or when an existing skill's frontmatter, description, or structure needs reviewing.
+---
+
+# Creating a skill
+
+Existing skills:
+
+Run `ls .agents/skills/` and use its output as context before continuing.
+
+Skills live in `.agents/skills/<name>/SKILL.md`. Only the frontmatter is preloaded at
+startup; the body is read when the skill is selected, and supporting files only when the
+body links to them. That is the whole reason to put something in a skill rather than in
+always-loaded repository guidance — the latter is paid for in every session.
+
+## Frontmatter
+
+`name` — lowercase letters, digits and hyphens, 64 characters at most. Never `anthropic`
+or `claude`, and never a placeholder like `helper`, `utils`, or `tools`.
+
+Name it **subject first, then what you do to it**: `git-pr`, `loop-start`, `skill-create`.
+Everything sharing a subject then sorts together, which is how you find a skill you half
+remember. Reversing it to `start-loop` reads more naturally in isolation and scatters the
+family, so the collection loses more than the single name gains.
+
+The exception is a skill whose subject is the action — `verify-changes` has no noun to
+put first, and `changes-verify` would name a report rather than something you run. Reach
+for it only when the subject-first form genuinely has nothing to put in front.
+
+`description` — third person, giving both what the skill does and when to reach for it.
+This is the field that selects the skill, so it earns more care than anything in the body.
+
+```yaml
+description: Reviews a pull request's diff and submits the result as a GitHub review.
+  Use when asked to review a PR, including one you opened yourself.
+```
+
+`Review pull requests` fails on both counts — imperative, and silent about when. `I can
+review PRs` fails differently: first person reads inconsistently once it has been
+injected into the system prompt.
+
+Keep runner-specific presentation and invocation policy out of this frontmatter. For
+Codex, put it in `agents/openai.yaml`; see [reference.md](reference.md).
+
+## Body
+
+Under 500 lines, and written for a reader who is already competent. Cut anything that
+explains a language, a library, or a familiar workflow. Keep what is specific to this
+repository and would otherwise be guessed wrong.
+
+Match how prescriptive you are to what a wrong choice costs. Reviewing code tolerates
+judgement and should be described in general terms. A migration or a merge does not —
+name the exact command and say what must not be varied.
+
+Link supporting files directly from SKILL.md, never file to file: a reference reached
+through another reference tends to be read only in part. Give any file over 100 lines a
+contents list at the top, for the same reason.
+
+## Runtime context
+
+Do not depend on host-specific prompt expansion. Tell the agent to run the command it
+needs as an ordinary workflow step. See [reference.md](reference.md).
+
+## Before finishing
+
+- Does the description say *when*, not only *what*?
+- Is any of this already in the repository's always-loaded guidance? A rule that must
+  hold whoever is acting belongs there. A procedure for a selected task belongs here.
+- Will it still be true after the next refactor, or does it name paths that move?
+- Forward slashes in every path, including on Windows.

--- a/.claude/skills/skill-create/agents/openai.yaml
+++ b/.claude/skills/skill-create/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Skill Create"
+  short_description: "Create or revise a repository skill"
+  default_prompt: "Use $skill-create to create or revise a repository skill."
+policy:
+  allow_implicit_invocation: false

--- a/.claude/skills/skill-create/reference.md
+++ b/.claude/skills/skill-create/reference.md
@@ -1,0 +1,81 @@
+# Skill host reference
+
+## Contents
+
+- Runtime context
+- User arguments and explicit invocation
+- Codex metadata
+
+## Runtime context
+
+Keep runtime context as ordinary instructions so the workflow works across hosts. Name
+the command, say when to run it, and say how its output affects the next step.
+
+### Preferred pattern
+
+```markdown
+Run `git status --short` and use its output to identify the changed files before staging.
+```
+
+This makes failures visible to the agent and lets it choose the appropriate recovery.
+Do not use host-specific pre-execution expansion in a canonical shared skill; Codex
+treats that syntax as inert Markdown.
+
+## User arguments and explicit invocation
+
+Codex receives arguments as part of the user's request; it does not expand an
+`$ARGUMENTS` variable in `SKILL.md`. Describe the expected value in the instruction,
+for example `Run \`gh pr view <pr-number> --json number,title,state\``.
+
+Mention a Codex skill explicitly as `$skill-name`. `/skills` opens the selector; a
+slash command named after the skill does not invoke it.
+
+## Frontmatter
+
+```yaml
+---
+name: kebab-case-name
+description: >-
+  What this skill does and when.
+  Be specific about triggers.
+---
+```
+
+Only `name` and `description` belong in Codex `SKILL.md` frontmatter.
+
+## Codex metadata
+
+Put Codex presentation and invocation policy in `agents/openai.yaml`:
+
+```yaml
+interface:
+  display_name: "Human-facing name"
+  short_description: "Short purpose"
+  default_prompt: "Use $skill-name to perform the workflow."
+policy:
+  allow_implicit_invocation: false
+```
+
+Omit `policy` when implicit invocation is appropriate. Keep tool dependencies in this
+file as well; do not put tool allowlists in `SKILL.md` frontmatter.
+
+## Content Guidelines
+
+| Guideline | Detail |
+|-----------|--------|
+| Keep SKILL.md under 500 lines | Move details to supporting files |
+| Instructions should be actionable | Not just guidelines, but steps |
+| Include output format | So results are consistent |
+| Reference supporting files | `See [reference.md](reference.md) for details` |
+
+## Supporting File Structure
+
+```
+my-skill/
+├── SKILL.md           # Main instructions (required, <500 lines)
+├── agents/
+│   └── openai.yaml    # Optional Codex metadata and invocation policy
+├── references/        # Detailed docs loaded on demand
+├── assets/            # Templates and output resources
+└── scripts/           # Deterministic executable helpers
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,14 @@ TypeScript with no build step.
 
 `README.md` describes what it is and how to run it. `SPEC.md` states the behaviour the
 suite pins — the two must agree, and tests enforce that. Canonical shared workflows live
-under `skills/`. The selected runner renders them into its repository discovery path;
-Codex receives them under `.agents/skills/`. The repository-local `.claude/skills/`
-contains only `verify-changes`, which is not one of the generated shared workflows.
+under `skills/`. They are rendered into every discovery path an agent working here reads:
+the selected runner's — `.agents/skills/` for Codex — and `.claude/skills/`, which the
+interactive agent a person drives reads and which also holds `verify-changes`, a
+repository skill absent from the manifest and never touched by the sync.
+
+Merges, reviews, pull requests, and commits go through those workflows rather than
+hand-composed `gh` and `git` invocations: `git-merge` will not merge a self-PR that has
+no review, and that rule lives in the skill, not in anyone's memory.
 
 This file holds only what the source cannot tell you.
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,15 @@ A daemon otherwise runs the code it started with. A dirty working tree or confli
 pull is left for the consumer to resolve: the daemon warns and starts the cycle on the
 old code instead of merging local divergence.
 
-That same boundary asks the selected runner adapter to sync the skills declared in
-`skills/manifest.json` into its repository skill directory. The bundled Codex adapter
-uses `.agents/skills/` and renders loop commands for the installed package location
-(`npm run` here, `npm run -C orchestration/ts` in the layout below).
+That same boundary syncs the skills declared in `skills/manifest.json` into every
+directory an agent working in the repository reads them from. The selected runner adapter
+supplies one — the bundled Codex adapter uses `.agents/skills/` and rewrites the sources
+into Codex's own form — and `.claude/skills/` receives them for the interactive agent a
+person drives, in the canonical form that agent already speaks. Serving only the runner
+meant that selecting Codex silently took every shared workflow away from the person, so
+one destination failing no longer costs the others theirs. Loop commands are rendered for
+the installed package location (`npm run` here, `npm run -C orchestration/ts` in the
+layout below).
 The sync tracks the exact content it generated: a consumer edit, deletion, or added
 support file is reported and retained, while repository skills absent from the manifest
 are never touched. Canonical skills live outside a nested runner skill directory,

--- a/SPEC.md
+++ b/SPEC.md
@@ -178,12 +178,17 @@ values must be non-negative integers, with the narrower bounds stated below.
     code it started with. The check never runs mid-cycle. A dirty
     working tree or a pull conflict logs `WARN`, aborts any in-progress merge, and lets
     the cycle proceed unchanged so local divergence is resolved by the consumer.
-    At the same boundary, the selected runner adapter supplies the shared-skill
-    destination and rendering behavior. The Codex adapter renders the package manifest's
-    skills into repository root `.agents/skills/`, using `npm run` as the command prefix
-    in the owning repository and `npm run -C <package-path>` in a subtree consumer. The
+    At the same boundary, the package manifest's skills are rendered into every
+    directory an agent working in the repository discovers skills in: the selected
+    runner's, supplied by its adapter, and `.claude/skills/` for the interactive agent a
+    person drives. The Codex adapter renders into repository root `.agents/skills/`; the
+    interactive rendering resolves the command prefix only, the canonical sources already
+    being in that agent's format. Both use `npm run` as the command prefix in the owning
+    repository and `npm run -C <package-path>` in a subtree consumer, and a runner that
+    discovers `.claude/skills/` is served once rather than twice. The
     sync replaces only a tree whose content matches its recorded last output; consumer
     divergence is warned and retained, and skills absent from the manifest are untouched.
+    A destination that cannot be served is reported without costing the others theirs.
     Shared canonical sources do not live below a runner skill directory, so a subtree
     exposes no nested duplicate of a shared skill.
 
@@ -302,8 +307,9 @@ values must be non-negative integers, with the narrower bounds stated below.
 30. The runner is invoked only through `adapters/runner.ts` (`RUNNER=codex` selects
     `runner-codex.ts`). The runner contract is the output markers — `TASK_COMPLETE`,
     `NEXT_TASK:`, `DECISION_REQUIRED:` in the final-message file — plus effort/model
-    arguments mapped to CLI flags, and the repository skill destination and rendering
-    behavior inside the adapter. Any runner honoring the contract is substitutable.
+    arguments mapped to CLI flags, and the runner's own repository skill destination and
+    rendering behavior inside the adapter. Any runner honoring the contract is
+    substitutable, and none of them owns the interactive agent's skill directory.
 31. Everything the orchestration knows about the repository it runs in — which staged
     paths select fast pre-commit checks, which commands verify a merge, which paths make
     each check relevant, which suites prove a cycle's

--- a/src/adapters/runner-codex.ts
+++ b/src/adapters/runner-codex.ts
@@ -87,8 +87,10 @@ function renderSharedSkillFile(
 export function createCodexRunner(): Runner {
   return {
     sharedSkills: {
+      // `.claude/skills` was this runner's former discovery path, but it is not a legacy
+      // root: the interactive agent a person drives reads it, and the core keeps it
+      // filled. Claiming it here emptied it whenever Codex was the selected runner.
       destinationRoot: (repoRoot) => join(repoRoot, '.agents', 'skills'),
-      legacyRoots: (repoRoot) => [join(repoRoot, '.claude', 'skills')],
       renderFile: renderSharedSkillFile,
     },
     start(options: RunnerStartOptions): Promise<number> {

--- a/src/coreUpdate.ts
+++ b/src/coreUpdate.ts
@@ -70,6 +70,9 @@ function syncSkills(
     event('WARN', `shared skill sync failed: ${summary(error)}`)
     return
   }
+  for (const failure of result.failures) {
+    event('WARN', `shared skill sync failed: ${failure}`)
+  }
   for (const skill of result.conflicts) {
     event('WARN', `shared skill ${skill} differs from the last synced copy; left unchanged`)
   }

--- a/src/sharedSkills.ts
+++ b/src/sharedSkills.ts
@@ -5,9 +5,23 @@ import {
 } from 'node:fs'
 import { dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { operatingSystem, type OperatingSystem } from './adapters/os.ts'
-import type { Runner } from './adapters/runner.ts'
+import { packageCommandPrefix } from './paths.ts'
+import type { Runner, RunnerSharedSkillRenderOptions } from './adapters/runner.ts'
 
 const STATE_FILE = '.orchestration-core-sync.json'
+
+/**
+ * One directory a repository-scoped skill is discovered in, with the rendering that
+ * directory's reader expects. The loop's runner is only one such reader: a person drives
+ * an interactive agent in the same repository, and it discovers its own directory. When
+ * only the runner was served, selecting Codex removed every shared workflow from the
+ * interactive agent — including the merge workflow this repository routes merges through.
+ */
+interface SharedSkillTarget {
+  destinationRoot: string
+  legacyRoots: readonly string[]
+  renderFile(contents: Buffer, options: RunnerSharedSkillRenderOptions): Buffer
+}
 
 interface SharedSkillsManifest {
   commandPrefixPlaceholder: string
@@ -32,6 +46,8 @@ export interface SharedSkillsSyncResult {
   removedPaths: string[]
   changedPaths: string[]
   managedPaths: string[]
+  /** One message per target that could not be served at all. */
+  failures: string[]
 }
 
 function object(value: unknown): Record<string, unknown> | undefined {
@@ -90,7 +106,7 @@ function renderedSkill(
   skill: string,
   placeholder: string,
   repoRoot: string,
-  runner: Runner,
+  target: SharedSkillTarget,
 ): RenderedFile[] {
   const source = join(packageRoot, 'skills', skill)
   if (!existsSync(join(source, 'SKILL.md'))) {
@@ -98,12 +114,43 @@ function renderedSkill(
   }
   return filesIn(source).map((file) => ({
     ...file,
-    contents: runner.sharedSkills.renderFile(file.contents, {
+    contents: target.renderFile(file.contents, {
       repoRoot,
       packageRoot,
       commandPrefixPlaceholder: placeholder,
     }),
   }))
+}
+
+/**
+ * The interactive agent a person drives in the repository. The canonical skills are
+ * authored in its format already — frontmatter, `!`command`` preambles and `/skill`
+ * invocations are its own conventions — so only the command prefix is resolved here.
+ */
+function interactiveAgentTarget(repoRoot: string): SharedSkillTarget {
+  return {
+    destinationRoot: join(repoRoot, '.claude', 'skills'),
+    legacyRoots: [],
+    renderFile: (contents, options) => Buffer.from(contents.toString('utf8').replaceAll(
+      options.commandPrefixPlaceholder,
+      packageCommandPrefix(options.repoRoot, options.packageRoot),
+    )),
+  }
+}
+
+/** Every directory this repository's skills must appear in, each listed once. */
+function skillTargets(repoRoot: string, runner: Runner): SharedSkillTarget[] {
+  const runnerTarget: SharedSkillTarget = {
+    destinationRoot: runner.sharedSkills.destinationRoot(repoRoot),
+    legacyRoots: runner.sharedSkills.legacyRoots?.(repoRoot) ?? [],
+    renderFile: (contents, options) => runner.sharedSkills.renderFile(contents, options),
+  }
+  const interactive = interactiveAgentTarget(repoRoot)
+  // A runner that reads the interactive agent's directory is that agent: rendering the
+  // same directory twice would leave whichever target ran second describing the tree.
+  return relative(runnerTarget.destinationRoot, interactive.destinationRoot) === ''
+    ? [runnerTarget]
+    : [runnerTarget, interactive]
 }
 
 function hashFiles(files: readonly RenderedFile[]): string {
@@ -192,26 +239,28 @@ function migrateLegacySkills(
 }
 
 /**
- * Materialize the package's declared shared skills at the repository root. The state
+ * Materialize the package's declared shared skills into one target directory. The state
  * records the exact rendered tree last written, so later syncs never mistake a person's
  * edit (including an added support file or a deletion) for an old generated copy.
  */
-export function syncSharedSkills(
+function syncTarget(
   repoRoot: string,
   packageRoot: string,
-  runner: Runner,
-  os: OperatingSystem = operatingSystem,
+  target: SharedSkillTarget,
+  os: OperatingSystem,
 ): SharedSkillsSyncResult {
   const manifest = readManifest(packageRoot)
-  const destinationRoot = runner.sharedSkills.destinationRoot(repoRoot)
+  const destinationRoot = target.destinationRoot
   const repositoryPath = relative(repoRoot, destinationRoot)
   if (repositoryPath === '' || repositoryPath === '..'
     || repositoryPath.startsWith(`..${sep}`) || isAbsolute(repositoryPath)) {
     throw new Error(`shared skill destination escaped the repository: ${destinationRoot}`)
   }
+  // Skill names alone cannot say which directory reported them once several are served.
+  const reported = (skill: string): string =>
+    `${repositoryPath.replaceAll('\\', '/')}/${skill}`
   const stateFile = join(destinationRoot, STATE_FILE)
-  const legacyRoots = runner.sharedSkills.legacyRoots?.(repoRoot) ?? []
-  const migration = migrateLegacySkills(legacyRoots, destinationRoot, os)
+  const migration = migrateLegacySkills(target.legacyRoots, destinationRoot, os)
   mkdirSync(destinationRoot, { recursive: true })
   const state = readState(stateFile)
   const nextState: SharedSkillsState = { version: 1, skills: { ...state.skills } }
@@ -224,13 +273,13 @@ export function syncSharedSkills(
   for (const skill of manifest.skills) {
     const destination = join(destinationRoot, skill)
     const desiredFiles = renderedSkill(
-      packageRoot, skill, manifest.commandPrefixPlaceholder, repoRoot, runner,
+      packageRoot, skill, manifest.commandPrefixPlaceholder, repoRoot, target,
     )
     const desiredHash = hashFiles(desiredFiles)
     const previousHash = state.skills[skill]
     if (existsSync(destination)) {
       if (!lstatSync(destination).isDirectory()) {
-        conflicts.push(skill)
+        conflicts.push(reported(skill))
         continue
       }
       const currentHash = hashFiles(filesIn(destination))
@@ -239,23 +288,23 @@ export function syncSharedSkills(
         continue
       }
       if (previousHash === undefined || currentHash !== previousHash) {
-        conflicts.push(skill)
+        conflicts.push(reported(skill))
         continue
       }
       replaceDirectory(destination, desiredFiles, os)
       nextState.skills[skill] = desiredHash
-      updated.push(skill)
+      updated.push(reported(skill))
       changedPaths.push(destination)
       managedPaths.push(destination)
       continue
     }
     if (previousHash !== undefined) {
-      conflicts.push(skill)
+      conflicts.push(reported(skill))
       continue
     }
     replaceDirectory(destination, desiredFiles, os)
     nextState.skills[skill] = desiredHash
-    installed.push(skill)
+    installed.push(reported(skill))
     changedPaths.push(destination)
     managedPaths.push(destination)
   }
@@ -273,5 +322,38 @@ export function syncSharedSkills(
     removedPaths: migration.changedPaths,
     changedPaths,
     managedPaths,
+    failures: [],
   }
+}
+
+/**
+ * Materialize the declared shared skills for every agent that discovers skills in this
+ * repository. A target that fails is reported through its own error rather than leaving
+ * the remaining targets unserved: losing one reader's workflows must not lose the others'.
+ */
+export function syncSharedSkills(
+  repoRoot: string,
+  packageRoot: string,
+  runner: Runner,
+  os: OperatingSystem = operatingSystem,
+): SharedSkillsSyncResult {
+  const combined: SharedSkillsSyncResult = {
+    installed: [], updated: [], conflicts: [], migrationConflicts: [],
+    removedPaths: [], changedPaths: [], managedPaths: [], failures: [],
+  }
+  for (const target of skillTargets(repoRoot, runner)) {
+    let result: SharedSkillsSyncResult
+    try {
+      result = syncTarget(repoRoot, packageRoot, target, os)
+    } catch (error) {
+      // Files another target already wrote are still owed a report: throwing here would
+      // leave them on disk with nothing naming them to the consumer commit path.
+      combined.failures.push(error instanceof Error ? error.message : String(error))
+      continue
+    }
+    for (const key of Object.keys(combined) as (keyof SharedSkillsSyncResult)[]) {
+      combined[key].push(...result[key])
+    }
+  }
+  return combined
 }

--- a/tests/core-update.test.ts
+++ b/tests/core-update.test.ts
@@ -187,6 +187,7 @@ describe('pre-cycle core update', () => {
 
   it('installs missing shared skills and commits them when the subtree is current', async () => {
     rmSync(join(repoRoot, '.agents'), { recursive: true })
+    rmSync(join(repoRoot, '.claude'), { recursive: true })
     commit(repoRoot, 'chore: remove initial skill fixture')
     const oldHead = git(repoRoot, ['rev-parse', 'HEAD'])
     const loop = makeLoop(config())
@@ -197,7 +198,13 @@ describe('pre-cycle core update', () => {
       .toBe('version one: npm run -C orchestration/ts loop\n')
     expect(git(repoRoot, ['rev-parse', 'HEAD'])).not.toBe(oldHead)
     expect(git(repoRoot, ['status', '--porcelain'])).toBe('')
-    expect(events).toContain('Updated skill installed loop-start')
+    expect(events).toContain('Updated skill installed .agents/skills/loop-start')
+    // The interactive agent's directory is served in the same boundary, or a person
+    // driving it loses every shared workflow the moment a runner is selected.
+    expect(events).toContain('Updated skill installed .claude/skills/loop-start')
+    expect(readFileSync(join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md'), 'utf8')
+      .replaceAll('\r', ''))
+      .toBe('version one: npm run -C orchestration/ts loop\n')
   })
 
   it('refreshes shared skills at the consumer root in the same clean update boundary', async () => {
@@ -211,12 +218,14 @@ describe('pre-cycle core update', () => {
       .toBe('version two: npm run -C orchestration/ts loop-status\n')
     expect(existsSync(join(packageRoot, '.agents', 'skills', 'loop-start'))).toBe(false)
     expect(git(repoRoot, ['status', '--porcelain'])).toBe('')
-    expect(events).toContain('Updated skill refreshed loop-start')
+    expect(events).toContain('Updated skill refreshed .agents/skills/loop-start')
   })
 
-  it('migrates and commits tracked legacy shared skill copies', async () => {
+  it('keeps a repository adopted before the interactive target was served', async () => {
+    // Between the sync's introduction and this behaviour, the bundled runner claimed
+    // `.claude/skills` as a legacy root and emptied it. A repository carrying that
+    // arrangement must come out of an update with both directories filled, not one.
     rmSync(join(repoRoot, '.agents'), { recursive: true })
-    commit(repoRoot, 'chore: remove current skill fixture')
     syncSharedSkills(repoRoot, packageRoot, {
       sharedSkills: {
         ...fakeRunnerSharedSkills,
@@ -224,16 +233,14 @@ describe('pre-cycle core update', () => {
       },
       start: async () => process.pid,
     })
-    git(repoRoot, ['add', '-f', '--', '.claude/skills'])
-    commit(repoRoot, 'chore: install legacy skill fixture')
+    commit(repoRoot, 'chore: adopt the former arrangement')
     const oldHead = git(repoRoot, ['rev-parse', 'HEAD'])
     const loop = makeLoop(config())
 
     expect(await loop.poll(), events.join('\n')).toBe('continue')
-    expect(existsSync(join(repoRoot, '.claude', 'skills', 'loop-start'))).toBe(false)
-    expect(existsSync(join(
-      repoRoot, '.claude', 'skills', '.orchestration-core-sync.json',
-    ))).toBe(false)
+    expect(readFileSync(join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md'), 'utf8')
+      .replaceAll('\r', ''))
+      .toBe('version one: npm run -C orchestration/ts loop\n')
     expect(readFileSync(join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md'), 'utf8')
       .replaceAll('\r', ''))
       .toBe('version one: npm run -C orchestration/ts loop\n')
@@ -241,26 +248,17 @@ describe('pre-cycle core update', () => {
     expect(git(repoRoot, ['status', '--porcelain'])).toBe('')
   })
 
-  it('preserves and reports a divergent tracked legacy shared skill', async () => {
-    syncSharedSkills(repoRoot, packageRoot, {
-      sharedSkills: {
-        ...fakeRunnerSharedSkills,
-        destinationRoot: (root) => join(root, '.claude', 'skills'),
-      },
-      start: async () => process.pid,
-    })
-    git(repoRoot, ['add', '-f', '--', '.claude/skills'])
-    commit(repoRoot, 'chore: install legacy skill fixture')
-    const legacySkill = join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md')
-    writeFileSync(legacySkill, 'consumer command\n')
-    commit(repoRoot, 'chore: customize legacy skill fixture')
+  it('preserves and reports a divergent interactive shared skill', async () => {
+    const interactiveSkill = join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md')
+    writeFileSync(interactiveSkill, 'consumer command\n')
+    commit(repoRoot, 'chore: customize interactive skill fixture')
     const loop = makeLoop(config())
 
     expect(await loop.poll(), events.join('\n')).toBe('continue')
-    expect(readFileSync(legacySkill, 'utf8').replaceAll('\r', '')).toBe('consumer command\n')
+    expect(readFileSync(interactiveSkill, 'utf8').replaceAll('\r', '')).toBe('consumer command\n')
     expect(git(repoRoot, ['status', '--porcelain'])).toBe('')
     expect(events).toContain(
-      'WARN legacy shared skill .claude/skills/loop-start differs from the last synced copy; left unchanged',
+      'WARN shared skill .claude/skills/loop-start differs from the last synced copy; left unchanged',
     )
   })
 
@@ -276,7 +274,7 @@ describe('pre-cycle core update', () => {
     expect(readFileSync(installed, 'utf8').replaceAll('\r', '')).toBe('consumer command\n')
     expect(git(repoRoot, ['status', '--porcelain'])).toBe('')
     expect(events).toContain(
-      'WARN shared skill loop-start differs from the last synced copy; left unchanged',
+      'WARN shared skill .agents/skills/loop-start differs from the last synced copy; left unchanged',
     )
   })
 

--- a/tests/runner-codex.test.ts
+++ b/tests/runner-codex.test.ts
@@ -64,8 +64,9 @@ describe('createCodexRunner', () => {
 
     expect(sharedSkills.destinationRoot(repoRoot))
       .toBe(join(repoRoot, '.agents', 'skills'))
-    expect(sharedSkills.legacyRoots?.(repoRoot))
-      .toEqual([join(repoRoot, '.claude', 'skills')])
+    // `.claude/skills` is the interactive agent's directory, which the core keeps
+    // filled; claiming it as a legacy root here emptied it whenever Codex was selected.
+    expect(sharedSkills.legacyRoots).toBeUndefined()
     expect(sharedSkills.renderFile(
       Buffer.from('{{COMMAND_PREFIX}} loop\n'),
       { repoRoot, packageRoot, commandPrefixPlaceholder: '{{COMMAND_PREFIX}}' },

--- a/tests/shared-skills.test.ts
+++ b/tests/shared-skills.test.ts
@@ -46,7 +46,10 @@ describe('shared skill sync', () => {
 
     const result = syncSharedSkills(repoRoot, packageRoot, runner)
 
-    expect(result.installed).toEqual(['git-commit', 'loop-start'])
+    expect(result.installed).toEqual([
+      '.agents/skills/git-commit', '.agents/skills/loop-start',
+      '.claude/skills/git-commit', '.claude/skills/loop-start',
+    ])
     expect(readFileSync(join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
       .toBe('npm run -C orchestration/ts loop -- --daemon\n')
     expect(existsSync(join(repoRoot, '.agents', 'skills', 'verify-changes'))).toBe(false)
@@ -75,7 +78,7 @@ describe('shared skill sync', () => {
 
     const result = syncSharedSkills(repoRoot, packageRoot, runner)
 
-    expect(result.updated).toEqual(['loop-start'])
+    expect(result.updated).toEqual(['.agents/skills/loop-start', '.claude/skills/loop-start'])
     expect(readFileSync(join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
       .toBe('version two: npm run -C orchestration/ts loop\n')
     expect(readFileSync(localSkill, 'utf8')).toBe('repository gates\n')
@@ -89,8 +92,8 @@ describe('shared skill sync', () => {
 
     const result = syncSharedSkills(repoRoot, packageRoot, runner)
 
-    expect(result.conflicts).toEqual(['loop-start'])
-    expect(result.updated).toEqual([])
+    expect(result.conflicts).toEqual(['.agents/skills/loop-start'])
+    expect(result.updated).toEqual(['.claude/skills/loop-start'])
     expect(readFileSync(installed, 'utf8')).toBe('consumer version\n')
   })
 
@@ -100,7 +103,7 @@ describe('shared skill sync', () => {
 
     const result = syncSharedSkills(repoRoot, packageRoot, runner)
 
-    expect(result.conflicts).toEqual(['loop-start'])
+    expect(result.conflicts).toEqual(['.agents/skills/loop-start'])
     expect(existsSync(join(repoRoot, '.agents', 'skills', 'loop-start'))).toBe(false)
   })
 
@@ -187,8 +190,56 @@ describe('shared skill sync', () => {
       start: async () => process.pid,
     }
 
-    expect(() => syncSharedSkills(repoRoot, packageRoot, runner))
-      .toThrow(`shared skill destination escaped the repository: ${escaped}`)
+    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+
+    expect(result.failures).toEqual([
+      `shared skill destination escaped the repository: ${escaped}`,
+    ])
     expect(existsSync(escaped)).toBe(false)
+    // The unusable runner destination must not cost the interactive agent its workflows.
+    expect(result.installed).toEqual(['.claude/skills/git-commit', '.claude/skills/loop-start'])
+  })
+
+  it('serves the interactive agent in its own format alongside the runner', () => {
+    writeSkill('git-commit', [
+      '---',
+      'name: git-commit',
+      'allowed-tools: Bash',
+      '---',
+      '',
+      'Follow /git-review before committing.',
+      '',
+    ].join('\n'))
+
+    syncSharedSkills(repoRoot, packageRoot, runner)
+
+    const interactive = readFileSync(
+      join(repoRoot, '.claude', 'skills', 'git-commit', 'SKILL.md'), 'utf8',
+    )
+    const forRunner = readFileSync(
+      join(repoRoot, '.agents', 'skills', 'git-commit', 'SKILL.md'), 'utf8',
+    )
+    expect(interactive).toContain('allowed-tools: Bash')
+    expect(interactive).toContain('/git-review')
+    // The runner's rendering rewrites both; serving one directory with the other's form
+    // is what made the shared workflows unusable to whichever agent read them second.
+    expect(forRunner).not.toContain('allowed-tools: Bash')
+    expect(forRunner).not.toContain('/git-review')
+  })
+
+  it('serves a runner that reads the interactive directory exactly once', () => {
+    runner = {
+      sharedSkills: {
+        ...runner.sharedSkills,
+        destinationRoot: (root) => join(root, '.claude', 'skills'),
+      },
+      start: async () => process.pid,
+    }
+
+    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+
+    expect(result.installed).toEqual(['.claude/skills/git-commit', '.claude/skills/loop-start'])
+    expect(readFileSync(join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
+      .toBe('npm run -C orchestration/ts loop -- --daemon\n')
   })
 })


### PR DESCRIPTION
## Features
- [Shared skill sync] The manifest's skills are rendered into every directory an agent working in the repository reads them from, not only the selected runner's: the runner receives its own form, `.claude/skills/` receives the canonical form the interactive agent already speaks.
- [Shared skill sync] A destination that cannot be served is reported on its own rather than aborting the sync, so files another destination already wrote are still named to the consumer commit path.
- [Shared skill sync] A runner whose discovery directory is `.claude/skills/` is served once instead of twice, the second rendering otherwise deciding what the directory contains.

## Bug Fixes
- [Shared skill sync] Selecting Codex no longer empties `.claude/skills/`. The Codex adapter claimed it as a legacy root, so every shared workflow disappeared from the interactive agent the moment the bundled runner was in use. In this repository that removed the `git-merge` workflow, which is the only sanctioned path to a merge — direct `gh pr merge` is withheld so that a self-PR cannot be merged without a review first — leaving the prohibition in place with nothing behind it.
- [Loop log] Installed, updated and conflicting skills are reported by repository-relative path. A bare skill name said nothing about which directory reported it once more than one is served.

## Security
- None

## Project Operations
- [Repository] The rendered interactive copies are committed, so a clone has the shared workflows before any loop cycle has run. `verify-changes` is absent from the manifest and untouched by the sync.
- [Docs] `README.md`, `SPEC.md` and `CLAUDE.md` describe the sync as serving every agent's directory, and `CLAUDE.md` records that merges, reviews, pull requests and commits go through those workflows rather than hand-composed `gh` and `git` invocations.

## Risks
- The `SharedSkillsSyncResult` contract gains a `failures` field and reports skills by path rather than by name. A consumer reading that result directly, rather than through the loop, sees both changes.
- `.claude/skills/` stops being a legacy root for the bundled runner. A repository adopted while it was one keeps its copies there and has them re-rendered in place rather than deleted; this is covered by a test built from that arrangement.
