### PR TITLE
fix: make conflicted and duplicate merges self-recovering

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -156,7 +156,9 @@ values must be non-negative integers, with the narrower bounds stated below.
 9. Before its merge gate, a completed local task branch is rebased onto the current run
    branch tip. This refresh is retained when a check fails, so the next attempt does not
    test the same stale branch again. A conflicting rebase is aborted and keeps both the
-   task worktree and run branch clean. Pre-merge tests are chosen from the paths the
+   task worktree and run branch clean. The task is abandoned after that first counted
+   merge failure: its worktree and branch are removed, and linked issues return to ready
+   before another poll can select it again. Pre-merge tests are chosen from the paths the
    rebased worktree touched. `TASK_GATE=full`
    asks the project adapter for its full merge checks; `TASK_GATE=light` asks it for
    reduced merge checks, then runs the adapter's cycle suite once at each cycle-gate
@@ -179,7 +181,9 @@ values must be non-negative integers, with the narrower bounds stated below.
     a completed task remains eligible for merge on later polls, and any successful merge
     resets the count. A durable per-task guard skips an attempt while that task's merge is
     active or after it succeeded, without changing the failure count; a failed attempt
-    releases the guard so a later poll can retry. Re-claiming completed-but-unmerged work
+    releases the guard so a later poll can retry. A conflicting pre-merge rebase is
+    terminal for that task and contributes at most one failure to this count; ordinary
+    gate failures remain retryable. Re-claiming completed-but-unmerged work
     requests that merge instead of silently treating the task as already processed. When
     the project adapter classifies an infrastructure failure, or the merge log names an
     unreachable registry, say which — "tests failed" misattributes an environment failure

--- a/SPEC.md
+++ b/SPEC.md
@@ -177,10 +177,13 @@ values must be non-negative integers, with the narrower bounds stated below.
     restores it, and a busy backup left after successful activation is only warned about.
 10. `MAX_CONSECUTIVE_MERGE_FAILURES` (default 3) merge failures in a row stop the loop;
     a completed task remains eligible for merge on later polls, and any successful merge
-    resets the count. Re-claiming completed-but-unmerged work requests that merge instead
-    of silently treating the task as already processed. When the project adapter classifies
-    an infrastructure failure, or the merge log names an unreachable registry, say which —
-    "tests failed" misattributes an environment failure to the task's diff.
+    resets the count. A durable per-task guard skips an attempt while that task's merge is
+    active or after it succeeded, without changing the failure count; a failed attempt
+    releases the guard so a later poll can retry. Re-claiming completed-but-unmerged work
+    requests that merge instead of silently treating the task as already processed. When
+    the project adapter classifies an infrastructure failure, or the merge log names an
+    unreachable registry, say which — "tests failed" misattributes an environment failure
+    to the task's diff.
 11. A task that merges while a cycle gate is already waiting clears that cycle's
     complete flag, so the gate pushes and verifies again with the new commits included.
 11a. After a local or remote task merge, a first-parent change to this package's

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -578,6 +578,10 @@ const cmdMerge: Command = async (paths, args) => {
       project: await loadProject(paths.root),
       closesIssues: linkedIssues,
       forge,
+      onMergeStart: () => console.log(`Merging ${taskId}`),
+      onMergeSkipped: (reason) => console.log(
+        `Skipped ${taskId}: ${reason === 'active' ? 'merge already in progress' : 'merge already succeeded'}`,
+      ),
       onNoChange: async () => {
         if (linkedIssues.length > 0) {
           await Promise.all(linkedIssues.map((linkedIssue) =>

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -17,7 +17,7 @@ import {
 } from './ids.ts'
 import {
   completeTaskWithoutChanges, mergeRemoteTask, mergeTask, MergeError,
-  NoChangeReconciliationError,
+  NoChangeReconciliationError, RebaseConflictError,
   OrchestrationDepsInstallError,
   type OrchestrationDepsRuntime,
 } from './merge.ts'
@@ -49,6 +49,7 @@ import {
   heartbeatIssueForTask, fingerprintOf, issueMergeComment,
   issueHasExactlyLifecycleLabel, issueNumberForTask, issueNumbersForTask, issuePromotionForIssue,
   missingRequirementCompletionMarkers, publishFinding, reapStaleLeases,
+  completeIssueReleaseIntent, prepareIssueReleaseIntent, reconcileIssueReleaseIntent,
   recordIssueCompletions, recordIssuesForTask, recordIssuePromotions, releaseIssueClaim,
   returnIssueToReady,
   ensureQueueLabels, reconcileClosedIssueLifecycleLabels, reconcileFindingFingerprints,
@@ -2044,6 +2045,43 @@ export function createLoop(deps: LoopDeps) {
         if (error instanceof MergeError) appendFileSync(mergeLog, `${error.message}\n`)
         if (error instanceof OrchestrationDepsInstallError) throw error
         event('Failed', shortTaskId(taskId), `log ${shortLogPath(mergeLog)}`)
+        if (error instanceof RebaseConflictError) {
+          noteMergeFailure(mergeLog)
+          try {
+            const terminalized = await transitionStatus(paths, taskId, 'completed', 'failed')
+            if (!terminalized) {
+              throw new Error('task status changed before rebase-conflict abandonment')
+            }
+            if (linkedIssues.length > 0) {
+              prepareIssueReleaseIntent(paths, taskId, linkedIssues)
+            }
+            cleanupTask(paths, taskId, undefined, false)
+            if (linkedIssues.length === 0) {
+              dropClaimedTaskMaterialization(paths, taskId)
+            } else {
+              completeIssueReleaseIntent(paths, taskId)
+              dropClaimedTaskMaterialization(paths, taskId, true)
+              if (remoteOperationsAvailable) {
+                const failures = await reconcileIssueReleaseIntent(forge, paths, taskId)
+                if (failures.length > 0) {
+                  throw new IssueReleaseReconciliationError(failures)
+                }
+              }
+            }
+            if (linkedIssues.length === 0) {
+              event('Abandoned', shortTaskId(taskId), 'rebase conflict')
+            } else if (remoteOperationsAvailable) {
+              event('Released', shortTaskId(taskId), 'rebase conflict abandoned')
+            } else {
+              event('Abandoned', shortTaskId(taskId), 'rebase conflict; issue release pending')
+            }
+          } catch (abandonmentError) {
+            if (!(abandonmentError instanceof ForgeRateLimitError)) {
+              event('WARN', `${shortTaskId(taskId)} rebase conflict was abandoned but cleanup or issue release failed: ${errorSummary(abandonmentError)}`)
+            }
+          }
+          return
+        }
         const abandoned = noteMergeFailure(mergeLog)
         if (abandoned && linkedIssues.length > 1 && remoteOperationsAvailable) {
           try {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1979,7 +1979,6 @@ export function createLoop(deps: LoopDeps) {
       if (!config.autoMerge || mergeAttempts.has(taskId)
         || !existsSync(join(scannedDir, taskId))) return
       mergeAttempts.add(taskId)
-      event('Merging', shortTaskId(taskId))
       const mergeLog = join(paths.logsDir, `${taskId}.merge.log`)
       const linkedIssues = issueNumbersForTask(paths, taskId)
       try {
@@ -1997,6 +1996,11 @@ export function createLoop(deps: LoopDeps) {
           outputFile: mergeLog,
           orchestrationDepsRuntime,
           onOrchestrationDepsEvent: orchestrationDepsEvent,
+          onMergeStart: () => event('Merging', shortTaskId(taskId)),
+          onMergeSkipped: (reason) => event(
+            'Skipped', shortTaskId(taskId),
+            reason === 'active' ? 'merge already in progress' : 'merge already succeeded',
+          ),
           onNoChange: async () => {
             if (linkedIssues.length > 0) {
               await Promise.all(linkedIssues.map((issueNumber) =>
@@ -2016,6 +2020,7 @@ export function createLoop(deps: LoopDeps) {
           }
           return
         }
+        if (mergeResult.outcome === 'skipped') return
         const mergeCommit = mergeResult.mergeCommit
         event('Merged', shortTaskId(taskId), `commit ${mergeCommit.slice(0, 8)}`)
         writeFileSync(mergeFailureFile, '0\n')

--- a/src/loopLog.ts
+++ b/src/loopLog.ts
@@ -14,6 +14,7 @@ const EVENT_NAMES = [
   'Running',
   'Idle',
   'Merging',
+  'Skipped',
   'Merged',
   'No-change',
   'Failed',

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,9 +1,10 @@
 import { execFileSync, execSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import {
-  appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync,
+  appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, rmSync, rmdirSync,
+  writeFileSync,
 } from 'node:fs'
-import { isAbsolute, join, relative, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import type { Forge } from './adapters/forge.ts'
 import { operatingSystem } from './adapters/os.ts'
 import type { ProjectAdapter } from './adapters/project.ts'
@@ -19,6 +20,7 @@ import {
 import { execShellSync } from './shell.ts'
 import { noChangeMarkerPresent } from './refresh.ts'
 import { readStatus, writeMergedStatus, writeStatus } from './status.ts'
+import { currentProcessStartIdentity, lockOwnerIsCurrent } from './processOwner.ts'
 import {
   removeWorktreeWithFallback, type WorktreeRemovalRuntime,
 } from './worktree.ts'
@@ -64,6 +66,10 @@ export interface MergeOptions {
   onNoChange?: (() => Promise<void>) | undefined
   /** Worktree cleanup implementation; tests replace it to exercise retained cleanup state. */
   worktreeRemovalRuntime?: WorktreeRemovalRuntime | undefined
+  /** Called only after this process has acquired the per-task merge guard. */
+  onMergeStart?: (() => void) | undefined
+  /** Report an idempotent attempt without treating it as a merge failure. */
+  onMergeSkipped?: ((reason: 'active' | 'succeeded') => void) | undefined
 }
 
 export interface RemoteMergeOptions extends MergeOptions {
@@ -81,6 +87,7 @@ export interface NoChangeOptions {
 export type MergeTaskResult =
   | { outcome: 'merged'; mergeCommit: string }
   | { outcome: 'no-change' }
+  | { outcome: 'skipped'; reason: 'active' | 'succeeded' }
 
 export interface OrchestrationDepsRuntime {
   install: (cwd: string) => void
@@ -587,12 +594,91 @@ export async function completeTaskWithoutChanges(
   )
 }
 
-/**
- * Merge a completed task into the current branch.
- * Uncommitted changes or a missing deliverable stop the merge and keep the worktree,
- * because removing it would lose work an agent forgot to commit.
- */
-export async function mergeTask(
+interface MergeGuardOwner {
+  state: 'active'
+  pid: number
+  startIdentity: string | null
+}
+
+function mergeGuardDir(paths: OrchPaths, taskId: string): string {
+  return join(paths.queueDir, 'merge-guards', taskId)
+}
+
+function activeMergeGuardOwner(dir: string): MergeGuardOwner | undefined {
+  try {
+    const value = JSON.parse(readFileSync(join(dir, 'owner.json'), 'utf8')) as Partial<MergeGuardOwner>
+    if (value.state !== 'active' || !Number.isInteger(value.pid) || Number(value.pid) < 1) {
+      return undefined
+    }
+    return {
+      state: 'active',
+      pid: Number(value.pid),
+      startIdentity: typeof value.startIdentity === 'string' ? value.startIdentity : null,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function acquireMergeGuard(
+  paths: OrchPaths,
+  taskId: string,
+): { acquired: true; file: string; owner: MergeGuardOwner } | {
+  acquired: false
+  reason: 'active' | 'succeeded'
+} {
+  const dir = mergeGuardDir(paths, taskId)
+  mkdirSync(dirname(dir), { recursive: true })
+  const owner: MergeGuardOwner = {
+    state: 'active', pid: process.pid, startIdentity: currentProcessStartIdentity(),
+  }
+  for (;;) {
+    try {
+      mkdirSync(dir)
+      writeFileSync(join(dir, 'owner.json'), `${JSON.stringify(owner)}\n`, { flag: 'wx' })
+      return { acquired: true, file: dir, owner }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+      if (existsSync(join(dir, 'succeeded'))) return { acquired: false, reason: 'succeeded' }
+      const recorded = activeMergeGuardOwner(dir)
+      // An ownerless directory is the narrow acquisition window of another process.
+      if (recorded === undefined) return { acquired: false, reason: 'active' }
+      if (lockOwnerIsCurrent(recorded.pid, recorded.startIdentity)) {
+        return { acquired: false, reason: 'active' }
+      }
+      // Removing the owner before the directory makes stale reclamation safe between
+      // multiple waiters: rmdir can never remove a replacement's non-empty guard.
+      try {
+        rmSync(join(dir, 'owner.json'))
+        rmdirSync(dir)
+      } catch {
+        // A concurrent owner changed the marker; retry against its current state.
+      }
+    }
+  }
+}
+
+function finishMergeGuard(
+  guard: { file: string; owner: MergeGuardOwner },
+  succeeded: boolean,
+): void {
+  let ownsGuard = false
+  try {
+    ownsGuard = readFileSync(join(guard.file, 'owner.json'), 'utf8').trim()
+      === JSON.stringify(guard.owner)
+  } catch {
+    return
+  }
+  if (!ownsGuard) return
+  if (!succeeded) {
+    rmSync(guard.file, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
+    return
+  }
+  writeFileSync(join(guard.file, 'succeeded'), '')
+  rmSync(join(guard.file, 'owner.json'), { force: true })
+}
+
+async function mergeTaskWithGuardHeld(
   paths: OrchPaths,
   taskId: string,
   options: MergeOptions,
@@ -709,6 +795,43 @@ export async function mergeTask(
     io, depsEvent, options,
   )
   return { outcome: 'merged', mergeCommit: finalizedCommit }
+}
+
+/**
+ * Merge a completed task into the current branch. A durable per-task guard makes the
+ * operation idempotent across the daemon and CLI; failures release it for a real retry.
+ * Uncommitted changes or a missing deliverable stop the merge and keep the worktree.
+ */
+export async function mergeTask(
+  paths: OrchPaths,
+  taskId: string,
+  options: MergeOptions,
+): Promise<MergeTaskResult> {
+  const status = readStatus(paths, taskId)
+  if (status?.status === 'merged' || status?.status === 'no-change') {
+    options.onMergeSkipped?.('succeeded')
+    return { outcome: 'skipped', reason: 'succeeded' }
+  }
+  const acquired = acquireMergeGuard(paths, taskId)
+  if (!acquired.acquired) {
+    options.onMergeSkipped?.(acquired.reason)
+    return { outcome: 'skipped', reason: acquired.reason }
+  }
+  let succeeded = false
+  try {
+    const guardedStatus = readStatus(paths, taskId)
+    if (guardedStatus?.status === 'merged' || guardedStatus?.status === 'no-change') {
+      succeeded = true
+      options.onMergeSkipped?.('succeeded')
+      return { outcome: 'skipped', reason: 'succeeded' }
+    }
+    options.onMergeStart?.()
+    const result = await mergeTaskWithGuardHeld(paths, taskId, options)
+    succeeded = result.outcome === 'merged' || result.outcome === 'no-change'
+    return result
+  } finally {
+    finishMergeGuard(acquired, succeeded)
+  }
 }
 
 /** Merge an already-fetched worker branch through the same selected checks as a local task. */

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -33,6 +33,9 @@ export class MergeError extends Error {
   }
 }
 
+/** A stale local task cannot be refreshed and must not be selected for merge again. */
+export class RebaseConflictError extends MergeError {}
+
 /** Remote bookkeeping for a valid no-change verdict failed and should be retried. */
 export class NoChangeReconciliationError extends MergeError {}
 
@@ -308,7 +311,7 @@ function rebaseTaskOntoRunTip(
     } catch {
       // nothing to abort
     }
-    throw new MergeError(
+    throw new RebaseConflictError(
       `A conflict occurred while rebasing the task onto ${currentBranch}; the rebase was aborted.`,
     )
   }

--- a/src/restart.ts
+++ b/src/restart.ts
@@ -9,7 +9,7 @@ import {
   LOOP_RESTART_PREDECESSOR_PID_ENV, LOOP_RESTART_READY_FILE_ENV,
 } from './internalEnvironment.ts'
 import {
-  parseProcessMarker, processMarker, processMarkerIsCurrent, processMarkerText,
+  currentProcessMarkerPid, parseProcessMarker, processMarker, processMarkerText,
 } from './processMarker.ts'
 
 export {
@@ -56,7 +56,10 @@ export function publishLoopReplacementPid(
 ): void {
   const ownerText = readFileSync(pidFile, 'utf8')
   const owner = parseProcessMarker(ownerText)
-  if (owner?.pid !== predecessorPid || !processMarkerIsCurrent(owner)) {
+  // A replacement started by a legacy predecessor must leave its bare reservation
+  // untouched until that predecessor completes the handover. The replacement can then
+  // upgrade that inherited reservation safely on its next current-version restart.
+  if (currentProcessMarkerPid(ownerText) !== predecessorPid) {
     throw new Error(`loop PID owner changed before restart handover (${owner?.pid ?? 'invalid'})`)
   }
   const candidate = `${pidFile}.handover-${predecessorPid}-${replacementPid}-${randomUUID()}`

--- a/src/status.ts
+++ b/src/status.ts
@@ -85,11 +85,15 @@ async function acquireStatusLock(paths: OrchPaths, taskId: string): Promise<stri
   for (let attempts = 0; ; attempts++) {
     try {
       mkdirSync(dir)
-      // Keep the PID file readable by older cores and publish identity separately.
-      writeFileSync(pidFile, `${process.pid}\n`)
-      writeFileSync(identityFile, `${owner}\n`)
-      return owner
-    } catch {
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+      try {
+        if (!statSync(dir).isDirectory()) throw error
+      } catch (inspectionError) {
+        // The directory may have been released between mkdir and inspection.
+        if ((inspectionError as NodeJS.ErrnoException).code === 'ENOENT') continue
+        throw error
+      }
       // Lock held. Reclaim it only when its owner is provably gone: a recorded PID that
       // no longer runs, or no PID at all once the lock has aged past the window in which
       // a live owner could still be about to publish one.
@@ -130,6 +134,19 @@ async function acquireStatusLock(paths: OrchPaths, taskId: string): Promise<stri
         throw new Error(`Timed out waiting for the status lock: ${taskId}`)
       }
       await sleep(10)
+      continue
+    }
+
+    try {
+      // Keep the PID file readable by older cores and publish identity separately.
+      writeFileSync(pidFile, `${process.pid}\n`)
+      writeFileSync(identityFile, `${owner}\n`)
+      return owner
+    } catch (error) {
+      // Publishing metadata is part of acquisition, not contention. A writer that
+      // cannot finish it must not leave its own PID looking like a live lock owner.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 })
+      throw error
     }
   }
 }
@@ -162,10 +179,15 @@ function writeStatusUnlocked(
   const file = statusFile(paths, taskId)
   const temporaryFile = join(paths.statusDir, `.${taskId}.${process.pid}.tmp`)
   const existing = readStatus(paths, taskId)
+  const existingPid = taskProcessPid(paths, taskId)
   // The registry, not the record, is what later readers believe. Publish a new owner
   // before its running status, but keep an existing owner visible until a terminal
   // status has been published successfully.
-  if (pid !== undefined && Number.isInteger(pid)) recordTaskProcess(paths, taskId, pid)
+  // Rewriting a status for the same PID must also preserve whether launch captured its
+  // start identity; a later successful probe cannot make an initially unsafe PID safe.
+  if (pid !== undefined && Number.isInteger(pid) && pid !== existingPid) {
+    recordTaskProcess(paths, taskId, pid)
+  }
   const now = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
   const record: DurableTaskStatus = {
     task_id: taskId,

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -2792,6 +2792,51 @@ describe('completion marker output', () => {
 })
 
 describe('completed task merge recovery', () => {
+  it('abandons a task after its first conflicting rebase and never retries it', async () => {
+    const taskId = '20260815_181908_194_auto-rebase-conflict'
+    const initialHead = initializeGitRepo()
+    makeCompletedTask(taskId)
+    const worktree = worktreeDir(paths, taskId)
+    writeFileSync(join(worktree, 'tracked.txt'), 'task change\n')
+    execFileSync('git', ['add', 'tracked.txt'], { cwd: worktree })
+    execFileSync('git', ['commit', '-qm', 'fix: change tracked line'], { cwd: worktree })
+    writeFileSync(join(repoRoot, 'tracked.txt'), 'run change\n')
+    git(['add', 'tracked.txt'])
+    git(['commit', '-m', 'fix: advance run branch'])
+    const runHead = git(['rev-parse', 'HEAD'])
+    expect(runHead).not.toBe(initialHead)
+
+    const loop = makeLoop({
+      autoMerge: true, issueQueueEnabled: true, scanEnabled: false, maxParallel: 0,
+    })
+    loop.initializeSessionStateForBranch()
+    const issueNumber = await fakeForge.createIssue({
+      title: 'conflicting fix', body: '', labels: [LABEL_FINDING, LABEL_IN_PROGRESS],
+    })
+    recordIssueForTask(paths, taskId, issueNumber)
+
+    expect(await loop.poll()).toBe('continue')
+
+    expect(readStatus(paths, taskId)).toBeUndefined()
+    expect(existsSync(worktree)).toBe(false)
+    expect(git(['branch', '--list', branchName(taskId)])).toBe('')
+    expect(git(['rev-parse', 'HEAD'])).toBe(runHead)
+    expect(issueNumbersForTask(paths, taskId)).toEqual([])
+    await expect(fakeForge.getIssue(issueNumber)).resolves.toMatchObject({
+      assignees: [],
+      labels: expect.arrayContaining([LABEL_FINDING, LABEL_READY]),
+    })
+    expect(readFileSync(join(paths.queueDir, 'merge-failure-count.txt'), 'utf8')).toBe('1\n')
+    expect(logged.filter((line) => line.startsWith('Merging 194_auto'))).toHaveLength(1)
+    expect(logged).toContain('Released 194_auto    rebase conflict abandoned')
+
+    expect(await loop.poll()).toBe('continue')
+
+    expect(git(['rev-parse', 'HEAD'])).toBe(runHead)
+    expect(readFileSync(join(paths.queueDir, 'merge-failure-count.txt'), 'utf8')).toBe('1\n')
+    expect(logged.filter((line) => line.startsWith('Merging 194_auto'))).toHaveLength(1)
+  })
+
   it('skips a task whose merge is already active without counting a failure', async () => {
     const taskId = '20260815_125258_037_auto-merge-race'
     const initialHead = initializeGitRepo()

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -25,6 +25,7 @@ import {
   type OrchPaths,
 } from '../src/paths.ts'
 import { forgetTaskProcess, recordTaskProcess } from '../src/processRegistry.ts'
+import { currentProcessStartIdentity } from '../src/processOwner.ts'
 import { GENERATED_BODY_MARKER } from '../src/prbody.ts'
 import { readStatus } from '../src/status.ts'
 import { enqueueTask } from '../src/tasks.ts'
@@ -2791,6 +2792,34 @@ describe('completion marker output', () => {
 })
 
 describe('completed task merge recovery', () => {
+  it('skips a task whose merge is already active without counting a failure', async () => {
+    const taskId = '20260815_125258_037_auto-merge-race'
+    const initialHead = initializeGitRepo()
+    makeCompletedTask(taskId)
+    const guardDir = join(paths.queueDir, 'merge-guards', taskId)
+    mkdirSync(guardDir, { recursive: true })
+    writeFileSync(join(guardDir, 'owner.json'), `${JSON.stringify({
+      state: 'active',
+      pid: process.pid,
+      startIdentity: currentProcessStartIdentity(),
+    })}\n`)
+    const loop = makeLoop({
+      autoMerge: true, issueQueueEnabled: true, scanEnabled: false, maxParallel: 0,
+    })
+    loop.initializeSessionStateForBranch()
+    writeFileSync(join(paths.queueDir, 'merge-failure-count.txt'), '2\n')
+
+    expect(await loop.poll()).toBe('continue')
+
+    expect(readStatus(paths, taskId)?.status).toBe('completed')
+    expect(git(['rev-parse', 'HEAD'])).toBe(initialHead)
+    expect(readFileSync(join(paths.queueDir, 'merge-failure-count.txt'), 'utf8')).toBe('2\n')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
+    expect(logged).toContain('Skipped 037_auto    merge already in progress')
+    expect(logged.some((line) => line.startsWith('Merging 037_auto'))).toBe(false)
+    expect(logged.some((line) => line.startsWith('Failed 037_auto'))).toBe(false)
+  })
+
   it('terminalizes a no-change task while preserving failures and invalidating the cycle', async () => {
     const taskId = '20260814_144959_066_auto-already-resolved'
     const initialHead = initializeGitRepo()

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { operatingSystem } from '../src/adapters/os.ts'
 import { finalMessageFile, orchPaths, statusFile, type OrchPaths } from '../src/paths.ts'
-import { recordTaskProcess } from '../src/processRegistry.ts'
+import { recordTaskProcess, terminableTaskProcessPid } from '../src/processRegistry.ts'
 import {
   completionMarkerPresent, noChangeMarkerPresent, refreshAll, refreshTask,
 } from '../src/refresh.ts'
@@ -122,6 +122,23 @@ describe('refreshTask', () => {
     const after = await refreshTask(paths, 'live-done')
     expect(after?.status).toBe('completed')
     expect(after?.pid).toBe(process.pid)
+  })
+
+  it('does not make an initially unverified live PID terminable while completing it', async () => {
+    const pid = 2147483647
+    const processIsAlive = vi.spyOn(operatingSystem, 'processIsAlive').mockReturnValue(true)
+    const processStartIdentity = vi.spyOn(operatingSystem, 'processStartIdentity')
+      .mockReturnValue(undefined)
+    writeRawStatus('unverified-done',
+      `{"task_id":"unverified-done","status":"running","pid":${pid}}\n`)
+    processStartIdentity.mockReturnValue('started:possibly-reused')
+    writeFileSync(finalMessageFile(paths, 'unverified-done'), 'TASK_COMPLETE\n')
+
+    const after = await refreshTask(paths, 'unverified-done')
+
+    expect(after).toMatchObject({ status: 'completed', pid })
+    expect(terminableTaskProcessPid(paths, 'unverified-done')).toBeUndefined()
+    expect(processIsAlive).toHaveBeenCalledWith(pid)
   })
 })
 

--- a/tests/restart.test.ts
+++ b/tests/restart.test.ts
@@ -133,6 +133,20 @@ describe('loop replacement startup', () => {
     expect(child.unref).not.toHaveBeenCalled()
   })
 
+  it('upgrades a legacy bare-PID reservation only when the ready replacement is published', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orch-restart-'))
+    fixtureRoots.push(root)
+    const pidFile = join(root, 'loop.pid')
+    writeFileSync(pidFile, `${process.pid}\n`)
+    vi.spyOn(operatingSystem, 'processStartIdentity')
+      .mockImplementation((pid) => `start-${pid}`)
+
+    publishLoopReplacementPid(pidFile, process.pid, 43214)
+
+    expect(readFileSync(pidFile, 'utf8'))
+      .toBe(processMarkerText({ pid: 43214, startIdentity: 'start-43214' }))
+  })
+
   it('delegates replacement launch details to the operating-system adapter', async () => {
     const root = mkdtempSync(join(tmpdir(), 'orch-restart-'))
     fixtureRoots.push(root)

--- a/tests/status-lock.test.ts
+++ b/tests/status-lock.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ writeFileSync: vi.fn() }))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+  return { ...actual, writeFileSync: mocks.writeFileSync }
+})
+
+import { orchPaths, type OrchPaths } from '../src/paths.ts'
+import { readStatus, writeStatus } from '../src/status.ts'
+
+const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs')
+let repoRoot = ''
+let paths: OrchPaths
+
+beforeEach(() => {
+  repoRoot = mkdtempSync(join(tmpdir(), 'orch-status-lock-'))
+  paths = orchPaths(repoRoot)
+  mocks.writeFileSync.mockReset().mockImplementation((...args: unknown[]) =>
+    Reflect.apply(actualFs.writeFileSync, actualFs, args))
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  rmSync(repoRoot, { recursive: true, force: true })
+})
+
+describe('status lock publication', () => {
+  it('removes a partially published lock and rethrows a metadata write failure', async () => {
+    const taskId = 'metadata-failure'
+    const lockDir = join(paths.statusDir, `.${taskId}.lock`)
+    const failure = Object.assign(new Error('identity metadata unavailable'), { code: 'EIO' })
+    mocks.writeFileSync.mockImplementation((...args: unknown[]) => {
+      if (basename(String(args[0])) === 'start-identity') throw failure
+      return Reflect.apply(actualFs.writeFileSync, actualFs, args)
+    })
+
+    await expect(writeStatus(paths, taskId, 'completed')).rejects.toBe(failure)
+    expect(actualFs.existsSync(lockDir)).toBe(false)
+
+    mocks.writeFileSync.mockImplementation((...args: unknown[]) =>
+      Reflect.apply(actualFs.writeFileSync, actualFs, args))
+    await expect(writeStatus(paths, taskId, 'completed')).resolves.toBeUndefined()
+    expect(readStatus(paths, taskId)?.status).toBe('completed')
+  })
+
+  it('does not treat a file at the lock path as lock contention', async () => {
+    const taskId = 'invalid-lock-file'
+    const lockFile = join(paths.statusDir, `.${taskId}.lock`)
+    actualFs.writeFileSync(lockFile, 'not a directory\n')
+
+    await expect(writeStatus(paths, taskId, 'completed')).rejects.toMatchObject({
+      code: 'EEXIST',
+    })
+    expect(actualFs.readFileSync(lockFile, 'utf8')).toBe('not a directory\n')
+  })
+})


### PR DESCRIPTION
## Features
- [Loop] Starting a merge is idempotent: a per-task guard skips a second concurrent or post-success start of the same task's merge, so a phantom failure can no longer push the loop toward its stop threshold.
- [Loop] A task whose pre-merge rebase conflicts is now truly abandoned on the first attempt — its issues are released back to ready, the worktree is cleaned, and the consecutive-failure counter is incremented at most once. The retry loop that previously counted one conflicting task three times and stopped the run is gone.

## Bug Fixes
- [Loop] Review-round fixes from run8's final review (#228).

## Security
- None

## Project Operations
- None

## Risks
- Both changes sit in the merge path and are covered by regression tests reproducing the live failures (duplicate 'Merging' race from run8, four-time rebase-conflict retry from a consumer run).

https://claude.ai/code/session_013be6ix5uC5UiTQvLevmeLQ