### PR TITLE
fix: detach the replacement daemon from its predecessor

### DIFF
--- a/src/restart.ts
+++ b/src/restart.ts
@@ -94,6 +94,11 @@ export async function startLoopReplacement(
   try {
     replacement = spawnProcess(command.executable, command.args, {
       cwd: command.cwd,
+      // A replacement daemon must be created the way a daemon is created. Without this
+      // it stayed attached to the predecessor that spawned it and died with it, so on
+      // Windows a consumer's loop ended at the first core auto-update rather than
+      // continuing on the pulled code.
+      detached: true,
       env: {
         ...(runtime.env ?? process.env),
         [LOOP_RESTART_READY_FILE_ENV]: readyFile,

--- a/tests/restart.test.ts
+++ b/tests/restart.test.ts
@@ -36,6 +36,9 @@ describe('loop replacement startup', () => {
       const env = options.env as NodeJS.ProcessEnv
       expect(env[LOOP_RESTART_READY_FILE_ENV]).toBe(readyFile)
       expect(env[LOOP_RESTART_PREDECESSOR_PID_ENV]).toBe(`${process.pid}`)
+      // The predecessor exits as soon as this process is ready, and an attached child
+      // dies with it: a Windows consumer's loop ended at its first core auto-update.
+      expect(options.detached).toBe(true)
       expect(readFileSync(pidFile, 'utf8')).toBe(`${process.pid}\n`)
       setTimeout(() => writeFileSync(readyFile, '43210\n'), 0)
       return child


### PR DESCRIPTION
## Features
- None

## Bug Fixes
- [Loop daemon] A core auto-update no longer ends the run. The daemon is launched detached, but the replacement it spawns to take over the pulled code was not, so it stayed attached to the predecessor that exits the moment the replacement reports readiness. On Windows a consumer's loop therefore stopped at its first auto-update instead of continuing. Reported from `menimani/react-ko` (#99).

## Security
- None

## Project Operations
- None

## Risks
- The replacement keeps `windowsHide: true` while the original daemon launch deliberately omits it, so the two still differ in console handling across a restart. That divergence is left alone here: which flag combination avoids the console flicker reported separately has not been measured, and guessing at it does not belong in a fix for a process that dies.

Closes #99
