### PR TITLE
feat: publish a written documentation page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,12 +1,14 @@
-name: Specification site
+name: Documentation site
 
-# `SPEC.md` is the specification the suite pins, so it must stay the single copy: the
-# site is assembled from it at build time rather than from a second file kept in step by
-# hand. Nothing here is checked into the repository except this workflow.
+# `README.md` says what this is and how to run it; `SPEC.md` states the behaviour the
+# suite pins. Both stay the single copy of themselves: the site is assembled from them at
+# build time rather than from second files kept in step by hand. Nothing here is checked
+# into the repository except this workflow, so a documentation change publishes itself
+# and nothing else has to be remembered.
 on:
   push:
     branches: [main]
-    paths: ['SPEC.md', '.github/workflows/pages.yml']
+    paths: ['README.md', 'SPEC.md', '.github/workflows/pages.yml']
   workflow_dispatch:
 
 # `pages` and `id-token` are what the deployment needs; `contents` stays read-only.
@@ -34,8 +36,8 @@ jobs:
       - uses: actions/configure-pages@v5
 
       # Jekyll converts a Markdown file only when it carries front matter, and adding
-      # front matter to SPEC.md would put site scaffolding in the specification. The
-      # copy taken here carries it instead.
+      # front matter to the documents would put site scaffolding in them. The copies
+      # taken here carry it instead.
       - name: Assemble the site source
         run: |
           mkdir site
@@ -46,20 +48,33 @@ jobs:
           # owner does not silently break the assets.
           cat > site/_config.yml <<CONFIG
           title: ${{ github.event.repository.name }}
-          description: The behaviour the suite pins
+          description: An autonomous improvement loop for a software repository
           theme: jekyll-theme-primer
           url: https://${{ github.repository_owner }}.github.io
           baseurl: /${{ github.event.repository.name }}
           CONFIG
-          {
-            echo '---'
-            echo 'title: Specification'
-            echo '---'
-            echo
-            echo "[Repository](${{ github.server_url }}/${{ github.repository }})"
-            echo
-            cat SPEC.md
-          } > site/index.md
+          repository="${{ github.server_url }}/${{ github.repository }}"
+          page() {
+            {
+              echo '---'
+              echo "title: $2"
+              echo '---'
+              echo
+              echo "[Overview](./) · [Specification](spec.html) · [Repository]($repository)"
+              echo
+              cat
+            } > "site/$3"
+          }
+          # README names SPEC.md as a file, in prose and as a link. On the site that file
+          # is a page, so both forms are pointed at it. Other repository paths it names
+          # are left alone: Jekyll publishes no such files, and a link that resolves to
+          # nothing is worse than a path a reader can look up. The specification is
+          # copied unaltered — rewriting its own name there would only produce links to
+          # the page it already is.
+          sed -e 's|(SPEC\.md)|(spec.html)|g' \
+              -e 's|`SPEC\.md`|[`SPEC.md`](spec.html)|g' README.md \
+            | page - Overview index.md
+          page - Specification spec.md < SPEC.md
 
       - uses: actions/jekyll-build-pages@v1
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,14 +1,13 @@
 name: Documentation site
 
-# `README.md` says what this is and how to run it; `SPEC.md` states the behaviour the
-# suite pins. Both stay the single copy of themselves: the site is assembled from them at
-# build time rather than from second files kept in step by hand. Nothing here is checked
-# into the repository except this workflow, so a documentation change publishes itself
-# and nothing else has to be remembered.
+# `docs/` is the published site: hand-written HTML, uploaded as it stands. It is a short
+# front door, not a copy of the repository's documents — `README.md` and `SPEC.md` remain
+# the full text and the site links to them, so there is nothing here to keep in step with
+# them line by line.
 on:
   push:
     branches: [main]
-    paths: ['README.md', 'SPEC.md', '.github/workflows/pages.yml']
+    paths: ['docs/**', '.github/workflows/pages.yml']
   workflow_dispatch:
 
 # `pages` and `id-token` are what the deployment needs; `contents` stays read-only.
@@ -35,55 +34,9 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
-      # Jekyll converts a Markdown file only when it carries front matter, and adding
-      # front matter to the documents would put site scaffolding in them. The copies
-      # taken here carry it instead.
-      - name: Assemble the site source
-        run: |
-          mkdir site
-          # A project site is served under /<repository>/, and the theme resolves its
-          # stylesheet against baseurl. Left empty, the page arrives unstyled because
-          # every asset link points at the domain root. Both values come from the
-          # context rather than being written out, so renaming the repository or the
-          # owner does not silently break the assets.
-          cat > site/_config.yml <<CONFIG
-          title: ${{ github.event.repository.name }}
-          description: An autonomous improvement loop for a software repository
-          theme: jekyll-theme-primer
-          url: https://${{ github.repository_owner }}.github.io
-          baseurl: /${{ github.event.repository.name }}
-          CONFIG
-          repository="${{ github.server_url }}/${{ github.repository }}"
-          page() {
-            {
-              echo '---'
-              echo "title: $2"
-              echo '---'
-              echo
-              echo "[Overview](./) · [Specification](spec.html) · [Repository]($repository)"
-              echo
-              cat
-            } > "site/$3"
-          }
-          # README names SPEC.md as a file, in prose and as a link. On the site that file
-          # is a page, so both forms are pointed at it. Other repository paths it names
-          # are left alone: Jekyll publishes no such files, and a link that resolves to
-          # nothing is worse than a path a reader can look up. The specification is
-          # copied unaltered — rewriting its own name there would only produce links to
-          # the page it already is.
-          sed -e 's|(SPEC\.md)|(spec.html)|g' \
-              -e 's|`SPEC\.md`|[`SPEC.md`](spec.html)|g' README.md \
-            | page - Overview index.md
-          page - Specification spec.md < SPEC.md
-
-      - uses: actions/jekyll-build-pages@v1
-        with:
-          source: site
-          destination: site/_site
-
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: site/_site
+          path: docs
 
       - id: deploy
         uses: actions/deploy-pages@v4

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>orchestration-core</title>
+<style>
+  :root {
+    --ink: #1f2430;
+    --sub: #5b6472;
+    --accent: #2563eb;
+    --accent-soft: #eff4ff;
+    --line: #e3e7ee;
+    --bg: #ffffff;
+    --panel: #f7f9fc;
+    --warn: #b45309;
+    --warn-soft: #fef7ec;
+    --good: #047857;
+    --good-soft: #ecfdf5;
+    --mono: "Consolas", "SFMono-Regular", "Cascadia Code", monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic UI", "Meiryo", system-ui, sans-serif;
+    color: var(--ink);
+    background: var(--bg);
+    line-height: 1.85;
+    font-size: 15.5px;
+  }
+  .page { max-width: 860px; margin: 0 auto; padding: 0 28px 96px; }
+
+  header.hero {
+    border-bottom: 3px solid var(--accent);
+    padding: 56px 0 28px;
+    margin-bottom: 40px;
+  }
+  .hero .kicker {
+    color: var(--accent);
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    font-size: 0.8rem;
+    margin-bottom: 10px;
+  }
+  .hero h1 { font-size: 1.9rem; line-height: 1.4; margin-bottom: 14px; }
+  .hero .meta { color: var(--sub); font-size: 0.88rem; }
+  .hero .meta span { margin-right: 1.4em; }
+  .hero .note {
+    display: inline-block;
+    margin-top: 14px;
+    background: var(--warn-soft);
+    color: var(--warn);
+    border: 1px solid #f3ddb9;
+    border-radius: 6px;
+    padding: 3px 12px;
+    font-size: 0.82rem;
+  }
+
+  section { margin-bottom: 56px; }
+  h2 {
+    font-size: 1.35rem;
+    padding-left: 14px;
+    border-left: 5px solid var(--accent);
+    margin-bottom: 20px;
+    line-height: 1.4;
+  }
+  h3 { font-size: 1.05rem; margin: 26px 0 12px; color: var(--ink); }
+  p { margin-bottom: 14px; }
+  strong { color: var(--ink); }
+  em { font-style: normal; background: linear-gradient(transparent 62%, #fde68a 62%); }
+  a { color: var(--accent); }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0 22px;
+    font-size: 0.92rem;
+  }
+  th, td { border: 1px solid var(--line); padding: 9px 13px; text-align: left; vertical-align: top; }
+  th { background: var(--panel); font-weight: 700; white-space: nowrap; }
+  tr:nth-child(even) td { background: #fcfdfe; }
+  .table-scroll { overflow-x: auto; }
+
+  ul.plain, ol.plain { margin: 0 0 16px 1.4em; }
+  ul.plain li, ol.plain li { margin-bottom: 7px; }
+
+  pre {
+    background: #0f172a;
+    color: #dbe4f3;
+    border-radius: 10px;
+    padding: 18px 22px;
+    overflow-x: auto;
+    font-family: var(--mono);
+    font-size: 0.83rem;
+    line-height: 1.7;
+    margin: 16px 0 22px;
+  }
+  code { font-family: var(--mono); font-size: 0.88em; background: var(--accent-soft); color: #1e40af; border-radius: 4px; padding: 1px 6px; }
+  pre code { background: none; color: inherit; padding: 0; }
+
+  .callout {
+    border-radius: 10px;
+    padding: 16px 20px;
+    margin: 18px 0 24px;
+    border: 1px solid;
+    font-size: 0.94rem;
+  }
+  .callout .label { font-weight: 700; font-size: 0.8rem; letter-spacing: 0.08em; display: block; margin-bottom: 6px; }
+  .callout.insight { background: var(--accent-soft); border-color: #c7d7f7; }
+  .callout.insight .label { color: var(--accent); }
+  .callout.incident { background: var(--warn-soft); border-color: #f3ddb9; }
+  .callout.incident .label { color: var(--warn); }
+  .callout.win { background: var(--good-soft); border-color: #bde5d4; }
+  .callout.win .label { color: var(--good); }
+
+  .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin: 18px 0 8px; }
+  .metric {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 14px 16px;
+  }
+  .metric .v { font-size: 1.3rem; font-weight: 800; color: var(--accent); line-height: 1.3; }
+  .metric .k { font-size: 0.8rem; color: var(--sub); margin-top: 2px; }
+
+  footer {
+    border-top: 1px solid var(--line);
+    padding-top: 20px;
+    color: var(--sub);
+    font-size: 0.82rem;
+  }
+
+  @media (max-width: 640px) {
+    body { font-size: 15px; }
+  }
+  @media print {
+    .page { max-width: none; padding: 0 8mm; }
+    pre { white-space: pre-wrap; }
+    section { break-inside: avoid-page; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+<header class="hero">
+  <div class="kicker">ORCHESTRATION CORE</div>
+  <h1>An autonomous improvement loop<br>for a software repository</h1>
+  <div class="meta">
+    <span>MIT licensed</span>
+    <span>Node 23.6+</span>
+    <span>TypeScript, no build step</span>
+  </div>
+  <div class="note">Nothing here decides that shipping is safe — deployment stays a human action</div>
+</header>
+
+<section>
+  <h2>What it does</h2>
+  <p>It scans the codebase, turns findings into tasks, runs them through an agent CLI in
+  isolated git worktrees, merges what passes the repository's own tests, and opens the
+  pull request.</p>
+  <pre>scan → tasks → worktrees → test → merge → cycle gate → … → review → promote</pre>
+  <p>A task merges only after the tests its changed paths select pass against the branch
+  tip. Cycles end at a gate that pushes and updates a draft pull request. With
+  <code>AUTO_REVIEW=true</code> an agent reads the whole branch diff, and its findings
+  become fix tasks.</p>
+</section>
+
+<section>
+  <h2>What you supply</h2>
+  <div class="table-scroll">
+  <table>
+    <tr><th>Adapter</th><th>Selector</th><th>Bundled</th></tr>
+    <tr><td>forge</td><td><code>FORGE</code></td><td><code>github</code>, through <code>gh</code></td></tr>
+    <tr><td>runner</td><td><code>RUNNER</code></td><td><code>codex</code></td></tr>
+    <tr><td>project</td><td><code>PROJECT</code></td><td>none — you write it</td></tr>
+  </table>
+  </div>
+  <p>The project adapter names your gates, suites and risk signals. It lives outside the
+  package, so a subtree pull never touches it.</p>
+</section>
+
+<section>
+  <h2>Install</h2>
+<pre>git subtree add --prefix=orchestration/ts \
+  https://github.com/menimani/orchestration-core.git main --squash
+npm ci --prefix orchestration/ts
+node orchestration/ts/src/cli.ts init &lt;project-name&gt;</pre>
+  <div class="callout incident">
+    <span class="label">BEFORE YOU START A RUN</span>
+    Start it on a topic branch, never on your default branch. The loop commits and merges
+    on its own.
+  </div>
+<pre>MAX_SCAN_CYCLES=12 MAX_PARALLEL=8 AUTO_REVIEW=true \
+  node orchestration/ts/src/cli.ts loop --daemon</pre>
+</section>
+
+<section>
+  <h2>Settings worth knowing</h2>
+  <div class="table-scroll">
+  <table>
+    <tr><th>Variable</th><th>Default</th><th>Effect</th></tr>
+    <tr><td><code>MAX_SCAN_CYCLES</code></td><td>3</td><td>Rounds before the pull request is promoted</td></tr>
+    <tr><td><code>MAX_PARALLEL</code></td><td>3</td><td>Agent processes at once</td></tr>
+    <tr><td><code>TASK_GATE</code></td><td>full</td><td><code>light</code> gates each merge with reduced checks and runs the suite once per cycle</td></tr>
+    <tr><td><code>AUTO_REVIEW</code></td><td>false</td><td>Review cycle diffs and queue the findings as fixes</td></tr>
+    <tr><td><code>ISSUE_QUEUE_ENABLED</code></td><td>false</td><td>Keep the backlog in forge issues so several machines share it</td></tr>
+    <tr><td><code>CORE_AUTO_UPDATE</code></td><td>true</td><td>Pull the shared core before each cycle</td></tr>
+  </table>
+  </div>
+</section>
+
+<section>
+  <h2>Requirements</h2>
+  <ul class="plain">
+    <li>Node 23.6 or later — the TypeScript sources are executed natively</li>
+    <li>git, and Bash on Windows for the bundled Codex runner</li>
+    <li>An agent CLI and a forge CLI</li>
+  </ul>
+  <div class="callout insight">
+    <span class="label">WHY IT IS MADE OF ORDINARY PARTS</span>
+    git worktrees, a text queue, forge issues, and the tests the repository already had.
+    Every behaviour in the specification was learned from a specific failure, and the
+    suite pins it.
+  </div>
+</section>
+
+<footer>
+  <a href="https://github.com/menimani/orchestration-core">Repository</a> ·
+  <a href="https://github.com/menimani/orchestration-core/blob/main/README.md">README</a> ·
+  <a href="https://github.com/menimani/orchestration-core/blob/main/SPEC.md">SPEC</a>
+  — the full text lives in those two files.
+</footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Features
- [Documentation site] The published page at https://menimani.github.io/orchestration-core/ is one hand-written HTML document: what the loop does, what a consumer supplies, how to install it, and the settings worth knowing. `README.md` and `SPEC.md` stay the full text and the page links to them.
- [Documentation site] A push to `main` under `docs/` republishes the site. The deployment assembles nothing — the directory is uploaded as it stands.

## Bug Fixes
- None

## Security
- None

## Project Operations
- [Documentation site] The Jekyll build is gone. The site no longer converts the two documents into pages, so nothing has to translate their Markdown, rewrite their cross-references, or keep front matter out of them.

## Risks
- The page restates a little of what the documents say — the pipeline, the adapter table, six settings — so those can drift from `README.md` and `SPEC.md`. It summarises rather than duplicates, and links out for the rest, but nothing checks the summary still matches. The previous build could not drift because it published the documents themselves; this trades that for a page worth arriving at.
- `docs/` is now a published directory. Anything committed under it reaches the public site on the next push to `main`.
