### PR TITLE
feat: let Claude Code work the loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ specific failure; the comments in the source name the incident rather than the p
 - Node 23.6 or later — the TypeScript sources are executed natively, with no build step
 - git
 - Bash on Windows (for example, Git Bash), with `bash` available on `PATH` — the bundled
-  Codex runner uses it to launch the Codex CLI safely
-- An agent CLI (the bundled runner adapter drives [Codex](https://openai.com/codex/))
+  runners use it to launch npm command shims safely
+- An agent CLI (the bundled runner adapters drive
+  [Codex](https://openai.com/codex/) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code))
 - A forge CLI (the bundled forge adapter drives GitHub through `gh`)
 
 ## How a run works
@@ -67,8 +68,9 @@ cycle on the old core instead of merging local divergence.
 That same boundary syncs the skills declared in `skills/manifest.json` into every
 directory an agent working in the repository reads them from. The selected runner adapter
 supplies one — the bundled Codex adapter uses `.agents/skills/` and rewrites the sources
-into Codex's own form — and `.claude/skills/` receives them for the interactive agent a
-person drives, in the canonical form that agent already speaks. Serving only the runner
+into Codex's own form, while the Claude adapter uses `.claude/skills/` in canonical form —
+and `.claude/skills/` receives them for the interactive agent a person drives. When Claude
+is the runner, that shared destination is rendered only once. Serving only the runner
 meant that selecting Codex silently took every shared workflow away from the person, so
 one destination failing no longer costs the others theirs. Loop commands are rendered for
 the installed package location (`npm run` here, `npm run -C orchestration/ts` in the
@@ -88,7 +90,7 @@ carry the consumer-selected parts of that:
 | Adapter | Selector | Valid selector value | Bundled implementation | Replace it to… |
 |---------|----------|----------------------|------------------------|----------------|
 | forge   | `FORGE`  | `github`             | `forge-github` (`gh`)  | move to Gitea, GitLab, … |
-| runner  | `RUNNER` | `codex`              | `runner-codex`         | drive a different agent CLI |
+| runner  | `RUNNER` | `codex`, `claude`    | `runner-codex`, `runner-claude` | drive a different agent CLI |
 | project | discovery or `PROJECT` | project name | none — you write it | describe *your* repository |
 
 The project adapter is the one you must supply. It lives **outside** this package so a
@@ -234,6 +236,9 @@ git subtree pull --prefix=orchestration/ts \
 | `CI_GATE_ENABLED` | false | Enable polling PR checks and queueing CI-fix tasks; when false, the CI gate is skipped |
 | `ISSUE_QUEUE_ENABLED` | false | Keep the backlog in forge issues so several machines can share it |
 | `SCAN_EFFORT` / `TASK_EFFORT` / `REVIEW_EFFORT` | high / medium / high | Reasoning effort per kind of work; `TASK_EFFORT` applies to queued tasks without a per-task override, while review-spawned fixes always use high effort |
+| `RUNNER` | codex | Agent CLI adapter; accepts `codex` or `claude` |
+| `RUNNER_CLAUDE_MODEL` | claude-opus-5 | Base Claude model used when `RUNNER=claude` and no task-specific model is set |
+| `RUNNER_CLAUDE_MODEL_MINIMAL` / `LOW` / `MEDIUM` / `HIGH` | `RUNNER_CLAUDE_MODEL` | Optional model selected for the matching reasoning effort when `RUNNER=claude` |
 | `CORE_AUTO_UPDATE` | true | Check and pull the shared-core subtree immediately before each cycle; `false` skips the check entirely |
 | `INTEGRATION_BRANCH` | empty | Empty keeps the direct single-worktree layout; a branch name freezes the daemon checkout and makes this separate branch the task base, merge target, gate target, and PR source |
 | `UPSTREAM_REMOTE` | package `upstreamRepo` | Remote name, Git URL/path, or GitHub `owner/repository` to fetch and subtree-pull |

--- a/SPEC.md
+++ b/SPEC.md
@@ -69,6 +69,9 @@ values must be non-negative integers, with the narrower bounds stated below.
 | `SCAN_ENABLED` | `true` | Start another scan cycle after the current backlog and gate are clear. `false` drains existing local and shared work, performs any enabled final PR promotion, and exits without starting a scan. |
 | `REVIEW_ENABLED` | `true` | Retain the review boundary in the cycle gate. Without `AUTO_REVIEW`, that boundary records resumable state and continues on the next poll; `false` skips it. If `AUTO_PR` is also `false`, disabling this setting bypasses the cycle gate entirely. |
 | `REVIEW_EFFORT` | `high` | Reasoning effort for automatic review tasks. Accepted values are `minimal`, `low`, `medium`, and `high`. |
+| `RUNNER` | `codex` | Select the bundled `codex` or `claude` runner adapter. |
+| `RUNNER_CLAUDE_MODEL` | `claude-opus-5` | Base model for the Claude runner when no task-specific model override applies. |
+| `RUNNER_CLAUDE_MODEL_MINIMAL`, `RUNNER_CLAUDE_MODEL_LOW`, `RUNNER_CLAUDE_MODEL_MEDIUM`, `RUNNER_CLAUDE_MODEL_HIGH` | `RUNNER_CLAUDE_MODEL` | Optional Claude model mapping for each runner-neutral reasoning effort. |
 | `MAX_PARALLEL` | `3` | Limit concurrently running queued-task processes and shared-issue claim capacity. It must be at least 1; scan fan-out is controlled separately by `SCAN_PARALLEL`. |
 | `POLL_INTERVAL` | `30` | Maximum seconds the daemon waits between polls when no wake signal arrives. Values from 0 through 1800 are accepted; the upper bound keeps polling within the issue-heartbeat interval. |
 | `TEST_CMD` | empty | When non-empty, run this command in a task worktree as its merge test and use it instead of the project adapter's path-selected merge checks. A manual merge's `--test-cmd` takes precedence. |
@@ -228,7 +231,10 @@ values must be non-negative integers, with the narrower bounds stated below.
     accept `minimal`, `low`, `medium`, or `high` and override their respective defaults;
     `TASK_EFFORT` applies to queued tasks that do not have a per-task override, so it does
     not replace the high-effort review-fix override. `SCAN_MODEL` and `TASK_MODEL`
-    override the runner model, and `delegate --effort` overrides effort per task.
+    override the runner model, and `delegate --effort` overrides effort per task. The
+    Claude runner maps effort to `RUNNER_CLAUDE_MODEL_MINIMAL`, `_LOW`, `_MEDIUM`, or
+    `_HIGH`, each defaulting to `RUNNER_CLAUDE_MODEL` (`claude-opus-5`), instead of
+    translating runner-neutral effort into a Claude thinking flag.
 14a. Immediately before a new cycle consumes its number or starts a scan, after the
     previous cycle gate has closed and while no task is running, the daemon first compares
     the selected project adapter with the exact source loaded at startup. A changed,
@@ -254,7 +260,8 @@ values must be non-negative integers, with the narrower bounds stated below.
     directory an agent working in the repository discovers skills in: the selected
     runner's, supplied by its adapter, and `.claude/skills/` for the interactive agent a
     person drives. The Codex adapter renders into repository root `.agents/skills/`; the
-    interactive rendering resolves the command prefix only, the canonical sources already
+    Claude adapter and interactive agent share `.claude/skills/` and are served once. The
+    Claude rendering resolves the command prefix only, the canonical sources already
     being in that agent's format. Both use `npm run` as the command prefix in the owning
     repository and `npm run -C <package-path>` in a subtree consumer, and a runner that
     discovers `.claude/skills/` is served once rather than twice. The
@@ -410,11 +417,13 @@ values must be non-negative integers, with the narrower bounds stated below.
     message decoration for forge-driven closure. Fingerprint deduplication, claim
     arbitration, and stale-lease reaping live in `src/issueQueue.ts` on those primitives.
 30. The runner is invoked only through `adapters/runner.ts` (`RUNNER=codex` selects
-    `runner-codex.ts`). The runner contract is the output markers — `TASK_COMPLETE`,
+    `runner-codex.ts`; `RUNNER=claude` selects `runner-claude.ts`). The runner contract is
+    the output markers — `TASK_COMPLETE`,
     `NO_CHANGE_WARRANTED`, `NEXT_TASK:`, `DECISION_REQUIRED:` in the final-message file — plus effort/model
     arguments mapped to CLI flags, and the runner's own repository skill destination and
     rendering behavior inside the adapter. Any runner honoring the contract is
-    substitutable, and none of them owns the interactive agent's skill directory.
+    substitutable. The Claude runner uses the interactive agent's skill directory as its
+    own discovery path, so the shared-skill sync deduplicates that target.
 31. Everything the orchestration knows about the repository it runs in — which staged
     paths select fast pre-commit checks, which commands verify a merge, which paths make
     each check relevant, which suites prove a cycle's

--- a/src/adapters/forge-github.ts
+++ b/src/adapters/forge-github.ts
@@ -1,4 +1,7 @@
 import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { z } from 'zod'
 import type {
@@ -157,6 +160,17 @@ async function gh(repoRoot: string, args: string[]): Promise<string> {
     maxBuffer: 16 * 1024 * 1024,
   })
   return stdout
+}
+
+async function withBodyFile<T>(body: string, action: (bodyFile: string) => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), 'orch-gh-body-'))
+  const bodyFile = join(directory, 'body.md')
+  try {
+    await writeFile(bodyFile, body, 'utf8')
+    return await action(bodyFile)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
 }
 
 function commandErrorText(error: unknown): string {
@@ -426,13 +440,15 @@ export function createGithubForge(
 
     async createIssue(options: CreateIssueOptions): Promise<number> {
       const repository = await issueQueueRepository()
-      const args = [
-        'issue', 'create', '--repo', repository,
-        '--title', options.title, '--body', options.body,
-      ]
-      for (const label of options.labels) args.push('--label', label)
-      for (const assignee of options.assignees ?? []) args.push('--assignee', assignee)
-      const stdout = await checkedGh(repoRoot, args)
+      const stdout = await withBodyFile(options.body, async (bodyFile) => {
+        const args = [
+          'issue', 'create', '--repo', repository,
+          '--title', options.title, '--body-file', bodyFile,
+        ]
+        for (const label of options.labels) args.push('--label', label)
+        for (const assignee of options.assignees ?? []) args.push('--assignee', assignee)
+        return checkedGh(repoRoot, args)
+      })
       const match = /\/issues\/(\d+)\s*$/.exec(stdout.trim())
       if (match === null) {
         throw new Error(`gh issue create returned no issue URL: ${stdout.trim()}`)
@@ -452,12 +468,14 @@ export function createGithubForge(
       ).map((candidate) => candidate.name)
       const labels = options.optionalLabels.filter((label) => available.includes(label))
 
-      const args = [
-        'issue', 'create', '--repo', options.repository,
-        '--title', options.title, '--body', options.body,
-      ]
-      for (const label of labels) args.push('--label', label)
-      const stdout = await checkedGh(repoRoot, args)
+      const stdout = await withBodyFile(options.body, async (bodyFile) => {
+        const args = [
+          'issue', 'create', '--repo', options.repository,
+          '--title', options.title, '--body-file', bodyFile,
+        ]
+        for (const label of labels) args.push('--label', label)
+        return checkedGh(repoRoot, args)
+      })
       const url = stdout.split(/\r?\n/).map((line) => line.trim())
         .find((line) => ISSUE_URL_PATTERN.test(line))
       if (url === undefined) {

--- a/src/adapters/runner-claude.ts
+++ b/src/adapters/runner-claude.ts
@@ -1,0 +1,194 @@
+import { spawn } from 'node:child_process'
+import {
+  closeSync, openSync, renameSync, rmSync, writeFileSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { packageCommandPrefix } from '../paths.ts'
+import { startWindowsProcess } from './windows-process.ts'
+import type {
+  ReasoningEffort, Runner, RunnerLoadOptions, RunnerSharedSkillRenderOptions,
+  RunnerStartOptions,
+} from './runner.ts'
+
+const DEFAULT_MODEL = 'claude-opus-5'
+const WRAPPER_ARGUMENT = '--claude-runner-wrapper'
+
+function configuredModel(value: string | undefined, fallback: string): string {
+  return value === undefined || value === '' ? fallback : value
+}
+
+function effortModels(options: RunnerLoadOptions): Record<ReasoningEffort, string> {
+  const base = configuredModel(options.runnerClaudeModel, DEFAULT_MODEL)
+  return {
+    minimal: configuredModel(options.runnerClaudeModelMinimal, base),
+    low: configuredModel(options.runnerClaudeModelLow, base),
+    medium: configuredModel(options.runnerClaudeModelMedium, base),
+    high: configuredModel(options.runnerClaudeModelHigh, base),
+  }
+}
+
+// Claude print mode reads the task specification from standard input. It has no
+// output-last-message option, so the detached wrapper below tees stdout to the transcript
+// and publishes it atomically as the final-message file only after Claude exits.
+function buildArgs(
+  options: RunnerStartOptions,
+  models: Record<ReasoningEffort, string>,
+): string[] {
+  const model = configuredModel(options.model, models[options.effort])
+  return ['-p', '--permission-mode', 'bypassPermissions', '--model', model]
+}
+
+function renderSharedSkillFile(
+  contents: Buffer,
+  options: RunnerSharedSkillRenderOptions,
+): Buffer {
+  return Buffer.from(contents.toString('utf8').replaceAll(
+    options.commandPrefixPlaceholder,
+    packageCommandPrefix(options.repoRoot, options.packageRoot),
+  ))
+}
+
+function publishFinalMessage(file: string, contents: Buffer): void {
+  const temporary = `${file}.${process.pid}.tmp`
+  writeFileSync(temporary, contents)
+  try {
+    renameSync(temporary, file)
+  } finally {
+    rmSync(temporary, { force: true })
+  }
+}
+
+/** Run Claude as the durable wrapper's child and return its exit code. */
+export function runClaudeProcess(
+  finalMessageFile: string,
+  args: readonly string[],
+): Promise<number> {
+  const viaBash = process.platform === 'win32'
+  const command = viaBash ? 'bash' : 'claude'
+  const commandArgs = viaBash
+    ? ['-c', 'exec claude "$@"', 'claude', ...args]
+    : [...args]
+
+  return new Promise((resolve, reject) => {
+    let child
+    try {
+      child = spawn(command, commandArgs, {
+        detached: false,
+        stdio: ['inherit', 'pipe', 'inherit'],
+        windowsHide: true,
+      })
+    } catch (error) {
+      reject(error)
+      return
+    }
+    const output: Buffer[] = []
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      output.push(buffer)
+      process.stdout.write(buffer)
+    })
+    child.once('error', reject)
+    child.once('close', (code) => {
+      try {
+        publishFinalMessage(finalMessageFile, Buffer.concat(output))
+        resolve(code ?? 1)
+      } catch (error) {
+        reject(error)
+      }
+    })
+  })
+}
+
+export function createClaudeRunner(options: RunnerLoadOptions = {}): Runner {
+  const models = effortModels(options)
+  return {
+    sharedSkills: {
+      destinationRoot: (repoRoot) => join(repoRoot, '.claude', 'skills'),
+      renderFile: renderSharedSkillFile,
+    },
+    start(startOptions: RunnerStartOptions): Promise<number> {
+      const wrapperArgs = [
+        fileURLToPath(import.meta.url),
+        WRAPPER_ARGUMENT,
+        startOptions.finalMessageFile,
+        ...buildArgs(startOptions, models),
+      ]
+
+      if (process.platform === 'win32') {
+        return startWindowsProcess({
+          args: wrapperArgs,
+          command: process.execPath,
+          cwd: startOptions.worktree,
+          inputFile: startOptions.specFile,
+          outputFile: startOptions.logFile,
+        })
+      }
+
+      const logFd = openSync(startOptions.logFile, 'a')
+      let specFd: number
+      try {
+        specFd = openSync(startOptions.specFile, 'r')
+      } catch (error) {
+        closeSync(logFd)
+        return Promise.reject(error)
+      }
+
+      return new Promise((resolve, reject) => {
+        let descriptorsClosed = false
+        const closeDescriptors = (): void => {
+          if (descriptorsClosed) return
+          descriptorsClosed = true
+          try {
+            closeSync(specFd)
+          } finally {
+            closeSync(logFd)
+          }
+        }
+
+        let child
+        try {
+          child = spawn(process.execPath, wrapperArgs, {
+            cwd: startOptions.worktree,
+            detached: true,
+            stdio: [specFd, logFd, logFd],
+            windowsHide: true,
+          })
+        } catch (error) {
+          closeDescriptors()
+          reject(error)
+          return
+        }
+        child.once('error', (error) => {
+          closeDescriptors()
+          reject(error)
+        })
+        child.once('spawn', () => {
+          closeDescriptors()
+          child.unref()
+          if (child.pid === undefined) {
+            reject(new Error('claude runner spawned without a PID'))
+            return
+          }
+          resolve(child.pid)
+        })
+      })
+    },
+  }
+}
+
+if (process.argv[2] === WRAPPER_ARGUMENT) {
+  const finalMessageFile = process.argv[3]
+  if (finalMessageFile === undefined) {
+    process.stderr.write('Claude runner wrapper requires a final-message file.\n')
+    process.exitCode = 1
+  } else {
+    try {
+      process.exitCode = await runClaudeProcess(finalMessageFile, process.argv.slice(4))
+    } catch (error) {
+      const detail = error instanceof Error ? error.stack ?? error.message : String(error)
+      process.stderr.write(`Claude runner failed: ${detail}\n`)
+      process.exitCode = 1
+    }
+  }
+}

--- a/src/adapters/runner.ts
+++ b/src/adapters/runner.ts
@@ -44,13 +44,28 @@ export interface Runner {
   start(options: RunnerStartOptions): Promise<number>
 }
 
-export async function loadRunner(name: string): Promise<Runner> {
+export interface RunnerLoadOptions {
+  runnerClaudeModel?: string | undefined
+  runnerClaudeModelMinimal?: string | undefined
+  runnerClaudeModelLow?: string | undefined
+  runnerClaudeModelMedium?: string | undefined
+  runnerClaudeModelHigh?: string | undefined
+}
+
+export async function loadRunner(
+  name: string,
+  options: RunnerLoadOptions = {},
+): Promise<Runner> {
   switch (name) {
     case 'codex': {
       const mod = await import('./runner-codex.ts')
       return mod.createCodexRunner()
     }
+    case 'claude': {
+      const mod = await import('./runner-claude.ts')
+      return mod.createClaudeRunner(options)
+    }
     default:
-      throw new Error(`Unknown RUNNER '${name}' (supported: codex)`)
+      throw new Error(`Unknown RUNNER '${name}' (supported: codex, claude)`)
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -460,7 +460,7 @@ const cmdStart: Command = async (paths, args) => {
       return 1
     }
   }
-  const runner = await loadRunner(config.runner)
+  const runner = await loadRunner(config.runner, config)
   const project = await loadProject(paths.root)
   const result = await startTask(paths, runner, taskId, {
     effort,
@@ -1005,7 +1005,7 @@ async function runLoopDaemon(
     const topology = prepareBranchTopology(paths, config.integrationBranch)
     const loopPaths = topology.paths
     const forge = await loadForge(config.forge, loopPaths.repoRoot)
-    const runner = await loadRunner(config.runner)
+    const runner = await loadRunner(config.runner, config)
     const projectModule = await import('./adapters/project.ts')
     const projectRoot = topology.integrationBranch === undefined
       ? paths.root

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,11 @@ export interface LoopConfig {
   taskGate: 'full' | 'light'
   forge: string
   runner: string
+  runnerClaudeModel: string
+  runnerClaudeModelMinimal: string
+  runnerClaudeModelLow: string
+  runnerClaudeModelMedium: string
+  runnerClaudeModelHigh: string
   /** Findings become forge issues that workers claim, instead of direct local enqueues. */
   issueQueueEnabled: boolean
   /** Claim and execute shared work without scanning, reviewing, or merging it locally. */
@@ -126,6 +131,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): LoopConfig {
   if (reviewEveryNCycles < 1) {
     throw new Error('REVIEW_EVERY_N_CYCLES must be at least 1')
   }
+  const runnerClaudeModel = str(env, 'RUNNER_CLAUDE_MODEL', 'claude-opus-5')
   return {
     maxParallel,
     pollIntervalSeconds,
@@ -156,6 +162,11 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): LoopConfig {
     taskGate,
     forge: str(env, 'FORGE', 'github'),
     runner: str(env, 'RUNNER', 'codex'),
+    runnerClaudeModel,
+    runnerClaudeModelMinimal: str(env, 'RUNNER_CLAUDE_MODEL_MINIMAL', runnerClaudeModel),
+    runnerClaudeModelLow: str(env, 'RUNNER_CLAUDE_MODEL_LOW', runnerClaudeModel),
+    runnerClaudeModelMedium: str(env, 'RUNNER_CLAUDE_MODEL_MEDIUM', runnerClaudeModel),
+    runnerClaudeModelHigh: str(env, 'RUNNER_CLAUDE_MODEL_HIGH', runnerClaudeModel),
     issueQueueEnabled,
     workerMode,
     issueLeaseHours: num(env, 'ISSUE_LEASE_HOURS', 3),

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -30,6 +30,11 @@ describe('loadConfig', () => {
       taskGate: 'full',
       forge: 'github',
       runner: 'codex',
+      runnerClaudeModel: 'claude-opus-5',
+      runnerClaudeModelMinimal: 'claude-opus-5',
+      runnerClaudeModelLow: 'claude-opus-5',
+      runnerClaudeModelMedium: 'claude-opus-5',
+      runnerClaudeModelHigh: 'claude-opus-5',
       workerMode: false,
       coreAutoUpdate: true,
       upstreamRemote: 'menimani/orchestration-core',
@@ -47,6 +52,9 @@ describe('loadConfig', () => {
       REVIEW_EFFORT: 'low',
       TASK_EFFORT: 'high',
       TASK_MODEL: 'task-model',
+      RUNNER_CLAUDE_MODEL: 'claude-base',
+      RUNNER_CLAUDE_MODEL_MINIMAL: 'claude-small',
+      RUNNER_CLAUDE_MODEL_HIGH: 'claude-large',
       CORE_AUTO_UPDATE: 'false',
       UPSTREAM_REMOTE: 'shared-core',
       UPSTREAM_BRANCH: 'stable',
@@ -59,6 +67,11 @@ describe('loadConfig', () => {
     expect(config.reviewEffort).toBe('low')
     expect(config.taskEffort).toBe('high')
     expect(config.taskModel).toBe('task-model')
+    expect(config.runnerClaudeModel).toBe('claude-base')
+    expect(config.runnerClaudeModelMinimal).toBe('claude-small')
+    expect(config.runnerClaudeModelLow).toBe('claude-base')
+    expect(config.runnerClaudeModelMedium).toBe('claude-base')
+    expect(config.runnerClaudeModelHigh).toBe('claude-large')
     expect(config.coreAutoUpdate).toBe(false)
     expect(config.upstreamRemote).toBe('shared-core')
     expect(config.upstreamBranch).toBe('stable')

--- a/tests/forge-github.test.ts
+++ b/tests/forge-github.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import {
   createGithubForge, workflowRunForDispatch, type GithubCommand, type GithubWorkflowRun,
@@ -167,8 +168,12 @@ describe('GitHub upstream issue creation', () => {
     { available: [], expectedLabel: false },
   ])('applies the optional label only when it exists', async ({ available, expectedLabel }) => {
     const calls: string[][] = []
+    let submittedBody: string | undefined
     const command: GithubCommand = async (_root, args) => {
       calls.push(args)
+      if (args[0] === 'issue') {
+        submittedBody = readFileSync(args[args.indexOf('--body-file') + 1]!, 'utf8')
+      }
       return args[0] === 'label'
         ? JSON.stringify(available)
         : 'https://github.com/menimani/orchestration-core/issues/42\n'
@@ -190,13 +195,39 @@ describe('GitHub upstream issue creation', () => {
     ])
     expect(calls[1]).toEqual([
       'issue', 'create', '--repo', 'menimani/orchestration-core',
-      '--title', 'Core defect report', '--body', 'Report body',
+      '--title', 'Core defect report', '--body-file', expect.any(String),
       ...(expectedLabel ? ['--label', 'upstream:report'] : []),
     ])
+    expect(submittedBody).toBe('Report body')
   })
 })
 
 describe('GitHub issue queue repository targeting', () => {
+  it('submits a multi-paragraph issue body without putting it on the command line', async () => {
+    const body = [
+      'First paragraph defines Part A.',
+      '',
+      'Second paragraph defines Part B.',
+      '',
+      'Final paragraph contains the completion criteria.',
+    ].join('\n')
+    let submittedBody: string | undefined
+    const command: GithubCommand = async (_root, args) => {
+      if (args[0] === 'repo') return JSON.stringify({ nameWithOwner: 'consumer/project' })
+      expect(args).not.toContain('--body')
+      const bodyFile = args[args.indexOf('--body-file') + 1]
+      if (bodyFile === undefined) throw new Error('expected an issue body file')
+      submittedBody = readFileSync(bodyFile, 'utf8')
+      return 'https://github.com/consumer/project/issues/42\n'
+    }
+    const forge = createGithubForge('repo-root', command)
+
+    await forge.createIssue({ title: 'Three-part task', body, labels: [QUEUE_LABELS[0]!.name] })
+
+    expect(submittedBody).toBe(body)
+    expect(submittedBody).toContain('Final paragraph contains the completion criteria.')
+  })
+
   it('lists labels once and creates only the missing loop labels', async () => {
     const calls: string[][] = []
     const command: GithubCommand = async (_root, args) => {

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -723,6 +723,26 @@ describe('claimIssue', () => {
       readFileSync(join(paths.tasksDir, `${taskId}.md`), 'utf8') + `\n${requirement}\n`)
   }
 
+  it('preserves all three paragraphs of a delegated issue in the materialized task', async () => {
+    const description = [
+      'Deliver Part A and Part B together.',
+      '',
+      'Keep the existing queue behavior while implementing both parts.',
+      '',
+      'The final paragraph must survive into the worker task requirement.',
+    ].join('\n')
+    const published = await publishDelegatedTask(forge, paths, description, 'user-task')
+    const issue = await forge.getIssue(published.issueNumber)
+
+    expect(issue.body).toContain('The final paragraph must survive into the worker task requirement.')
+
+    const result = await claimIssue(forge, paths, issue, 'worker-a', appendRequirement)
+    if (result.outcome !== 'claimed') throw new Error(`expected a claim, got ${result.outcome}`)
+    const spec = readFileSync(specFile(paths, result.taskId), 'utf8')
+    expect(spec).toContain(description)
+    expect(spec).toContain('The final paragraph must survive into the worker task requirement.')
+  })
+
   it('claims same-file findings into one task while preserving each requirement', async () => {
     const descriptions = [
       '[BUG] `src/a/b.ts` rejects an empty value',

--- a/tests/runner-claude.test.ts
+++ b/tests/runner-claude.test.ts
@@ -1,0 +1,262 @@
+import { EventEmitter } from 'node:events'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReasoningEffort, RunnerStartOptions } from '../src/adapters/runner.ts'
+
+const mocks = vi.hoisted(() => ({
+  closeSync: vi.fn(),
+  openSync: vi.fn((path: string) => path === 'task.log' ? 42 : 43),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
+  spawn: vi.fn(),
+  startWindowsProcess: vi.fn(),
+  writeFileSync: vi.fn(),
+}))
+
+vi.mock('node:fs', () => ({
+  closeSync: mocks.closeSync,
+  openSync: mocks.openSync,
+  renameSync: mocks.renameSync,
+  rmSync: mocks.rmSync,
+  writeFileSync: mocks.writeFileSync,
+}))
+
+vi.mock('node:child_process', () => ({ spawn: mocks.spawn }))
+vi.mock('../src/adapters/windows-process.ts', () => ({
+  startWindowsProcess: mocks.startWindowsProcess,
+}))
+
+import { createClaudeRunner, runClaudeProcess } from '../src/adapters/runner-claude.ts'
+import { loadRunner } from '../src/adapters/runner.ts'
+
+const options: RunnerStartOptions = {
+  effort: 'high',
+  finalMessageFile: 'final-message.txt',
+  logFile: 'task.log',
+  specFile: 'task.md',
+  worktree: 'worktree',
+}
+
+const originalPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+}
+
+function mockChild(pid: number | undefined = 1234): EventEmitter & {
+  pid: number | undefined
+  stdout: EventEmitter
+  unref: ReturnType<typeof vi.fn>
+} {
+  return Object.assign(new EventEmitter(), {
+    pid,
+    stdout: new EventEmitter(),
+    unref: vi.fn(),
+  })
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset()
+  mocks.openSync.mockImplementation((path: string) => path === 'task.log' ? 42 : 43)
+  mocks.startWindowsProcess.mockResolvedValue(5678)
+  setPlatform('linux')
+})
+
+afterEach(() => {
+  setPlatform(originalPlatform)
+  vi.restoreAllMocks()
+})
+
+describe('createClaudeRunner', () => {
+  it('renders canonical skills into the Claude repository discovery path', () => {
+    const repoRoot = join('fixture', 'repository')
+    const packageRoot = join(repoRoot, 'orchestration', 'ts')
+    const sharedSkills = createClaudeRunner().sharedSkills
+    const source = [
+      '---',
+      'name: git-commit',
+      'allowed-tools: Bash',
+      '---',
+      '',
+      'Run /git-review, then {{COMMAND_PREFIX}} loop-status.',
+      '',
+    ].join('\n')
+
+    expect(sharedSkills.destinationRoot(repoRoot)).toBe(join(repoRoot, '.claude', 'skills'))
+    expect(sharedSkills.legacyRoots).toBeUndefined()
+    expect(sharedSkills.renderFile(
+      Buffer.from(source),
+      { repoRoot, packageRoot, commandPrefixPlaceholder: '{{COMMAND_PREFIX}}' },
+    ).toString('utf8')).toBe([
+      '---',
+      'name: git-commit',
+      'allowed-tools: Bash',
+      '---',
+      '',
+      'Run /git-review, then npm run -C orchestration/ts loop-status.',
+      '',
+    ].join('\n'))
+  })
+
+  it.each<[ReasoningEffort, string]>([
+    ['minimal', 'claude-minimal'],
+    ['low', 'claude-low'],
+    ['medium', 'claude-medium'],
+    ['high', 'claude-high'],
+  ])('maps %s effort to its configured model while delivering the prompt by stdin', async (
+    effort,
+    model,
+  ) => {
+    const child = mockChild(4321)
+    mocks.spawn.mockReturnValue(child)
+    const runner = createClaudeRunner({
+      runnerClaudeModel: 'claude-base',
+      runnerClaudeModelMinimal: 'claude-minimal',
+      runnerClaudeModelLow: 'claude-low',
+      runnerClaudeModelMedium: 'claude-medium',
+      runnerClaudeModelHigh: 'claude-high',
+    })
+
+    const started = runner.start({ ...options, effort })
+
+    expect(mocks.openSync).toHaveBeenNthCalledWith(1, 'task.log', 'a')
+    expect(mocks.openSync).toHaveBeenNthCalledWith(2, 'task.md', 'r')
+    expect(mocks.spawn).toHaveBeenCalledWith(process.execPath, [
+      expect.stringMatching(/runner-claude\.ts$/),
+      '--claude-runner-wrapper',
+      'final-message.txt',
+      '-p',
+      '--permission-mode', 'bypassPermissions',
+      '--model', model,
+    ], {
+      cwd: 'worktree',
+      detached: true,
+      stdio: [43, 42, 42],
+      windowsHide: true,
+    })
+    expect((mocks.spawn.mock.calls[0]?.[1] as string[])).not.toContain('--effort')
+
+    child.emit('spawn')
+    await expect(started).resolves.toBe(4321)
+    expect(child.unref).toHaveBeenCalledOnce()
+  })
+
+  it('prefers a task-specific model over the configured effort model', async () => {
+    const child = mockChild()
+    mocks.spawn.mockReturnValue(child)
+
+    const started = createClaudeRunner({
+      runnerClaudeModelHigh: 'claude-high',
+    }).start({ ...options, model: 'task-model' })
+
+    expect(mocks.spawn.mock.calls[0]?.[1]).toContain('task-model')
+    expect(mocks.spawn.mock.calls[0]?.[1]).not.toContain('claude-high')
+    child.emit('spawn')
+    await expect(started).resolves.toBe(1234)
+  })
+
+  it('uses the hidden process launcher on Windows with the default Opus model', async () => {
+    setPlatform('win32')
+
+    const started = createClaudeRunner().start(options)
+
+    expect(mocks.startWindowsProcess).toHaveBeenCalledWith({
+      args: [
+        expect.stringMatching(/runner-claude\.ts$/),
+        '--claude-runner-wrapper',
+        'final-message.txt',
+        '-p',
+        '--permission-mode', 'bypassPermissions',
+        '--model', 'claude-opus-5',
+      ],
+      command: process.execPath,
+      cwd: 'worktree',
+      inputFile: 'task.md',
+      outputFile: 'task.log',
+    })
+    await expect(started).resolves.toBe(5678)
+    expect(mocks.spawn).not.toHaveBeenCalled()
+  })
+
+  it('closes inherited descriptors and rejects when the detached wrapper has no PID', async () => {
+    const child = mockChild()
+    child.pid = undefined
+    mocks.spawn.mockReturnValue(child)
+
+    const started = createClaudeRunner().start(options)
+    child.emit('spawn')
+
+    await expect(started).rejects.toThrow('claude runner spawned without a PID')
+    expect(mocks.closeSync).toHaveBeenNthCalledWith(1, 43)
+    expect(mocks.closeSync).toHaveBeenNthCalledWith(2, 42)
+    expect(child.unref).toHaveBeenCalledOnce()
+  })
+
+  it('closes the log and rejects when the prompt file cannot be opened', async () => {
+    const error = new Error('prompt open failed')
+    mocks.openSync.mockImplementation((path: string) => {
+      if (path === 'task.log') return 42
+      throw error
+    })
+
+    await expect(createClaudeRunner().start(options)).rejects.toBe(error)
+    expect(mocks.closeSync).toHaveBeenCalledWith(42)
+    expect(mocks.spawn).not.toHaveBeenCalled()
+  })
+})
+
+describe('Claude process wrapper', () => {
+  it('runs a fake claude executable and publishes its marker output as the final message', async () => {
+    const child = mockChild()
+    mocks.spawn.mockReturnValue(child)
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    const completed = runClaudeProcess('final-message.txt', [
+      '-p', '--permission-mode', 'bypassPermissions', '--model', 'claude-opus-5',
+    ])
+    const finalOutput = Buffer.from('Finished.\nNO_CHANGE_WARRANTED\nTASK_COMPLETE\n')
+    child.stdout.emit('data', finalOutput)
+    child.emit('close', 0)
+
+    await expect(completed).resolves.toBe(0)
+    expect(mocks.spawn).toHaveBeenCalledWith('claude', [
+      '-p', '--permission-mode', 'bypassPermissions', '--model', 'claude-opus-5',
+    ], {
+      detached: false,
+      stdio: ['inherit', 'pipe', 'inherit'],
+      windowsHide: true,
+    })
+    expect(stdout).toHaveBeenCalledWith(finalOutput)
+    expect(mocks.writeFileSync).toHaveBeenCalledWith(
+      `final-message.txt.${process.pid}.tmp`, finalOutput,
+    )
+    expect(mocks.renameSync).toHaveBeenCalledWith(
+      `final-message.txt.${process.pid}.tmp`, 'final-message.txt',
+    )
+  })
+
+  it('routes the fake claude executable through Bash on Windows', async () => {
+    setPlatform('win32')
+    const child = mockChild()
+    mocks.spawn.mockReturnValue(child)
+
+    const completed = runClaudeProcess('final-message.txt', ['-p'])
+    child.emit('close', 7)
+
+    await expect(completed).resolves.toBe(7)
+    expect(mocks.spawn).toHaveBeenCalledWith('bash', [
+      '-c', 'exec claude "$@"', 'claude', '-p',
+    ], expect.any(Object))
+  })
+})
+
+describe('loadRunner', () => {
+  it('loads Claude and lists both supported runners in errors', async () => {
+    const runner = await loadRunner('claude')
+    expect(runner.sharedSkills.destinationRoot('repo'))
+      .toBe(join('repo', '.claude', 'skills'))
+    await expect(loadRunner('missing')).rejects.toThrow(
+      "Unknown RUNNER 'missing' (supported: codex, claude)",
+    )
+  })
+})

--- a/tests/shared-skills.test.ts
+++ b/tests/shared-skills.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createClaudeRunner } from '../src/adapters/runner-claude.ts'
 import type { Runner } from '../src/adapters/runner.ts'
 import { syncSharedSkills } from '../src/sharedSkills.ts'
 import { fakeRunnerSharedSkills } from './fakeRunner.ts'
@@ -241,5 +242,19 @@ describe('shared skill sync', () => {
     expect(result.installed).toEqual(['.claude/skills/git-commit', '.claude/skills/loop-start'])
     expect(readFileSync(join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
       .toBe('npm run -C orchestration/ts loop -- --daemon\n')
+  })
+
+  it('serves the Claude runner without touching an unlisted repository skill', () => {
+    const localSkill = join(repoRoot, '.claude', 'skills', 'verify-changes', 'SKILL.md')
+    mkdirSync(dirname(localSkill), { recursive: true })
+    writeFileSync(localSkill, 'repository gates\n')
+    runner = createClaudeRunner()
+
+    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+
+    expect(result.installed).toEqual([
+      '.claude/skills/git-commit', '.claude/skills/loop-start',
+    ])
+    expect(readFileSync(localSkill, 'utf8')).toBe('repository gates\n')
   })
 })


### PR DESCRIPTION
## Features
- [Runner] A Claude Code runner adapter: `RUNNER=claude` starts tasks through the `claude` CLI with the same detached-process, logging, and completion contract as the Codex runner — the loop cannot tell them apart. The model comes from `RUNNER_CLAUDE_MODEL` (default `claude-opus-5`), with optional per-effort overrides, and canonical skills render into `.claude/skills/`, the path Claude Code reads.
- [CLI] Multi-paragraph delegation descriptions survive intact into forge issues and materialized tasks — previously everything after the first blank line was silently dropped, which stranded workers with truncated specifications.

## Bug Fixes
- None

## Security
- None

## Project Operations
- README documents the second runner and its variables.

## Risks
- The Claude runner is exercised by fake-binary tests only until a real loop runs with `RUNNER=claude`; the contract mirrors the Codex runner, which those same tests pin.

https://claude.ai/code/session_013be6ix5uC5UiTQvLevmeLQ