### PR TITLE
feat: publish the specification as a site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,67 @@
+name: Specification site
+
+# `SPEC.md` is the specification the suite pins, so it must stay the single copy: the
+# site is assembled from it at build time rather than from a second file kept in step by
+# hand. Nothing here is checked into the repository except this workflow.
+on:
+  push:
+    branches: [main]
+    paths: ['SPEC.md', '.github/workflows/pages.yml']
+  workflow_dispatch:
+
+# `pages` and `id-token` are what the deployment needs; `contents` stays read-only.
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
+# One deployment at a time, and never cancel one midway: the published site is the
+# artifact of whichever run finishes, so an interrupted deployment leaves the old page.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/configure-pages@v5
+
+      # Jekyll converts a Markdown file only when it carries front matter, and adding
+      # front matter to SPEC.md would put site scaffolding in the specification. The
+      # copy taken here carries it instead.
+      - name: Assemble the site source
+        run: |
+          mkdir site
+          cat > site/_config.yml <<'CONFIG'
+          title: orchestration-core
+          description: The behaviour the suite pins
+          theme: jekyll-theme-primer
+          CONFIG
+          {
+            echo '---'
+            echo 'title: Specification'
+            echo '---'
+            echo
+            echo '[Repository](https://github.com/menimani/orchestration-core)'
+            echo
+            cat SPEC.md
+          } > site/index.md
+
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: site
+          destination: site/_site
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/_site
+
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,17 +39,24 @@ jobs:
       - name: Assemble the site source
         run: |
           mkdir site
-          cat > site/_config.yml <<'CONFIG'
-          title: orchestration-core
+          # A project site is served under /<repository>/, and the theme resolves its
+          # stylesheet against baseurl. Left empty, the page arrives unstyled because
+          # every asset link points at the domain root. Both values come from the
+          # context rather than being written out, so renaming the repository or the
+          # owner does not silently break the assets.
+          cat > site/_config.yml <<CONFIG
+          title: ${{ github.event.repository.name }}
           description: The behaviour the suite pins
           theme: jekyll-theme-primer
+          url: https://${{ github.repository_owner }}.github.io
+          baseurl: /${{ github.event.repository.name }}
           CONFIG
           {
             echo '---'
             echo 'title: Specification'
             echo '---'
             echo
-            echo '[Repository](https://github.com/menimani/orchestration-core)'
+            echo "[Repository](${{ github.server_url }}/${{ github.repository }})"
             echo
             cat SPEC.md
           } > site/index.md


### PR DESCRIPTION
## Features
- [Specification site] `SPEC.md` is published at https://menimani.github.io/orchestration-core/ on every push that changes it, and on demand through `workflow_dispatch`. The page is assembled from `SPEC.md` during the build, so the repository keeps exactly one copy of the specification and no site scaffolding beyond the workflow itself.

## Bug Fixes
- None

## Security
- The workflow keeps `contents` read-only and takes only the `pages` and `id-token` permissions the deployment needs. The repository is already public and `SPEC.md` already readable in it, so nothing becomes visible that was not.

## Project Operations
- [Repository settings] GitHub Pages is enabled with `build_type: workflow`, which is what lets this workflow deploy without a `gh-pages` branch or a `/docs` directory.

## Risks
- The deployment is not cancelled in progress (`cancel-in-progress: false`). A run interrupted by a newer one would otherwise leave the site mid-replacement; instead the previous page stands until a run finishes.
- Jekyll converts Markdown only when it carries front matter, so the build injects it into a copy rather than into `SPEC.md`. A future change to the specification's own heading structure needs no site change, but replacing the theme or the front matter means editing the workflow, not a file that looks like part of the site.
