### PR TITLE
fix: fail closed across the loop's recovery paths and absorb duplicate merges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,10 @@ TypeScript with no build step.
 
 `README.md` describes what it is and how to run it. `SPEC.md` states the behaviour the
 suite pins — the two must agree, and tests enforce that. Canonical shared workflows live
-under `skills/`. They are rendered into every discovery path an agent working here reads:
-the selected runner's — `.agents/skills/` for Codex — and `.claude/skills/`, which the
-interactive agent a person drives reads and which also holds `verify-changes`, a
-repository skill absent from the manifest and never touched by the sync.
+under `skills/`. They are rendered into every discovery path selected by an adapter:
+`.agents/skills/` by the Codex runner, and `.claude/skills/` by this repository's project
+adapter for the interactive agent a person drives. The latter also holds `verify-changes`,
+a repository skill absent from the manifest and never touched by the sync.
 
 Merges, reviews, pull requests, and commits go through those workflows rather than
 hand-composed `gh` and `git` invocations: `git-merge` will not merge a self-PR that has

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ and merge into the integration branch as well, where the next task can see them.
 Immediately before a completed local task enters its merge gate, the loop rebases that
 task branch onto the current integration tip. Long-running tasks therefore test the work
 that has landed while they were running instead of repeatedly presenting the same stale
-branch to the gate.
+branch to the gate. If every task commit becomes empty because that work already landed,
+the task completes as no-change and its linked issues are closed normally.
 
 A stopped daemon retains both branch identities and the daemon commit. Restarting is a
 resume of the same run: integration commits made while it was down remain available to

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ That same boundary syncs the skills declared in `skills/manifest.json` into ever
 directory an agent working in the repository reads them from. The selected runner adapter
 supplies one — the bundled Codex adapter uses `.agents/skills/` and rewrites the sources
 into Codex's own form, while the Claude adapter uses `.claude/skills/` in canonical form —
-and `.claude/skills/` receives them for the interactive agent a person drives. When Claude
-is the runner, that shared destination is rendered only once. Serving only the runner
-meant that selecting Codex silently took every shared workflow away from the person, so
-one destination failing no longer costs the others theirs. Loop commands are rendered for
+and the project adapter selects any additional interactive-agent targets. This repository
+selects the bundled Claude target for `.claude/skills/`; duplicate destinations are served
+only once. One destination failing does not cost the others theirs. Loop commands are
+rendered for
 the installed package location (`npm run` here, `npm run -C orchestration/ts` in the
 layout below).
 The sync tracks the exact content it generated: a consumer edit, deletion, or added
@@ -109,7 +109,8 @@ With neither variable set, the core uses the single `project-*.ts` file in
 to select `project-<name>.ts`. You can instead give `PROJECT_ADAPTER` an explicit path;
 it overrides the conventional path selected by `PROJECT`.
 
-A project adapter answers a few questions: which staged-path checks run before a commit,
+A project adapter answers a few questions: which interactive agents receive shared skills,
+which staged-path checks run before a commit,
 which commands gate a merge, which tests a changed path implies, which suites run once per
 cycle, which repository or toolchain output identifies an infrastructure failure, how
 commits are grouped in the generated pull request, which changed paths signal risk, and

--- a/SPEC.md
+++ b/SPEC.md
@@ -88,8 +88,9 @@ values must be non-negative integers, with the narrower bounds stated below.
    completed task may additionally report `NO_CHANGE_WARRANTED` on its own line when its
    investigation proves the requested change is already unnecessary.
 2. Task ids are `YYYYMMDD_HHMMSS_nnn_<slug>` with `nnn` a per-day sequence; slugs end in
-   `scan` for scans and start with `ci-fix`, `auto-`, `fix-`, or `user-` for CI fixes,
-   scan findings, review-origin fixes, and delegated work. Listings sort chronologically.
+   `scan` for scans, are `review-c<n>` for automatic reviews of cycle `<n>`, and start
+   with `ci-fix`, `auto-`, `fix-`, or `user-` for CI fixes, scan findings, review-origin
+   fixes, and delegated work. Listings sort chronologically.
 3. `queue/desc-index` maps a description to its current task id. The same decision
    delegated twice resolves to one task, as does a repeated finding while its indexed
    task is queued, running, completed, or retryable after failure. If an identical
@@ -167,6 +168,8 @@ values must be non-negative integers, with the narrower bounds stated below.
    reduced merge checks, then runs the adapter's cycle suite once at each cycle-gate
    entry. Light-gate attribution cost (a suite break at the gate names no task) is
    accepted and documented; the gate stops the loop rather than promote a failing tip.
+   A missing-toolchain repair that fails also stops the gate and reports the adapter's
+   remediation message without running the subsequent suite step.
 9a. A merge check that passes counts only where its directory satisfies its own declared
     dependencies. A worktree sits inside the checkout it was cut from, so Node resolves
     anything the worktree lacks from the parent's `node_modules`: an install that stopped
@@ -212,7 +215,9 @@ values must be non-negative integers, with the narrower bounds stated below.
     every scan in it found nothing; `MAX_EMPTY_SCANS` consecutive empty cycles end the
     run early. The expected scan count (`queue/scan-expected-<n>`) and scan yield
     (`queue/scan-yield-<n>`) are recorded per cycle. Yields are folded into the empty
-    counter once, at the gate, only when every expected scan completed successfully.
+    counter once, at the gate, only when every expected scan completed successfully. A
+    scan launch failure stops the loop without advancing the cycle number, and a cycle
+    missing any expected yield stops rather than advancing to another cycle or completion.
     For parallel scans, sections in the rendered `scan-template.md` are Markdown ATX
     headings whose text begins with a number and period (for example, `### 1. Tests`),
     and every section number must be unique; headings inside fenced code blocks do not

--- a/SPEC.md
+++ b/SPEC.md
@@ -265,14 +265,14 @@ values must be non-negative integers, with the narrower bounds stated below.
     working tree or a pull conflict logs `WARN`, aborts any in-progress merge, and lets
     the cycle proceed unchanged so local divergence is resolved by the consumer.
     At the same boundary, the package manifest's skills are rendered into every
-    directory an agent working in the repository discovers skills in: the selected
-    runner's, supplied by its adapter, and `.claude/skills/` for the interactive agent a
-    person drives. The Codex adapter renders into repository root `.agents/skills/`; the
-    Claude adapter and interactive agent share `.claude/skills/` and are served once. The
-    Claude rendering resolves the command prefix only, the canonical sources already
-    being in that agent's format. Both use `npm run` as the command prefix in the owning
-    repository and `npm run -C <package-path>` in a subtree consumer, and a runner that
-    discovers `.claude/skills/` is served once rather than twice. The
+    directory selected by an agent adapter. The runner supplies its target, and the
+    project adapter supplies targets for additional interactive agents. The Codex adapter
+    renders into repository root `.agents/skills/`; this repository's project adapter
+    selects the Claude adapter, which renders into `.claude/skills/` and resolves only the
+    command prefix because the canonical sources already use that agent's format. Both use
+    `npm run` as the command prefix in the owning repository and
+    `npm run -C <package-path>` in a subtree consumer, and duplicate destinations are
+    served once. The
     sync replaces only a tree whose content matches its recorded last output; consumer
     divergence is warned and retained, and skills absent from the manifest are untouched.
     A destination that cannot be served is reported without costing the others theirs.
@@ -430,8 +430,9 @@ values must be non-negative integers, with the narrower bounds stated below.
     `NO_CHANGE_WARRANTED`, `NEXT_TASK:`, `DECISION_REQUIRED:` in the final-message file — plus effort/model
     arguments mapped to CLI flags, and the runner's own repository skill destination and
     rendering behavior inside the adapter. Any runner honoring the contract is
-    substitutable. The Claude runner uses the interactive agent's skill directory as its
-    own discovery path, so the shared-skill sync deduplicates that target.
+    substitutable. Additional interactive-agent skill destinations and rendering are
+    selected by the consumer's project adapter rather than assumed by the core. The Claude
+    runner and an interactive Claude adapter may share a destination, which is deduplicated.
 31. Everything the orchestration knows about the repository it runs in — which staged
     paths select fast pre-commit checks, which commands verify a merge, which paths make
     each check relevant, which suites prove a cycle's

--- a/SPEC.md
+++ b/SPEC.md
@@ -156,7 +156,10 @@ values must be non-negative integers, with the narrower bounds stated below.
    retryable and does not count toward the merge-failure limit. Scan tasks and `--inspect`
    tasks remain exempt because investigation normally produces no commits. A
    completed task that still records a runner PID has its process tree stopped and
-   verified gone before the merge can discard that PID or remove the worktree.
+   verified gone before the merge can discard that PID or remove the worktree. When all
+   of a task's commits become empty while rebasing because their changes are already on
+   the run branch, the task follows the same `no-change` completion path without
+   requiring the worker to have predicted that outcome.
 9. Before its merge gate, a completed local task branch is rebased onto the current run
    branch tip. This refresh is retained when a check fails, so the next attempt does not
    test the same stale branch again. A conflicting rebase is aborted and keeps both the

--- a/orchestration/project/project-core.ts
+++ b/orchestration/project/project-core.ts
@@ -1,4 +1,5 @@
 import type { MergeCheck, ProjectAdapter, SuiteStep } from '../../src/adapters/project.ts'
+import { createClaudeSharedSkills } from '../../src/adapters/shared-skills-claude.ts'
 
 // The package this adapter gates is the same one running the loop, so both gates are the
 // package's own checks: its source-language rule, the type checker the sources are
@@ -15,6 +16,7 @@ const SUITE = 'npm test -- --pool=threads --poolOptions.threads.singleThread'
 
 export const coreProject: ProjectAdapter = {
   name: 'core',
+  sharedSkills: [createClaudeSharedSkills()],
   verifyDependencyIsolation: true,
   integrationWorktreeSetup: [{
     label: 'Core dependencies',

--- a/skills/loop-start/SKILL.md
+++ b/skills/loop-start/SKILL.md
@@ -56,7 +56,8 @@ Work can be handed to a running loop without stopping it — `/loop-delegate`
 turns a decision from the conversation into a queued task the loop picks up on
 its next poll, ahead of any future scan.
 
-The daemon holds the code it started with. **Editing the loop source under `src` changes
+The daemon holds the code it started with. **Editing the loop source under
+`{{ORCHESTRATION_PACKAGE_PATH_PREFIX}}src` changes
 nothing until the loop is restarted**, and reporting that a fix took effect without
 restarting is how a fix gets credited that never ran.
 

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -1,5 +1,6 @@
 {
   "commandPrefixPlaceholder": "{{ORCHESTRATION_COMMAND_PREFIX}}",
+  "packagePathPrefixPlaceholder": "{{ORCHESTRATION_PACKAGE_PATH_PREFIX}}",
   "skills": [
     "git-commit",
     "git-merge",

--- a/src/adapters/forge-github.ts
+++ b/src/adapters/forge-github.ts
@@ -193,6 +193,12 @@ function isRateLimitFailure(error: unknown): boolean {
   return /rate.?limit|HTTP 429/i.test(commandErrorText(error))
 }
 
+function isMissingPrFailure(error: unknown): boolean {
+  const text = commandErrorText(error)
+  return /\bno (?:open )?pull requests found for branch\b/i.test(text)
+    || /\bCould not resolve to a PullRequest with the number of \d+\b/i.test(text)
+}
+
 function githubPrBody(body: string): string {
   // GitHub reads a bare #N in a PR body as an issue reference and links it to some
   // unrelated pull request from the repository's first week. This presentation rule
@@ -332,7 +338,10 @@ export function createGithubForge(
         stdout = await checkedGh(repoRoot, args)
       } catch (error) {
         if (error instanceof ForgeRateLimitError) throw error
-        return { state: 'none', isDraft: false, url: '', headSha: '', checks: [] }
+        if (isMissingPrFailure(error)) {
+          return { state: 'none', isDraft: false, url: '', headSha: '', checks: [] }
+        }
+        throw error
       }
       const data = parseGhJson(args, stdout, prStatusSchema)
       const state

--- a/src/adapters/project.ts
+++ b/src/adapters/project.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { basename, dirname, extname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import ts from 'typescript'
+import type { SharedSkillsAdapter } from './shared-skills.ts'
 
 // The project adapter carries everything the orchestration knows about the repository
 // it runs in: which checks verify a merge, which suites prove a cycle's tip, and which
@@ -102,6 +103,8 @@ export interface PullRequestPresentation {
 
 export interface ProjectAdapter {
   name: string
+  /** Additional agents a person may drive in this repository, independent of the runner. */
+  sharedSkills?: SharedSkillsAdapter[]
   /** Manual production deployment, when this repository has one. */
   deployment?: { workflow: string; revisionUrl: string }
   /** Whether pull requests are expected to receive CI checks. Omit when unknown. */

--- a/src/adapters/runner-claude.ts
+++ b/src/adapters/runner-claude.ts
@@ -4,11 +4,10 @@ import {
 } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { packageCommandPrefix } from '../paths.ts'
+import { createClaudeSharedSkills } from './shared-skills-claude.ts'
 import { startWindowsProcess } from './windows-process.ts'
 import type {
-  ReasoningEffort, Runner, RunnerLoadOptions, RunnerSharedSkillRenderOptions,
-  RunnerStartOptions,
+  ReasoningEffort, Runner, RunnerLoadOptions, RunnerStartOptions,
 } from './runner.ts'
 
 const DEFAULT_MODEL = 'claude-opus-5'
@@ -37,16 +36,6 @@ function buildArgs(
 ): string[] {
   const model = configuredModel(options.model, models[options.effort])
   return ['-p', '--permission-mode', 'bypassPermissions', '--model', model]
-}
-
-function renderSharedSkillFile(
-  contents: Buffer,
-  options: RunnerSharedSkillRenderOptions,
-): Buffer {
-  return Buffer.from(contents.toString('utf8').replaceAll(
-    options.commandPrefixPlaceholder,
-    packageCommandPrefix(options.repoRoot, options.packageRoot),
-  ))
 }
 
 function publishFinalMessage(file: string, contents: Buffer): void {
@@ -103,10 +92,7 @@ export function runClaudeProcess(
 export function createClaudeRunner(options: RunnerLoadOptions = {}): Runner {
   const models = effortModels(options)
   return {
-    sharedSkills: {
-      destinationRoot: (repoRoot) => join(repoRoot, '.claude', 'skills'),
-      renderFile: renderSharedSkillFile,
-    },
+    sharedSkills: createClaudeSharedSkills(),
     start(startOptions: RunnerStartOptions): Promise<number> {
       const wrapperArgs = [
         fileURLToPath(import.meta.url),

--- a/src/adapters/runner-codex.ts
+++ b/src/adapters/runner-codex.ts
@@ -89,8 +89,8 @@ export function createCodexRunner(): Runner {
   return {
     sharedSkills: {
       // `.claude/skills` was this runner's former discovery path, but it is not a legacy
-      // root: the interactive agent a person drives reads it, and the core keeps it
-      // filled. Claiming it here emptied it whenever Codex was the selected runner.
+      // root: a consumer may still select that interactive-agent target independently.
+      // Claiming it here would empty it whenever Codex was the selected runner.
       destinationRoot: (repoRoot) => join(repoRoot, '.agents', 'skills'),
       renderFile: renderSharedSkillFile,
     },

--- a/src/adapters/runner-codex.ts
+++ b/src/adapters/runner-codex.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process'
 import { closeSync, existsSync, openSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { packageCommandPrefix } from '../paths.ts'
+import { packageCommandPrefix, packagePathPrefix } from '../paths.ts'
 import { startWindowsProcess } from './windows-process.ts'
 import type {
   Runner, RunnerSharedSkillRenderOptions, RunnerStartOptions,
@@ -55,6 +55,10 @@ function renderSharedSkillFile(
     : 'AGENTS.md'
   text = text
     .replaceAll(options.commandPrefixPlaceholder, commandPrefix)
+    .replaceAll(
+      options.packagePathPrefixPlaceholder,
+      packagePathPrefix(options.repoRoot, options.packageRoot),
+    )
     .replaceAll('CLAUDE.md', guidanceFile)
     .replace(
       /\.claude\/skills\/([a-z][a-z0-9]*(?:-[a-z0-9]+)+)(\/SKILL\.md)?/g,

--- a/src/adapters/runner.ts
+++ b/src/adapters/runner.ts
@@ -6,6 +6,10 @@
 // `DECISION_REQUIRED: <text>` lines before it.
 // Markers anywhere else (the transcript log) are ignored by the core. SPEC.md item 30.
 
+import type { SharedSkillRenderOptions, SharedSkillsAdapter } from './shared-skills.ts'
+
+export type { SharedSkillRenderOptions, SharedSkillsAdapter } from './shared-skills.ts'
+
 export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high'
 
 export interface RunnerStartOptions {
@@ -22,20 +26,8 @@ export interface RunnerStartOptions {
   model?: string | undefined
 }
 
-export interface RunnerSharedSkillRenderOptions {
-  repoRoot: string
-  packageRoot: string
-  commandPrefixPlaceholder: string
-}
-
-export interface RunnerSharedSkills {
-  /** Absolute directory where this runner discovers repository-scoped skills. */
-  destinationRoot(repoRoot: string): string
-  /** Absolute former discovery directories whose generated skills may be migrated. */
-  legacyRoots?(repoRoot: string): string[]
-  /** Render a canonical shared-skill file into the runner's on-disk format. */
-  renderFile(contents: Buffer, options: RunnerSharedSkillRenderOptions): Buffer
-}
+export type RunnerSharedSkillRenderOptions = SharedSkillRenderOptions
+export type RunnerSharedSkills = SharedSkillsAdapter
 
 export interface Runner {
   /** Runner-specific repository skill discovery and rendering behavior. */

--- a/src/adapters/shared-skills-claude.ts
+++ b/src/adapters/shared-skills-claude.ts
@@ -1,0 +1,14 @@
+import { join } from 'node:path'
+import { packageCommandPrefix } from '../paths.ts'
+import type { SharedSkillsAdapter } from './shared-skills.ts'
+
+/** Repository-scoped skill discovery and rendering for an interactive Claude agent. */
+export function createClaudeSharedSkills(): SharedSkillsAdapter {
+  return {
+    destinationRoot: (repoRoot) => join(repoRoot, '.claude', 'skills'),
+    renderFile: (contents, options) => Buffer.from(contents.toString('utf8').replaceAll(
+      options.commandPrefixPlaceholder,
+      packageCommandPrefix(options.repoRoot, options.packageRoot),
+    )),
+  }
+}

--- a/src/adapters/shared-skills-claude.ts
+++ b/src/adapters/shared-skills-claude.ts
@@ -1,14 +1,19 @@
 import { join } from 'node:path'
-import { packageCommandPrefix } from '../paths.ts'
+import { packageCommandPrefix, packagePathPrefix } from '../paths.ts'
 import type { SharedSkillsAdapter } from './shared-skills.ts'
 
 /** Repository-scoped skill discovery and rendering for an interactive Claude agent. */
 export function createClaudeSharedSkills(): SharedSkillsAdapter {
   return {
     destinationRoot: (repoRoot) => join(repoRoot, '.claude', 'skills'),
-    renderFile: (contents, options) => Buffer.from(contents.toString('utf8').replaceAll(
-      options.commandPrefixPlaceholder,
-      packageCommandPrefix(options.repoRoot, options.packageRoot),
-    )),
+    renderFile: (contents, options) => Buffer.from(contents.toString('utf8')
+      .replaceAll(
+        options.commandPrefixPlaceholder,
+        packageCommandPrefix(options.repoRoot, options.packageRoot),
+      )
+      .replaceAll(
+        options.packagePathPrefixPlaceholder,
+        packagePathPrefix(options.repoRoot, options.packageRoot),
+      )),
   }
 }

--- a/src/adapters/shared-skills.ts
+++ b/src/adapters/shared-skills.ts
@@ -2,6 +2,7 @@ export interface SharedSkillRenderOptions {
   repoRoot: string
   packageRoot: string
   commandPrefixPlaceholder: string
+  packagePathPrefixPlaceholder: string
 }
 
 /** One agent's repository-scoped skill discovery and rendering behavior. */

--- a/src/adapters/shared-skills.ts
+++ b/src/adapters/shared-skills.ts
@@ -1,0 +1,15 @@
+export interface SharedSkillRenderOptions {
+  repoRoot: string
+  packageRoot: string
+  commandPrefixPlaceholder: string
+}
+
+/** One agent's repository-scoped skill discovery and rendering behavior. */
+export interface SharedSkillsAdapter {
+  /** Absolute directory where this agent discovers repository-scoped skills. */
+  destinationRoot(repoRoot: string): string
+  /** Absolute former discovery directories whose generated skills may be migrated. */
+  legacyRoots?(repoRoot: string): string[]
+  /** Render a canonical shared-skill file into this agent's on-disk format. */
+  renderFile(contents: Buffer, options: SharedSkillRenderOptions): Buffer
+}

--- a/src/branchTopology.ts
+++ b/src/branchTopology.ts
@@ -60,6 +60,12 @@ export function prepareBranchTopology(
   integrationBranch: string,
   packageRoot = PACKAGE_ROOT,
 ): BranchTopology {
+  const recordedBranch = readMarker(paths, 'integration-branch.txt')
+  if (recordedBranch !== undefined && recordedBranch !== integrationBranch) {
+    throw new Error(
+      `This run uses integration branch ${recordedBranch}; refusing ${integrationBranch || 'direct mode'}.`,
+    )
+  }
   if (integrationBranch === '') {
     return {
       paths,
@@ -75,15 +81,9 @@ export function prepareBranchTopology(
   if (daemonBranch === '') throw new Error('The daemon checkout must be on a branch.')
 
   git(paths.repoRoot, ['check-ref-format', '--branch', integrationBranch])
-  const recordedBranch = readMarker(paths, 'integration-branch.txt')
   const recordedDaemonBranch = readMarker(paths, 'daemon-branch.txt')
   const recordedDaemonHead = readMarker(paths, 'daemon-head.txt')
   const resuming = recordedBranch !== undefined
-  if (resuming && recordedBranch !== integrationBranch) {
-    throw new Error(
-      `This run uses integration branch ${recordedBranch}; refusing ${integrationBranch}.`,
-    )
-  }
   if (resuming && (recordedDaemonBranch !== daemonBranch || recordedDaemonHead !== daemonHead)) {
     throw new Error(
       `The resumed run is fixed to ${recordedDaemonBranch ?? '(unknown)'} at `

--- a/src/coreUpdate.ts
+++ b/src/coreUpdate.ts
@@ -70,29 +70,28 @@ function syncSkills(
   runtime: CoreUpdateRuntime,
 ): void {
   const sharedSkills = [runner.sharedSkills, ...(project.sharedSkills ?? [])]
-  const skippedDestinations: string[] = []
   if (isConsumer) {
-    try {
-      for (const target of sharedSkillManagedTargets(repoRoot, packageRoot, sharedSkills)) {
-        const managedPaths = repositoryPaths(repoRoot, target.managedPaths)
-        const alreadyStaged = runtime.git(repoRoot, [
+    for (const target of sharedSkillManagedTargets(repoRoot, packageRoot, sharedSkills)) {
+      const managedPaths = repositoryPaths(repoRoot, target.managedPaths)
+      let alreadyStaged: string
+      try {
+        alreadyStaged = runtime.git(repoRoot, [
           'diff', '--cached', '--name-only', '--', ...managedPaths,
         ]).trim()
-        if (alreadyStaged !== '') {
-          event('WARN',
-            `shared skill sync could not be committed: staged changes exist at ${alreadyStaged.replaceAll(/\r?\n/g, ', ')}`)
-          skippedDestinations.push(target.destinationRoot)
-        }
+      } catch (error) {
+        throw new Error(`shared skill sync could not verify a clean managed index: ${summary(error)}`)
       }
-    } catch (error) {
-      event('WARN', `shared skill sync could not be committed: ${summary(error)}`)
-      return
+      if (alreadyStaged !== '') {
+        throw new Error(
+          `shared skill sync requires a clean managed index: staged changes exist at ${alreadyStaged.replaceAll(/\r?\n/g, ', ')}`,
+        )
+      }
     }
   }
 
   let result: ReturnType<typeof syncSharedSkills>
   try {
-    result = syncSharedSkills(repoRoot, packageRoot, sharedSkills, undefined, skippedDestinations)
+    result = syncSharedSkills(repoRoot, packageRoot, sharedSkills)
   } catch (error) {
     event('WARN', `shared skill sync failed: ${summary(error)}`)
     return
@@ -110,17 +109,17 @@ function syncSkills(
   if (isConsumer) {
     const managed = repositoryPaths(repoRoot, result.managedPaths)
     const removed = repositoryPaths(repoRoot, result.removedPaths)
-    try {
-      const scope = [...managed, ...removed]
-      if (scope.length > 0) {
-        const alreadyStaged = runtime.git(repoRoot, [
-          'diff', '--cached', '--name-only', '--', ...scope,
-        ]).trim()
-        if (alreadyStaged !== '') {
-          event('WARN',
-            `shared skill sync could not be committed: staged changes exist at ${alreadyStaged.replaceAll(/\r?\n/g, ', ')}`)
-          return
-        }
+    const scope = [...managed, ...removed]
+    if (scope.length > 0) {
+      const alreadyStaged = runtime.git(repoRoot, [
+        'diff', '--cached', '--name-only', '--', ...scope,
+      ]).trim()
+      if (alreadyStaged !== '') {
+        throw new Error(
+          `shared skill sync requires a clean managed index: staged changes exist at ${alreadyStaged.replaceAll(/\r?\n/g, ', ')}`,
+        )
+      }
+      try {
         if (managed.length > 0) runtime.git(repoRoot, ['add', '-f', '--', ...managed])
         const trackedRemoved = removed.length === 0
           ? []
@@ -140,10 +139,9 @@ function syncSkills(
             ])
           }
         }
+      } catch (error) {
+        throw new Error(`shared skill sync could not be committed: ${summary(error)}`)
       }
-    } catch (error) {
-      event('WARN', `shared skill sync could not be committed: ${summary(error)}`)
-      return
     }
   }
 
@@ -217,21 +215,25 @@ export async function updateCoreBeforeCycle(
   let upstream: string
   try {
     upstream = runtime.git(paths.repoRoot, ['rev-parse', 'FETCH_HEAD']).trim()
-    if (upstream === imported) return finish('continue')
-    runtime.git(paths.repoRoot, ['merge-base', '--is-ancestor', imported, upstream])
+    if (upstream !== imported) {
+      runtime.git(paths.repoRoot, ['merge-base', '--is-ancestor', imported, upstream])
+    }
   } catch {
     warn(event,
       `core update skipped: imported ${imported.slice(0, 8)} is not behind ${config.upstreamBranch}`)
     return finish('continue')
   }
+  if (upstream === imported) return finish('continue')
 
+  let dirty: boolean
   try {
-    if (runtime.git(paths.repoRoot, ['status', '--porcelain']).trim() !== '') {
-      warn(event, 'core update skipped: working tree is dirty')
-      return finish('continue')
-    }
+    dirty = runtime.git(paths.repoRoot, ['status', '--porcelain']).trim() !== ''
   } catch (error) {
     warn(event, `core update status check failed: ${summary(error)}`)
+    return finish('continue')
+  }
+  if (dirty) {
+    warn(event, 'core update skipped: working tree is dirty')
     return finish('continue')
   }
 

--- a/src/coreUpdate.ts
+++ b/src/coreUpdate.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process'
 import { dirname, isAbsolute, join, relative, sep } from 'node:path'
 import type { LoopConfig } from './config.ts'
 import type { Forge } from './adapters/forge.ts'
+import type { ProjectAdapter } from './adapters/project.ts'
 import type { Runner } from './adapters/runner.ts'
 import { PACKAGE_ROOT, packageSubtreePrefix, type OrchPaths } from './paths.ts'
 import { sharedSkillManagedTargets, syncSharedSkills } from './sharedSkills.ts'
@@ -63,14 +64,16 @@ function syncSkills(
   repoRoot: string,
   packageRoot: string,
   runner: Runner,
+  project: ProjectAdapter,
   isConsumer: boolean,
   event: CoreUpdateEvent,
   runtime: CoreUpdateRuntime,
 ): void {
+  const sharedSkills = [runner.sharedSkills, ...(project.sharedSkills ?? [])]
   const skippedDestinations: string[] = []
   if (isConsumer) {
     try {
-      for (const target of sharedSkillManagedTargets(repoRoot, packageRoot, runner)) {
+      for (const target of sharedSkillManagedTargets(repoRoot, packageRoot, sharedSkills)) {
         const managedPaths = repositoryPaths(repoRoot, target.managedPaths)
         const alreadyStaged = runtime.git(repoRoot, [
           'diff', '--cached', '--name-only', '--', ...managedPaths,
@@ -89,7 +92,7 @@ function syncSkills(
 
   let result: ReturnType<typeof syncSharedSkills>
   try {
-    result = syncSharedSkills(repoRoot, packageRoot, runner, undefined, skippedDestinations)
+    result = syncSharedSkills(repoRoot, packageRoot, sharedSkills, undefined, skippedDestinations)
   } catch (error) {
     event('WARN', `shared skill sync failed: ${summary(error)}`)
     return
@@ -160,6 +163,7 @@ export async function updateCoreBeforeCycle(
     'coreAutoUpdate' | 'upstreamRemote' | 'upstreamBranch' | 'integrationBranch'>,
   forge: Forge,
   runner: Runner,
+  project: ProjectAdapter,
   cycle: number,
   event: CoreUpdateEvent,
   runtime: CoreUpdateRuntime = defaultRuntime,
@@ -175,12 +179,12 @@ export async function updateCoreBeforeCycle(
   // consumers. Only the owning repository receives local, ignored generated copies.
   if (prefix === undefined) {
     if (relative(paths.repoRoot, packageRoot) === '') {
-      syncSkills(paths.repoRoot, packageRoot, runner, false, event, runtime)
+      syncSkills(paths.repoRoot, packageRoot, runner, project, false, event, runtime)
     }
     return 'continue'
   }
   const finish = (outcome: CoreUpdateOutcome): CoreUpdateOutcome => {
-    syncSkills(paths.repoRoot, packageRoot, runner, true, event, runtime)
+    syncSkills(paths.repoRoot, packageRoot, runner, project, true, event, runtime)
     return outcome
   }
   if (config.upstreamRemote.trim() === '') {
@@ -246,7 +250,7 @@ export async function updateCoreBeforeCycle(
     return finish('continue')
   }
 
-  syncSkills(paths.repoRoot, packageRoot, runner, true, event, runtime)
+  syncSkills(paths.repoRoot, packageRoot, runner, project, true, event, runtime)
   const newHead = runtime.git(paths.repoRoot, ['rev-parse', 'HEAD']).trim()
   const changed = runtime.git(paths.repoRoot, [
     'diff', '--name-only', oldHead, newHead, '--', prefix,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -50,7 +50,7 @@ import {
   issueHasExactlyLifecycleLabel, issueNumberForTask, issueNumbersForTask, issuePromotionForIssue,
   missingRequirementCompletionMarkers, publishFinding, reapStaleLeases,
   completeIssueReleaseIntent, prepareIssueReleaseIntent, reconcileIssueReleaseIntent,
-  recordIssueCompletions, recordIssuesForTask, recordIssuePromotions, releaseIssueClaim,
+  recordIssueCompletions, recordIssueReleaseIntent, recordIssuesForTask, recordIssuePromotions,
   returnIssueToReady,
   ensureQueueLabels, reconcileClosedIssueLifecycleLabels, reconcileFindingFingerprints,
   unresolvedFindings, type ClaimedRequirement, IssueReleaseReconciliationError,
@@ -1599,7 +1599,9 @@ export function createLoop(deps: LoopDeps) {
       const repair = step.repairWhenMissing
       if (repair !== undefined && !existsSync(join(paths.repoRoot, repair.path))) {
         if (!runStep(join(paths.repoRoot, step.cwd), repair.command)) {
-          event('WARN', 'repair command could not restore the toolchain')
+          event('ERROR', repair.message)
+          writeFileSync(stopFile, '')
+          return false
         }
       }
       ok = runStep(join(paths.repoRoot, step.cwd), step.command)
@@ -1693,6 +1695,13 @@ export function createLoop(deps: LoopDeps) {
     }
 
     const currentScans = readCount(scanCountFile)
+    const expectedScanFile = join(paths.queueDir, `scan-expected-${currentScans}`)
+    if (currentScans > 0 && existsSync(expectedScanFile)
+      && completeScanYields(currentScans) === undefined) {
+      event('ERROR', `cycle ${currentScans} did not receive every expected scan yield; stopping the loop`)
+      writeFileSync(stopFile, '')
+      return 'continue'
+    }
 
     if (currentScans > 0 && (config.autoPr || config.reviewEnabled)) {
       const resumeFlag = join(paths.queueDir, `cycle-resume-${currentScans}`)
@@ -1876,11 +1885,9 @@ export function createLoop(deps: LoopDeps) {
         sectionGroups = partitionScanSections(sections, nScans)
       }
     }
-    writeFileSync(join(paths.queueDir, `scan-expected-${nextCycle}`), `${nScans}\n`)
-    writeFileSync(scanCountFile, `${nextCycle}\n`)
-
     // Round-robin groups cover every discovered section exactly once while keeping
     // group sizes within one, without assuming what any section asks the scan to do.
+    let launchFailed = false
     for (let i = 1; i <= nScans; i++) {
       const scanId = newTaskId(paths, 'scan', now())
       const scope = nScans === 1
@@ -1895,9 +1902,17 @@ export function createLoop(deps: LoopDeps) {
         })
         event('Started', shortTaskId(scanId), `scan ${i}/${nScans}`)
       } catch (error) {
-        event('WARN', `scan startup failed: ${errorSummary(error)} (log: ${shortLogPath(logFile(paths, scanId))})`)
+        event('ERROR', `scan startup failed: ${errorSummary(error)} (log: ${shortLogPath(logFile(paths, scanId))}); stopping the loop`)
+        launchFailed = true
+        break
       }
     }
+    if (launchFailed) {
+      writeFileSync(stopFile, '')
+      return 'continue'
+    }
+    writeFileSync(join(paths.queueDir, `scan-expected-${nextCycle}`), `${nScans}\n`)
+    writeFileSync(scanCountFile, `${nextCycle}\n`)
     return 'continue'
   }
 
@@ -2143,15 +2158,13 @@ export function createLoop(deps: LoopDeps) {
       const failedFlag = join(scannedDir, `${taskId}.failed`)
       const failedIssues = status === 'failed' ? issueNumbersForTask(paths, taskId) : []
       if (failedIssues.length > 0 && remoteOperationsAvailable) {
-        try {
-          await Promise.all(failedIssues.map((issueNumber) =>
-            returnIssueToReady(forge, issueNumber, true)))
-          dropClaimedTaskMaterialization(paths, taskId)
+        recordIssueReleaseIntent(paths, taskId, failedIssues)
+        const failures = await reconcileIssueReleaseIntent(forge, paths, taskId)
+        if (failures.length === 0) {
           event('Released', shortTaskId(taskId), 'grouped task failed')
-        } catch (releaseError) {
-          if (!(releaseError instanceof ForgeRateLimitError)) {
-            event('WARN', `${shortTaskId(taskId)} failed and its grouped issues could not all be released: ${errorSummary(releaseError)}`)
-          }
+        } else {
+          issueReconciliationPending = true
+          noteIssueReleaseFailure(new IssueReleaseReconciliationError(failures))
         }
       }
       if (status === 'failed' && !existsSync(failedFlag)) {
@@ -2356,20 +2369,14 @@ export function createLoop(deps: LoopDeps) {
           if (config.issueQueueEnabled && issueNumbers.length > 0) {
             let released = false
             if (remoteOperationsAvailable) {
-              try {
-                if (cachedUser === undefined) cachedUser = await forge.currentUser()
-                if (issueNumbers.length > 1) {
-                  await Promise.all(issueNumbers.map((issueNumber) =>
-                    returnIssueToReady(forge, issueNumber, true)))
-                } else {
-                  await releaseIssueClaim(forge, issueNumbers[0]!, cachedUser)
-                }
+              recordIssueReleaseIntent(paths, entry.taskId, issueNumbers)
+              const failures = await reconcileIssueReleaseIntent(forge, paths, entry.taskId)
+              if (failures.length === 0) {
                 released = true
                 event('Released', shortTaskId(entry.taskId), 'startup failed')
-              } catch (releaseError) {
-                if (!(releaseError instanceof ForgeRateLimitError)) {
-                  event('WARN', `${shortTaskId(entry.taskId)} startup failed and issues ${issueNumbers.map((number) => `#${number}`).join(' ')} could not all be released: ${errorSummary(releaseError)}`)
-                }
+              } else {
+                issueReconciliationPending = true
+                noteIssueReleaseFailure(new IssueReleaseReconciliationError(failures))
               }
             }
             if (released) {
@@ -2380,9 +2387,8 @@ export function createLoop(deps: LoopDeps) {
                 event('WARN', `${shortTaskId(entry.taskId)} startup cleanup failed: ${errorSummary(cleanupError)}`)
               }
             } else {
-              requeueAfterStartupFailure(entry.taskId, entry.depth, error)
-              // Do not dequeue the same retained materialization again in this poll.
-              // The next poll retries the release while keeping the forge claim linked.
+              // The durable release intent owns the retry. Keep the task mapping linked
+              // until reconciliation succeeds, but do not restart work for that claim.
               break
             }
           } else {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2021,7 +2021,7 @@ export function createLoop(deps: LoopDeps) {
             if (linkedIssues.length > 0) {
               await Promise.all(linkedIssues.map((issueNumber) =>
                 closeIssueAndRemoveLifecycleLabels(forge, issueNumber,
-                  `Task ${taskId} completed without commits after reporting that no change was warranted.`)))
+                  `Task ${taskId} completed without changes because no change was warranted.`)))
             }
             recordIssueCompletions(paths, taskId, 'no-change')
           },

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -194,6 +194,7 @@ export function createLoop(deps: LoopDeps) {
       config,
       rawForge,
       runner,
+      project,
       cycle,
       (name, subject, detail = '') => event(name, subject, detail),
     ))

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -317,6 +317,15 @@ function rebaseTaskOntoRunTip(
   }
 }
 
+/** Whether every task commit has the same tree as its parent. */
+function taskCommitsAreEmpty(worktree: string, currentBranch: string): boolean {
+  const commits = git(worktree, ['rev-list', '--reverse', `${currentBranch}..HEAD`])
+    .trim().split(/\s+/).filter((commit) => commit !== '')
+  return commits.every((commit) =>
+    git(worktree, ['rev-parse', `${commit}^{tree}`]).trim()
+      === git(worktree, ['rev-parse', `${commit}^1^{tree}`]).trim())
+}
+
 function mergeIo(outputFile?: string): MergeIo {
   const out = (text: string): void => {
     if (outputFile !== undefined) {
@@ -752,6 +761,15 @@ async function mergeTaskWithGuardHeld(
     }
   }
   rebaseTaskOntoRunTip(worktree, currentBranch, io)
+  if (!isInspectionTaskId(paths, taskId) && taskCommitsAreEmpty(worktree, currentBranch)) {
+    if (closingIssues.length > 0 && options.onNoChange === undefined) {
+      throw new NoChangeReconciliationError(
+        'A linked no-change task requires issue reconciliation.',
+      )
+    }
+    await finalizeNoChange(paths, taskId, branch, worktree, io, options)
+    return { outcome: 'no-change' }
+  }
   const prospectiveWorktree = join(
     paths.worktreesDir, `.merge-${shortTaskId(taskId)}-${process.pid}-${Date.now()}`,
   )

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -38,6 +38,12 @@ export function packageCommandPrefix(repoRoot: string, packageRoot = PACKAGE_ROO
   return packageDirectory === '' ? 'npm run' : `npm run -C ${packageArgument}`
 }
 
+/** Prefix a repository-relative package file, including its separator when needed. */
+export function packagePathPrefix(repoRoot: string, packageRoot = PACKAGE_ROOT): string {
+  const packageDirectory = relative(repoRoot, packageRoot).replaceAll('\\', '/')
+  return packageDirectory === '' ? '' : `${packageDirectory}/`
+}
+
 export function packageScriptCommand(
   repoRoot: string,
   script: string,

--- a/src/restart.ts
+++ b/src/restart.ts
@@ -142,29 +142,38 @@ export async function startLoopReplacement(
       if (result.ok) replacement.release()
       resolve(result)
     }
+    const fail = (result: LoopRestartResult): void => {
+      if (settled) return
+      let terminationError: string | undefined
+      let cleanupError: string | undefined
+      try {
+        os.terminateProcessTree(pid)
+      } catch (error) {
+        terminationError = errorSummary(error)
+      }
+      try {
+        if (os.processTreeIsAlive(pid)) {
+          cleanupError = terminationError ?? `Could not stop process tree ${pid}.`
+        }
+      } catch (error) {
+        cleanupError = errorSummary(error)
+      }
+      finish(cleanupError === undefined ? result : {
+        ...result,
+        error: `${result.error ?? 'replacement startup failed'}; replacement cleanup failed: ${cleanupError}`,
+      })
+    }
     const onError = (error: Error): void => {
       spawnError = errorSummary(error)
-      finish({ ok: false, pid, error: spawnError })
+      fail({ ok: false, pid, error: spawnError })
     }
     const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
       const outcome = code === null ? `signal ${signal ?? 'unknown'}` : `exit code ${code}`
-      finish({
+      fail({
         ok: false,
         pid,
         error: spawnError ?? `replacement exited before becoming ready (${outcome})`,
       })
-    }
-    const terminateAndFinish = (result: LoopRestartResult): void => {
-      try {
-        replacement.terminate()
-      } catch (error) {
-        finish({
-          ...result,
-          error: `${result.error ?? 'replacement startup failed'}; replacement cleanup failed: ${errorSummary(error)}`,
-        })
-        return
-      }
-      finish(result)
     }
     const poll = setInterval(() => {
       if (!existsSync(readyFile)) return
@@ -175,7 +184,7 @@ export async function startLoopReplacement(
         return
       }
       if (owner !== `${pid}`) {
-        terminateAndFinish({
+        fail({
           ok: false,
           pid,
           error: `replacement published an unexpected PID (${owner || 'empty'})`,
@@ -183,19 +192,19 @@ export async function startLoopReplacement(
         return
       }
       if (!replacement.isAlive()) {
-        finish({ ok: false, pid, error: 'replacement exited before becoming ready' })
+        fail({ ok: false, pid, error: 'replacement exited before becoming ready' })
         return
       }
       try {
         runtime.onReady?.(pid)
       } catch (error) {
-        terminateAndFinish({ ok: false, pid, error: errorSummary(error) })
+        fail({ ok: false, pid, error: errorSummary(error) })
         return
       }
       finish({ ok: true, pid })
     }, 10)
     const timeout = setTimeout(() => {
-      terminateAndFinish({
+      fail({
         ok: false,
         pid,
         error: 'replacement did not become ready before the startup timeout',

--- a/src/sharedSkills.ts
+++ b/src/sharedSkills.ts
@@ -5,8 +5,7 @@ import {
 } from 'node:fs'
 import { dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { operatingSystem, type OperatingSystem } from './adapters/os.ts'
-import { packageCommandPrefix } from './paths.ts'
-import type { Runner, RunnerSharedSkillRenderOptions } from './adapters/runner.ts'
+import type { SharedSkillRenderOptions, SharedSkillsAdapter } from './adapters/shared-skills.ts'
 
 const STATE_FILE = '.orchestration-core-sync.json'
 
@@ -20,7 +19,7 @@ const STATE_FILE = '.orchestration-core-sync.json'
 interface SharedSkillTarget {
   destinationRoot: string
   legacyRoots: readonly string[]
-  renderFile(contents: Buffer, options: RunnerSharedSkillRenderOptions): Buffer
+  renderFile(contents: Buffer, options: SharedSkillRenderOptions): Buffer
 }
 
 interface SharedSkillsManifest {
@@ -59,10 +58,10 @@ export interface SharedSkillManagedTarget {
 export function sharedSkillManagedTargets(
   repoRoot: string,
   packageRoot: string,
-  runner: Runner,
+  adapters: readonly SharedSkillsAdapter[],
 ): SharedSkillManagedTarget[] {
   const manifest = readManifest(packageRoot)
-  return skillTargets(repoRoot, runner).map((target) => {
+  return skillTargets(repoRoot, adapters).map((target) => {
     const paths = [join(target.destinationRoot, STATE_FILE)]
     paths.push(...manifest.skills.map((skill) => join(target.destinationRoot, skill)))
     for (const legacyRoot of target.legacyRoots) {
@@ -148,35 +147,26 @@ function renderedSkill(
   }))
 }
 
-/**
- * The interactive agent a person drives in the repository. The canonical skills are
- * authored in its format already — frontmatter, `!`command`` preambles and `/skill`
- * invocations are its own conventions — so only the command prefix is resolved here.
- */
-function interactiveAgentTarget(repoRoot: string): SharedSkillTarget {
-  return {
-    destinationRoot: join(repoRoot, '.claude', 'skills'),
-    legacyRoots: [],
-    renderFile: (contents, options) => Buffer.from(contents.toString('utf8').replaceAll(
-      options.commandPrefixPlaceholder,
-      packageCommandPrefix(options.repoRoot, options.packageRoot),
-    )),
-  }
-}
-
 /** Every directory this repository's skills must appear in, each listed once. */
-function skillTargets(repoRoot: string, runner: Runner): SharedSkillTarget[] {
-  const runnerTarget: SharedSkillTarget = {
-    destinationRoot: runner.sharedSkills.destinationRoot(repoRoot),
-    legacyRoots: runner.sharedSkills.legacyRoots?.(repoRoot) ?? [],
-    renderFile: (contents, options) => runner.sharedSkills.renderFile(contents, options),
+function skillTargets(
+  repoRoot: string,
+  adapters: readonly SharedSkillsAdapter[],
+): SharedSkillTarget[] {
+  const targets: SharedSkillTarget[] = []
+  for (const adapter of adapters) {
+    const target: SharedSkillTarget = {
+      destinationRoot: adapter.destinationRoot(repoRoot),
+      legacyRoots: adapter.legacyRoots?.(repoRoot) ?? [],
+      renderFile: (contents, options) => adapter.renderFile(contents, options),
+    }
+    // One directory has one reader format. A duplicate adapter cannot safely render it
+    // again because whichever target ran second would overwrite the first description.
+    if (targets.some((existing) => relative(
+      existing.destinationRoot, target.destinationRoot,
+    ) === '')) continue
+    targets.push(target)
   }
-  const interactive = interactiveAgentTarget(repoRoot)
-  // A runner that reads the interactive agent's directory is that agent: rendering the
-  // same directory twice would leave whichever target ran second describing the tree.
-  return relative(runnerTarget.destinationRoot, interactive.destinationRoot) === ''
-    ? [runnerTarget]
-    : [runnerTarget, interactive]
+  return targets
 }
 
 function hashFiles(files: readonly RenderedFile[]): string {
@@ -360,7 +350,7 @@ function syncTarget(
 export function syncSharedSkills(
   repoRoot: string,
   packageRoot: string,
-  runner: Runner,
+  adapters: readonly SharedSkillsAdapter[],
   os: OperatingSystem = operatingSystem,
   skippedDestinationRoots: readonly string[] = [],
 ): SharedSkillsSyncResult {
@@ -368,7 +358,7 @@ export function syncSharedSkills(
     installed: [], updated: [], conflicts: [], migrationConflicts: [],
     removedPaths: [], changedPaths: [], managedPaths: [], failures: [],
   }
-  for (const target of skillTargets(repoRoot, runner)) {
+  for (const target of skillTargets(repoRoot, adapters)) {
     if (skippedDestinationRoots.some((root) => relative(root, target.destinationRoot) === '')) {
       continue
     }

--- a/src/sharedSkills.ts
+++ b/src/sharedSkills.ts
@@ -24,6 +24,7 @@ interface SharedSkillTarget {
 
 interface SharedSkillsManifest {
   commandPrefixPlaceholder: string
+  packagePathPrefixPlaceholder: string
   skills: string[]
 }
 
@@ -85,8 +86,11 @@ function readManifest(packageRoot: string): SharedSkillsManifest {
   const file = join(packageRoot, 'skills', 'manifest.json')
   const parsed = object(JSON.parse(readFileSync(file, 'utf8')))
   const placeholder = parsed?.commandPrefixPlaceholder
+  const packagePathPrefixPlaceholder = parsed?.packagePathPrefixPlaceholder
   const skills = parsed?.skills
-  if (typeof placeholder !== 'string' || placeholder === '' || !Array.isArray(skills)
+  if (typeof placeholder !== 'string' || placeholder === ''
+    || typeof packagePathPrefixPlaceholder !== 'string' || packagePathPrefixPlaceholder === ''
+    || !Array.isArray(skills)
     || skills.some((skill) => typeof skill !== 'string'
       || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(skill))) {
     throw new Error(`invalid shared skills manifest: ${file}`)
@@ -94,7 +98,11 @@ function readManifest(packageRoot: string): SharedSkillsManifest {
   if (new Set(skills).size !== skills.length) {
     throw new Error(`duplicate skill in shared skills manifest: ${file}`)
   }
-  return { commandPrefixPlaceholder: placeholder, skills: skills as string[] }
+  return {
+    commandPrefixPlaceholder: placeholder,
+    packagePathPrefixPlaceholder,
+    skills: skills as string[],
+  }
 }
 
 function readState(file: string): SharedSkillsState {
@@ -129,7 +137,7 @@ function filesIn(root: string, current = root): RenderedFile[] {
 function renderedSkill(
   packageRoot: string,
   skill: string,
-  placeholder: string,
+  manifest: SharedSkillsManifest,
   repoRoot: string,
   target: SharedSkillTarget,
 ): RenderedFile[] {
@@ -142,7 +150,8 @@ function renderedSkill(
     contents: target.renderFile(file.contents, {
       repoRoot,
       packageRoot,
-      commandPrefixPlaceholder: placeholder,
+      commandPrefixPlaceholder: manifest.commandPrefixPlaceholder,
+      packagePathPrefixPlaceholder: manifest.packagePathPrefixPlaceholder,
     }),
   }))
 }
@@ -289,7 +298,7 @@ function syncTarget(
   for (const skill of manifest.skills) {
     const destination = join(destinationRoot, skill)
     const desiredFiles = renderedSkill(
-      packageRoot, skill, manifest.commandPrefixPlaceholder, repoRoot, target,
+      packageRoot, skill, manifest, repoRoot, target,
     )
     const desiredHash = hashFiles(desiredFiles)
     const previousHash = state.skills[skill]

--- a/tests/__snapshots__/runner-codex.test.ts.snap
+++ b/tests/__snapshots__/runner-codex.test.ts.snap
@@ -372,7 +372,8 @@ Work can be handed to a running loop without stopping it — \`$loop-delegate\`
 turns a decision from the conversation into a queued task the loop picks up on
 its next poll, ahead of any future scan.
 
-The daemon holds the code it started with. **Editing the loop source under \`src\` changes
+The daemon holds the code it started with. **Editing the loop source under
+\`src\` changes
 nothing until the loop is restarted**, and reporting that a fix took effect without
 restarting is how a fix gets credited that never ran.
 

--- a/tests/branch-topology.test.ts
+++ b/tests/branch-topology.test.ts
@@ -327,6 +327,13 @@ describe('integration branch topology', () => {
       .toThrow('The resumed run is fixed')
   })
 
+  it('refuses direct mode when resuming an integration run', () => {
+    prepareBranchTopology(paths, 'integration/run')
+
+    expect(() => prepareBranchTopology(paths, ''))
+      .toThrow('This run uses integration branch integration/run; refusing direct mode.')
+  })
+
   it('installs integration dependencies through adapter-owned setup', () => {
     const topology = prepareBranchTopology(paths, 'integration/run')
     const reported: string[] = []

--- a/tests/core-update.test.ts
+++ b/tests/core-update.test.ts
@@ -337,7 +337,7 @@ describe('pre-cycle core update', () => {
     )
   })
 
-  it('skips a staged skill destination while syncing and committing the other destination', async () => {
+  it('requires managed staged changes to be cleared before syncing any destination', async () => {
     const installed = join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md')
     const generated = readFileSync(installed)
     writeFileSync(join(packageRoot, 'skills', 'loop-start', 'SKILL.md'), 'version two\n')
@@ -347,23 +347,44 @@ describe('pre-cycle core update', () => {
     writeFileSync(installed, generated)
     const loop = makeLoop(config())
 
-    expect(await loop.poll(), events.join('\n')).toBe('continue')
+    await expect(loop.poll()).rejects.toThrow(
+      'shared skill sync requires a clean managed index',
+    )
     expect(readFileSync(installed, 'utf8').replaceAll('\r', ''))
       .toBe('version one: npm run -C orchestration/ts loop\n')
     expect(readFileSync(join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md'), 'utf8')
       .replaceAll('\r', ''))
-      .toBe('version two\n')
+      .toBe('version one: npm run -C orchestration/ts loop\n')
     expect(git(repoRoot, ['show', ':.agents/skills/loop-start/SKILL.md'])
       .replaceAll('\r', ''))
       .toBe('staged consumer command')
-    expect(git(repoRoot, ['show', 'HEAD:.claude/skills/loop-start/SKILL.md'])
-      .replaceAll('\r', ''))
-      .toBe('version two')
     expect(git(repoRoot, ['status', '--short']))
       .toBe('MM .agents/skills/loop-start/SKILL.md')
-    expect(events.some((line) => line.startsWith(
-      'WARN shared skill sync could not be committed: staged changes exist at',
-    )), events.join('\n')).toBe(true)
+    expect(runnerStarts).toHaveLength(0)
+  })
+
+  it('stops after a skill commit failure and refuses to resume with its staged output', async () => {
+    const bundled = join(packageRoot, 'skills', 'loop-start', 'SKILL.md')
+    writeFileSync(bundled, 'version two: {{ORCHESTRATION_COMMAND_PREFIX}} loop-status\n')
+    commit(repoRoot, 'test: update bundled skill fixture')
+    const failingGit = vi.fn((root: string, args: string[]) => {
+      if (args[0] === 'commit') throw new Error('simulated commit failure')
+      return git(root, args)
+    })
+    const loop = makeLoop(config(), { packageRoot, git: failingGit })
+
+    await expect(loop.poll()).rejects.toThrow(
+      'shared skill sync could not be committed: simulated commit failure',
+    )
+    expect(runnerStarts).toHaveLength(0)
+    expect(git(repoRoot, ['diff', '--cached', '--name-only']))
+      .toContain('.agents/skills/loop-start/SKILL.md')
+
+    const resumedLoop = makeLoop(config())
+    await expect(resumedLoop.poll()).rejects.toThrow(
+      'shared skill sync requires a clean managed index',
+    )
+    expect(runnerStarts).toHaveLength(0)
   })
 
   it('syncs managed skills while preserving an unrelated staged repository skill', async () => {

--- a/tests/core-update.test.ts
+++ b/tests/core-update.test.ts
@@ -113,6 +113,7 @@ beforeEach(() => {
   mkdirSync(join(upstreamRoot, 'skills'), { recursive: true })
   writeFileSync(join(upstreamRoot, 'skills', 'manifest.json'), JSON.stringify({
     commandPrefixPlaceholder: '{{ORCHESTRATION_COMMAND_PREFIX}}',
+    packagePathPrefixPlaceholder: '{{ORCHESTRATION_PACKAGE_PATH_PREFIX}}',
     skills: ['loop-start'],
   }))
   writeUpstreamSkill('version one: {{ORCHESTRATION_COMMAND_PREFIX}} loop\n')

--- a/tests/core-update.test.ts
+++ b/tests/core-update.test.ts
@@ -95,7 +95,7 @@ function makeLoop(
     now: () => new Date(2026, 7, 12, 0, 0, 0),
     updateCoreBeforeCycle: (cycle) =>
       updateCoreBeforeCycle(
-        paths, coreConfig, forge, runner, cycle, event as CoreUpdateEvent, runtime,
+        paths, coreConfig, forge, runner, stubProject, cycle, event as CoreUpdateEvent, runtime,
       ),
   })
   loop.initializeSessionStateForBranch()
@@ -135,10 +135,9 @@ beforeEach(() => {
   ])
 
   packageRoot = join(repoRoot, 'orchestration', 'ts')
-  syncSharedSkills(repoRoot, packageRoot, {
-    sharedSkills: fakeRunnerSharedSkills,
-    start: async () => process.pid,
-  })
+  syncSharedSkills(repoRoot, packageRoot, [
+    fakeRunnerSharedSkills, ...(stubProject.sharedSkills ?? []),
+  ])
   commit(repoRoot, 'chore: install shared skills')
   paths = orchPaths(repoRoot)
   events = []
@@ -207,6 +206,7 @@ describe('pre-cycle core update', () => {
       coreConfig,
       makeFakeForge(),
       { sharedSkills: fakeRunnerSharedSkills, start: async () => process.pid },
+      stubProject,
       2,
       event as CoreUpdateEvent,
       { packageRoot, git },
@@ -281,13 +281,16 @@ describe('pre-cycle core update', () => {
     // `.claude/skills` as a legacy root and emptied it. A repository carrying that
     // arrangement must come out of an update with both directories filled, not one.
     rmSync(join(repoRoot, '.agents'), { recursive: true })
-    syncSharedSkills(repoRoot, packageRoot, {
+    const formerRunner: Runner = {
       sharedSkills: {
         ...fakeRunnerSharedSkills,
         destinationRoot: (root) => join(root, '.claude', 'skills'),
       },
       start: async () => process.pid,
-    })
+    }
+    syncSharedSkills(repoRoot, packageRoot, [
+      formerRunner.sharedSkills, ...(stubProject.sharedSkills ?? []),
+    ])
     commit(repoRoot, 'chore: adopt the former arrangement')
     const oldHead = git(repoRoot, ['rev-parse', 'HEAD'])
     const loop = makeLoop(config())

--- a/tests/forge-github.test.ts
+++ b/tests/forge-github.test.ts
@@ -388,6 +388,38 @@ describe('GitHub forge JSON schemas', () => {
     ]])
   })
 
+  it.each([
+    'no pull requests found for branch "task/branch"',
+    'no open pull requests found for branch "task/branch"',
+    'GraphQL: Could not resolve to a PullRequest with the number of 12. (repository.pullRequest)',
+  ])('reports none only when gh confirms the pull request is missing: %s', async (stderr) => {
+    const command: GithubCommand = async () => {
+      const error = new Error('Command failed: gh pr view') as Error & { stderr: string }
+      error.stderr = stderr
+      throw error
+    }
+
+    await expect(createGithubForge('repo-root', command).prStatus({
+      kind: 'branch', value: 'task/branch',
+    })).resolves.toEqual({
+      state: 'none', isDraft: false, url: '', headSha: '', checks: [],
+    })
+  })
+
+  it.each([
+    'failed to connect to github.com',
+    'HTTP 503: Service Unavailable',
+    'GraphQL: Resource not accessible by integration',
+  ])('rethrows a gh pr view outage instead of reporting none: %s', async (stderr) => {
+    const failure = new Error('Command failed: gh pr view') as Error & { stderr: string }
+    failure.stderr = stderr
+    const command: GithubCommand = async () => { throw failure }
+
+    await expect(createGithubForge('repo-root', command).prStatus({
+      kind: 'branch', value: 'task/branch',
+    })).rejects.toBe(failure)
+  })
+
   it('queries the GraphQL reset when a rate-limit error does not report one', async () => {
     const calls: string[][] = []
     const command: GithubCommand = async (_root, args) => {

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -1048,6 +1048,26 @@ describe('claimIssue', () => {
     expect(after.labels).toContain(LABEL_READY)
   })
 
+  it('releases its assignment when the lifecycle changes immediately after assignment', async () => {
+    const issueNumber = await readyIssue('[BUG] `src/a/b.ts` changes during assignment')
+    const issue = await forge.getIssue(issueNumber)
+    const assignIssue = forge.assignIssue.bind(forge)
+    const removeLabel = forge.removeLabel.bind(forge)
+    forge.assignIssue = async (number, assignee) => {
+      await assignIssue(number, assignee)
+      if (number === issueNumber) await removeLabel(number, LABEL_READY)
+    }
+
+    const result = await claimIssue(forge, paths, issue, 'worker-a', appendRequirement)
+
+    expect(result).toEqual({ outcome: 'lost-race', issueNumber })
+    const after = await forge.getIssue(issueNumber)
+    expect(after.assignees).toEqual([])
+    expect(after.labels).not.toContain(LABEL_IN_PROGRESS)
+    expect(existsSync(join(paths.queueDir, 'backlog.txt'))).toBe(false)
+    expect(readdirSync(paths.tasksDir)).toEqual([])
+  })
+
   it('releases the assignment when the first post-assignment read fails', async () => {
     const issueNumber = await readyIssue('[BUG] `src/a/b.ts` breaks during claim verification')
     const issue = await forge.getIssue(issueNumber)

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -3285,6 +3285,25 @@ describe('runCycleSuite', () => {
     expect(logged).toContain('Started Suite       cycle 1')
   })
 
+  it('stops before running a Docker suite when its probe is not configured', () => {
+    const suiteProject: ProjectAdapter = {
+      ...stubProject,
+      cycleSuite: () => [{
+        label: 'Docker suite', cwd: '',
+        command: `node -e "require('node:fs').writeFileSync('suite-ran', '')"`,
+        needsDocker: true,
+      }],
+    }
+    const loop = makeLoop({ taskGate: 'light' }, suiteProject)
+
+    expect(existsSync(stopFile())).toBe(false)
+    expect(loop.runCycleSuite(1)).toBe(false)
+
+    expect(logText()).toContain('ERROR cycle suite infrastructure probe is not configured')
+    expect(existsSync(stopFile())).toBe(true)
+    expect(existsSync(join(repoRoot, 'suite-ran'))).toBe(false)
+  })
+
   it('stops before running suite steps when the Docker probe fails', () => {
     const suiteProject: ProjectAdapter = {
       ...stubProject,

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -412,6 +412,45 @@ describe('forge poll budget', () => {
     expect(existsSync(join(paths.tasksDir, `${failedTaskId}.md`))).toBe(false)
   })
 
+  it('persists a failed-task release and stops after three failed reconciliations', async () => {
+    initializeGitRepo()
+    const loop = makeLoop({
+      issueQueueEnabled: true, scanEnabled: false, autoMerge: false, maxParallel: 1,
+    })
+    loop.initializeSessionStateForBranch()
+    const description = '[BUG] `src/single.ts` retain an unreleasable failed task'
+    const issueNumber = await fakeForge.createIssue({
+      title: description,
+      body: buildIssueBody(description, 'scan-task'),
+      labels: [LABEL_FINDING, LABEL_READY],
+    })
+
+    await loop.poll()
+    const failedTaskId = readdirSync(paths.statusDir)[0]!.replace(/\.json$/, '')
+    writeRawStatus(failedTaskId, 'failed')
+    const addLabel = fakeForge.addLabel.bind(fakeForge)
+    fakeForge.addLabel = async (number, label) => {
+      if (number === issueNumber && label === LABEL_READY) throw new Error('forge unavailable')
+      await addLabel(number, label)
+    }
+
+    expect(await loop.poll()).toBe('continue')
+    expect(readFileSync(join(paths.queueDir, 'issue-release-intent', failedTaskId), 'utf8'))
+      .toBe(`${issueNumber}\n`)
+    expect(readFileSync(join(paths.queueDir, 'issue-release-failure-count.txt'), 'utf8'))
+      .toBe('1\n')
+
+    expect(await loop.poll()).toBe('continue')
+    expect(await loop.poll()).toBe('continue')
+
+    expect(readFileSync(join(paths.queueDir, 'issue-release-failure-count.txt'), 'utf8'))
+      .toBe('3\n')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(logText()).toContain(
+      `ERROR 3 consecutive issue release failures for #${issueNumber}; stopping the loop`,
+    )
+  })
+
   it('warns with the outsider login and leaves an untrusted issue unclaimed', async () => {
     initializeGitRepo()
     const loop = makeLoop({
@@ -1247,6 +1286,7 @@ describe('cycle gate', () => {
   ])('partitions $sectionCount scan sections across $scanParallel scans', async ({
     sectionCount, scanParallel,
   }) => {
+    initializeGitRepo()
     mkdirSync(join(paths.root, 'templates'), { recursive: true })
     const sections = Array.from(
       { length: sectionCount },
@@ -1348,6 +1388,54 @@ describe('cycle gate', () => {
     expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
     expect(logText()).toContain(
       'ERROR scan-template.md is unusable: it must contain unique numbered Markdown headings outside fenced code blocks',
+    )
+  })
+
+  it('stops without advancing the cycle when any scan fails to launch', async () => {
+    initializeGitRepo()
+    mkdirSync(join(paths.root, 'templates'), { recursive: true })
+    writeFileSync(
+      join(paths.root, 'templates', 'scan-template.md'),
+      '# {{SCAN_ID}}\n\n{{SCAN_SCOPE}}\n### 1. First check\n### 2. Second check\n',
+    )
+    let starts = 0
+    const runner: Runner = {
+      sharedSkills: fakeRunnerSharedSkills,
+      start: async () => {
+        starts += 1
+        if (starts === 2) throw new Error('runner unavailable')
+        return process.pid
+      },
+    }
+    const loop = makeLoop(
+      { scanParallel: 2, autoPr: false, reviewEnabled: false },
+      stubProject, undefined, undefined, runner,
+    )
+
+    expect(await loop.triggerScanIfIdle()).toBe('continue')
+
+    expect(starts).toBe(2)
+    expect(existsSync(join(paths.queueDir, 'scan-expected-1'))).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'scan-count.txt'))).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(logText()).toContain(
+      'ERROR scan startup failed: runner unavailable (log:',
+    )
+  })
+
+  it('stops a cycle gate that is missing an expected scan yield', async () => {
+    writeFileSync(join(paths.queueDir, 'scan-count.txt'), '1\n')
+    writeFileSync(join(paths.queueDir, 'scan-expected-1'), '2\n')
+    writeFileSync(join(paths.queueDir, 'scan-yield-1'), 'empty\n')
+    const loop = makeLoop({ autoPr: false, reviewEnabled: false })
+
+    expect(await loop.triggerScanIfIdle()).toBe('continue')
+
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(existsSync(join(paths.queueDir, 'scan-expected-1'))).toBe(true)
+    expect(readFileSync(join(paths.queueDir, 'scan-count.txt'), 'utf8')).toBe('1\n')
+    expect(logText()).toContain(
+      'ERROR cycle 1 did not receive every expected scan yield; stopping the loop',
     )
   })
 
@@ -2304,7 +2392,7 @@ describe('failure announcement and burst stop (via poll)', () => {
     expect(reclaimed.assignees).toEqual(['worker-a'])
   })
 
-  it('retains and re-enqueues a claimed task when releasing its issue fails', async () => {
+  it('persists a startup-failure release and stops after three failed reconciliations', async () => {
     initializeGitRepo()
     const description = '[BUG] retain a claimed task until its issue can be released'
     const attemptedTaskIds: string[] = []
@@ -2342,11 +2430,26 @@ describe('failure announcement and burst stop (via poll)', () => {
     expect(issue.labels).toContain(LABEL_IN_PROGRESS)
     expect(issue.labels).not.toContain(LABEL_READY)
     expect(issue.assignees).toEqual([])
-    expect(readFileSync(join(paths.queueDir, 'backlog.txt'), 'utf8')).toBe(`${taskId}:1\n`)
+    expect(readFileSync(join(paths.queueDir, 'backlog.txt'), 'utf8')).toBe('')
     expect(existsSync(join(paths.tasksDir, `${taskId}.md`))).toBe(true)
     expect(existsSync(statusFile(paths, taskId))).toBe(true)
     expect(existsSync(worktreeDir(paths, taskId))).toBe(true)
     expect(existingTaskIdForDesc(paths, 'auto', description)).toBe(taskId)
+    expect(readFileSync(join(paths.queueDir, 'issue-release-intent', taskId), 'utf8'))
+      .toBe(`${issueNumber}\n`)
+    expect(readFileSync(join(paths.queueDir, 'issue-release-failure-count.txt'), 'utf8'))
+      .toBe('1\n')
+
+    expect(await loop.poll()).toBe('continue')
+    expect(await loop.poll()).toBe('continue')
+
+    expect(attemptedTaskIds).toHaveLength(1)
+    expect(readFileSync(join(paths.queueDir, 'issue-release-failure-count.txt'), 'utf8'))
+      .toBe('3\n')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(logText()).toContain(
+      `ERROR 3 consecutive issue release failures for #${issueNumber}; stopping the loop`,
+    )
   })
 })
 
@@ -3456,6 +3559,28 @@ describe('runCycleSuite', () => {
     writeFileSync(join(repoRoot, 'launcher-shim'), '')
     expect(loop.runCycleSuite(4)).toBe(true)
     expect(existsSync(join(repoRoot, 'repaired'))).toBe(false)
+  })
+
+  it('stops and reports the remediation when a missing-toolchain repair fails', () => {
+    const suiteProject: ProjectAdapter = {
+      ...stubProject,
+      cycleSuite: () => [{
+        label: 'Repairable', cwd: '',
+        command: `node -e "require('node:fs').writeFileSync('suite-ran', '')"`,
+        repairWhenMissing: {
+          path: 'launcher-shim',
+          command: 'node -e "process.exit(1)"',
+          message: 'restore the launcher and restart the loop',
+        },
+      }],
+    }
+    const loop = makeLoop({ taskGate: 'light' }, suiteProject)
+
+    expect(loop.runCycleSuite(7)).toBe(false)
+
+    expect(existsSync(join(repoRoot, 'suite-ran'))).toBe(false)
+    expect(existsSync(stopFile())).toBe(true)
+    expect(logText()).toContain('ERROR restore the launcher and restart the loop')
   })
 
   it('skips a step whose required path is absent', () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -3007,6 +3007,65 @@ describe('completed task merge recovery', () => {
     expect(logged.some((line) => line.startsWith('Failed 066_auto'))).toBe(false)
   })
 
+  it('terminalizes a task whose change is already on the run branch as no-change', async () => {
+    const taskId = '20260814_144306_064_auto-duplicate-fix'
+    initializeGitRepo()
+    writeFileSync(join(paths.tasksDir, `${taskId}.md`), '# spec\n')
+    const worktree = worktreeDir(paths, taskId)
+    git(['worktree', 'add', worktree, '-b', branchName(taskId)])
+    writeFileSync(join(worktree, 'tracked.txt'), 'fixed\n')
+    execFileSync('git', ['add', 'tracked.txt'], { cwd: worktree })
+    execFileSync('git', ['commit', '-qm', 'fix: duplicate the run fix'], { cwd: worktree })
+    writeFinal(taskId, 'TASK_COMPLETE\n')
+    writeRawStatus(taskId, 'completed')
+
+    writeFileSync(join(repoRoot, 'tracked.txt'), 'fixed\n')
+    git(['add', 'tracked.txt'])
+    git(['commit', '-m', 'fix: land the fix from another task'])
+    const runHead = git(['rev-parse', 'HEAD'])
+
+    const loop = makeLoop({
+      autoMerge: true, issueQueueEnabled: true, scanEnabled: false, maxParallel: 0,
+    })
+    loop.initializeSessionStateForBranch()
+    const issueNumber = await fakeForge.createIssue({
+      title: 'duplicate fix', body: '', labels: [LABEL_FINDING, LABEL_IN_PROGRESS],
+    })
+    recordIssueForTask(paths, taskId, issueNumber)
+    const getIssue = fakeForge.getIssue.bind(fakeForge)
+    let unavailable = true
+    fakeForge.getIssue = async (number) => {
+      if (number === issueNumber && unavailable) {
+        unavailable = false
+        throw new Error('forge unavailable')
+      }
+      return getIssue(number)
+    }
+
+    expect(await loop.poll()).toBe('continue')
+
+    expect(readStatus(paths, taskId)?.status).toBe('completed')
+    expect(git(['rev-parse', 'HEAD'])).toBe(runHead)
+    expect(readFileSync(join(paths.queueDir, 'merge-failure-count.txt'), 'utf8')).toBe('0\n')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
+
+    expect(await loop.poll()).toBe('continue')
+
+    expect(readStatus(paths, taskId)?.status).toBe('no-change')
+    expect(issueCompletionForIssue(paths, issueNumber)).toMatchObject({
+      taskId, outcome: 'no-change',
+    })
+    expect((await fakeForge.getIssue(issueNumber)).state).toBe('closed')
+    expect(fakeForge.issueComments.get(issueNumber)?.join('\n'))
+      .toContain('no change was warranted')
+    expect(git(['rev-parse', 'HEAD'])).toBe(runHead)
+    expect(existsSync(worktree)).toBe(false)
+    expect(readFileSync(join(paths.queueDir, 'merge-failure-count.txt'), 'utf8')).toBe('0\n')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
+    expect(logged).toContain('No-change 064_auto    no change warranted')
+    expect(logged.some((line) => line.startsWith('Failed 064_auto'))).toBe(false)
+  })
+
   it('retries no-change issue reconciliation without counting a merge failure', async () => {
     const taskId = '20260814_145209_067_auto-no-change-retry'
     initializeGitRepo()

--- a/tests/restart.test.ts
+++ b/tests/restart.test.ts
@@ -51,6 +51,13 @@ function fakeOperatingSystem(
       return daemon
     },
     processTreeRootPid: () => process.pid,
+    terminateProcessTree: vi.fn(() => {
+      if (child.exitCode !== null) return false
+      child.kill()
+      Object.assign(child, { exitCode: 0 })
+      return true
+    }),
+    processTreeIsAlive: vi.fn(() => child.exitCode === null),
   } as unknown as OperatingSystem
 }
 
@@ -176,10 +183,11 @@ describe('loop replacement startup', () => {
     fixtureRoots.push(root)
     const child = fakeChild(43213)
     child.kill = vi.fn(() => { throw new Error('access denied while stopping replacement') })
+    const os = fakeOperatingSystem(child)
 
     await expect(startLoopReplacement(join(root, 'ready'), {
       env: environmentWithoutWrapper(),
-      operatingSystem: fakeOperatingSystem(child),
+      operatingSystem: os,
       outputFile: join(root, 'loop.log'),
       packageRoot: root,
       startupTimeoutMs: 1,
@@ -188,6 +196,50 @@ describe('loop replacement startup', () => {
       pid: 43213,
       error: 'replacement did not become ready before the startup timeout; '
         + 'replacement cleanup failed: access denied while stopping replacement',
+    })
+    expect(os.processTreeIsAlive).toHaveBeenCalledWith(43213)
+  })
+
+  it('terminates and verifies the replacement process tree after the startup timeout', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orch-restart-'))
+    fixtureRoots.push(root)
+    const child = fakeChild(43215)
+    const os = fakeOperatingSystem(child)
+
+    await expect(startLoopReplacement(join(root, 'ready'), {
+      env: environmentWithoutWrapper(),
+      operatingSystem: os,
+      outputFile: join(root, 'loop.log'),
+      packageRoot: root,
+      startupTimeoutMs: 1,
+    })).resolves.toEqual({
+      ok: false,
+      pid: 43215,
+      error: 'replacement did not become ready before the startup timeout',
+    })
+    expect(os.terminateProcessTree).toHaveBeenCalledWith(43215)
+    expect(os.processTreeIsAlive).toHaveBeenCalledWith(43215)
+  })
+
+  it('reports failure when the replacement process tree survives cleanup', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orch-restart-'))
+    fixtureRoots.push(root)
+    const child = fakeChild(43216)
+    const os = fakeOperatingSystem(child)
+    vi.mocked(os.terminateProcessTree).mockReturnValue(true)
+    vi.mocked(os.processTreeIsAlive).mockReturnValue(true)
+
+    await expect(startLoopReplacement(join(root, 'ready'), {
+      env: environmentWithoutWrapper(),
+      operatingSystem: os,
+      outputFile: join(root, 'loop.log'),
+      packageRoot: root,
+      startupTimeoutMs: 1,
+    })).resolves.toEqual({
+      ok: false,
+      pid: 43216,
+      error: 'replacement did not become ready before the startup timeout; '
+        + 'replacement cleanup failed: Could not stop process tree 43216.',
     })
   })
 

--- a/tests/runner-claude.test.ts
+++ b/tests/runner-claude.test.ts
@@ -86,7 +86,12 @@ describe('createClaudeRunner', () => {
     expect(sharedSkills.legacyRoots).toBeUndefined()
     expect(sharedSkills.renderFile(
       Buffer.from(source),
-      { repoRoot, packageRoot, commandPrefixPlaceholder: '{{COMMAND_PREFIX}}' },
+      {
+        repoRoot,
+        packageRoot,
+        commandPrefixPlaceholder: '{{COMMAND_PREFIX}}',
+        packagePathPrefixPlaceholder: '{{PACKAGE_PATH_PREFIX}}',
+      },
     ).toString('utf8')).toBe([
       '---',
       'name: git-commit',

--- a/tests/runner-codex.test.ts
+++ b/tests/runner-codex.test.ts
@@ -70,8 +70,8 @@ describe('createCodexRunner', () => {
 
     expect(sharedSkills.destinationRoot(repoRoot))
       .toBe(join(repoRoot, '.agents', 'skills'))
-    // `.claude/skills` is the interactive agent's directory, which the core keeps
-    // filled; claiming it as a legacy root here emptied it whenever Codex was selected.
+    // `.claude/skills` may be selected independently by the consumer; claiming it as a
+    // legacy root here emptied it whenever Codex was selected.
     expect(sharedSkills.legacyRoots).toBeUndefined()
     expect(sharedSkills.renderFile(
       Buffer.from('{{COMMAND_PREFIX}} loop\n'),

--- a/tests/runner-codex.test.ts
+++ b/tests/runner-codex.test.ts
@@ -75,7 +75,12 @@ describe('createCodexRunner', () => {
     expect(sharedSkills.legacyRoots).toBeUndefined()
     expect(sharedSkills.renderFile(
       Buffer.from('{{COMMAND_PREFIX}} loop\n'),
-      { repoRoot, packageRoot, commandPrefixPlaceholder: '{{COMMAND_PREFIX}}' },
+      {
+        repoRoot,
+        packageRoot,
+        commandPrefixPlaceholder: '{{COMMAND_PREFIX}}',
+        packagePathPrefixPlaceholder: '{{PACKAGE_PATH_PREFIX}}',
+      },
     ).toString('utf8')).toBe('npm run -C orchestration/ts loop\n')
   })
 
@@ -102,7 +107,12 @@ describe('createCodexRunner', () => {
 
     const rendered = createCodexRunner().sharedSkills.renderFile(
       Buffer.from(source),
-      { repoRoot, packageRoot, commandPrefixPlaceholder: '{{COMMAND_PREFIX}}' },
+      {
+        repoRoot,
+        packageRoot,
+        commandPrefixPlaceholder: '{{COMMAND_PREFIX}}',
+        packagePathPrefixPlaceholder: '{{PACKAGE_PATH_PREFIX}}',
+      },
     ).toString('utf8')
 
     expect(rendered).toBe([
@@ -134,7 +144,12 @@ describe('createCodexRunner', () => {
       Buffer.from(
         'Read `CLAUDE.md` and `.claude/skills/git-review/SKILL.md`, then run `/git-review` and `/verify-changes`.\n',
       ),
-      { repoRoot, packageRoot, commandPrefixPlaceholder: '{{COMMAND_PREFIX}}' },
+      {
+        repoRoot,
+        packageRoot,
+        commandPrefixPlaceholder: '{{COMMAND_PREFIX}}',
+        packagePathPrefixPlaceholder: '{{PACKAGE_PATH_PREFIX}}',
+      },
     ).toString('utf8')
 
     expect(rendered).toBe(
@@ -151,7 +166,12 @@ describe('createCodexRunner', () => {
 
     const rendered = createCodexRunner().sharedSkills.renderFile(
       Buffer.from('Read `CLAUDE.md` and `.claude/skills/verify-changes/SKILL.md`.\n'),
-      { repoRoot, packageRoot, commandPrefixPlaceholder: '{{COMMAND_PREFIX}}' },
+      {
+        repoRoot,
+        packageRoot,
+        commandPrefixPlaceholder: '{{COMMAND_PREFIX}}',
+        packagePathPrefixPlaceholder: '{{PACKAGE_PATH_PREFIX}}',
+      },
     ).toString('utf8')
 
     expect(rendered)
@@ -167,7 +187,11 @@ describe('createCodexRunner', () => {
     ) ? actualFs.readFileSync(path, 'utf8') : 'task specification')
     const manifest = JSON.parse(actualFs.readFileSync(
       join(packageRoot, 'skills', 'manifest.json'), 'utf8',
-    )) as { commandPrefixPlaceholder: string; skills: string[] }
+    )) as {
+      commandPrefixPlaceholder: string
+      packagePathPrefixPlaceholder: string
+      skills: string[]
+    }
     const rendered: Record<string, string> = {}
     const visit = (skill: string, root: string, current = root): void => {
       for (const entry of actualFs.readdirSync(current, { withFileTypes: true })
@@ -182,6 +206,7 @@ describe('createCodexRunner', () => {
               repoRoot: packageRoot,
               packageRoot,
               commandPrefixPlaceholder: manifest.commandPrefixPlaceholder,
+              packagePathPrefixPlaceholder: manifest.packagePathPrefixPlaceholder,
             },
           ).toString('utf8')
         }

--- a/tests/shared-skills.test.ts
+++ b/tests/shared-skills.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createClaudeRunner } from '../src/adapters/runner-claude.ts'
 import type { Runner } from '../src/adapters/runner.ts'
+import { createClaudeSharedSkills } from '../src/adapters/shared-skills-claude.ts'
 import { syncSharedSkills } from '../src/sharedSkills.ts'
 import { fakeRunnerSharedSkills } from './fakeRunner.ts'
 
@@ -11,6 +12,11 @@ let fixtureRoot: string
 let repoRoot: string
 let packageRoot: string
 let runner: Runner
+const interactiveSharedSkills = createClaudeSharedSkills()
+
+function skillAdapters(selectedRunner: Runner = runner) {
+  return [selectedRunner.sharedSkills, interactiveSharedSkills]
+}
 
 function writeSkill(name: string, contents: string): void {
   const directory = join(packageRoot, 'skills', name)
@@ -45,7 +51,7 @@ describe('shared skill sync', () => {
   it('installs only manifest skills at the consumer root with its package command prefix', () => {
     writeSkill('verify-changes', 'consumer-specific gates\n')
 
-    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+    const result = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(result.installed).toEqual([
       '.agents/skills/git-commit', '.agents/skills/loop-start',
@@ -64,7 +70,7 @@ describe('shared skill sync', () => {
     writeManifest(['loop-start'])
     writeSkill('loop-start', '{{ORCHESTRATION_COMMAND_PREFIX}} loop-status\n')
 
-    syncSharedSkills(repoRoot, packageRoot, runner)
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(readFileSync(join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
       .toBe('npm run loop-status\n')
@@ -74,10 +80,10 @@ describe('shared skill sync', () => {
     const localSkill = join(repoRoot, '.agents', 'skills', 'verify-changes', 'SKILL.md')
     mkdirSync(join(repoRoot, '.agents', 'skills', 'verify-changes'), { recursive: true })
     writeFileSync(localSkill, 'repository gates\n')
-    syncSharedSkills(repoRoot, packageRoot, runner)
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters())
     writeSkill('loop-start', 'version two: {{ORCHESTRATION_COMMAND_PREFIX}} loop\n')
 
-    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+    const result = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(result.updated).toEqual(['.agents/skills/loop-start', '.claude/skills/loop-start'])
     expect(readFileSync(join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
@@ -86,12 +92,12 @@ describe('shared skill sync', () => {
   })
 
   it('reports and preserves a generated skill that the consumer changed', () => {
-    syncSharedSkills(repoRoot, packageRoot, runner)
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters())
     const installed = join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md')
     writeFileSync(installed, 'consumer version\n')
     writeSkill('loop-start', 'upstream version\n')
 
-    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+    const result = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(result.conflicts).toEqual(['.agents/skills/loop-start'])
     expect(result.updated).toEqual(['.claude/skills/loop-start'])
@@ -99,10 +105,10 @@ describe('shared skill sync', () => {
   })
 
   it('treats deletion of a managed skill as deliberate divergence', () => {
-    syncSharedSkills(repoRoot, packageRoot, runner)
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters())
     rmSync(join(repoRoot, '.agents', 'skills', 'loop-start'), { recursive: true })
 
-    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+    const result = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(result.conflicts).toEqual(['.agents/skills/loop-start'])
     expect(existsSync(join(repoRoot, '.agents', 'skills', 'loop-start'))).toBe(false)
@@ -117,7 +123,7 @@ describe('shared skill sync', () => {
         destinationRoot: () => legacyRoot,
       },
     }
-    syncSharedSkills(repoRoot, packageRoot, legacyRunner)
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters(legacyRunner))
     runner = {
       ...runner,
       sharedSkills: { ...runner.sharedSkills, legacyRoots: () => [legacyRoot] },
@@ -126,7 +132,7 @@ describe('shared skill sync', () => {
     mkdirSync(dirname(localSkill), { recursive: true })
     writeFileSync(localSkill, 'repository gates\n')
 
-    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+    const result = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(result.migrationConflicts).toEqual([])
     expect(existsSync(join(legacyRoot, 'git-commit'))).toBe(false)
@@ -144,7 +150,7 @@ describe('shared skill sync', () => {
         destinationRoot: () => legacyRoot,
       },
     }
-    syncSharedSkills(repoRoot, packageRoot, legacyRunner)
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters(legacyRunner))
     runner = {
       ...runner,
       sharedSkills: { ...runner.sharedSkills, legacyRoots: () => [legacyRoot] },
@@ -152,8 +158,8 @@ describe('shared skill sync', () => {
     const divergent = join(legacyRoot, 'loop-start', 'SKILL.md')
     writeFileSync(divergent, 'consumer version\n')
 
-    const first = syncSharedSkills(repoRoot, packageRoot, runner)
-    const second = syncSharedSkills(repoRoot, packageRoot, runner)
+    const first = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
+    const second = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(first.migrationConflicts).toEqual([join(legacyRoot, 'loop-start')])
     expect(second.migrationConflicts).toEqual([])
@@ -172,13 +178,20 @@ describe('shared skill sync', () => {
       start: async () => process.pid,
     }
 
-    syncSharedSkills(repoRoot, packageRoot, runner)
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(readFileSync(
       join(repoRoot, '.alternate-runner', 'skills', 'loop-start', 'SKILL.md'),
       'utf8',
     )).toBe('alternate command loop -- --daemon\n')
     expect(existsSync(join(repoRoot, '.agents', 'skills'))).toBe(false)
+  })
+
+  it('does not assume an interactive agent target the consumer did not select', () => {
+    syncSharedSkills(repoRoot, packageRoot, [runner.sharedSkills])
+
+    expect(existsSync(join(repoRoot, '.agents', 'skills', 'loop-start'))).toBe(true)
+    expect(existsSync(join(repoRoot, '.claude'))).toBe(false)
   })
 
   it('rejects a runner destination outside the repository before writing', () => {
@@ -191,7 +204,7 @@ describe('shared skill sync', () => {
       start: async () => process.pid,
     }
 
-    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+    const result = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(result.failures).toEqual([
       `shared skill destination escaped the repository: ${escaped}`,
@@ -212,7 +225,7 @@ describe('shared skill sync', () => {
       '',
     ].join('\n'))
 
-    syncSharedSkills(repoRoot, packageRoot, runner)
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     const interactive = readFileSync(
       join(repoRoot, '.claude', 'skills', 'git-commit', 'SKILL.md'), 'utf8',
@@ -237,7 +250,7 @@ describe('shared skill sync', () => {
       start: async () => process.pid,
     }
 
-    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+    const result = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(result.installed).toEqual(['.claude/skills/git-commit', '.claude/skills/loop-start'])
     expect(readFileSync(join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
@@ -250,7 +263,7 @@ describe('shared skill sync', () => {
     writeFileSync(localSkill, 'repository gates\n')
     runner = createClaudeRunner()
 
-    const result = syncSharedSkills(repoRoot, packageRoot, runner)
+    const result = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
     expect(result.installed).toEqual([
       '.claude/skills/git-commit', '.claude/skills/loop-start',

--- a/tests/shared-skills.test.ts
+++ b/tests/shared-skills.test.ts
@@ -28,6 +28,7 @@ function writeManifest(skills: string[]): void {
   mkdirSync(join(packageRoot, 'skills'), { recursive: true })
   writeFileSync(join(packageRoot, 'skills', 'manifest.json'), `${JSON.stringify({
     commandPrefixPlaceholder: '{{ORCHESTRATION_COMMAND_PREFIX}}',
+    packagePathPrefixPlaceholder: '{{ORCHESTRATION_PACKAGE_PATH_PREFIX}}',
     skills,
   }, null, 2)}\n`)
 }
@@ -74,6 +75,32 @@ describe('shared skill sync', () => {
 
     expect(readFileSync(join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
       .toBe('npm run loop-status\n')
+  })
+
+  it('renders package source paths for consumer and package-owned layouts', () => {
+    writeSkill(
+      'loop-start',
+      'source: `{{ORCHESTRATION_PACKAGE_PATH_PREFIX}}src`\n',
+    )
+
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters())
+
+    expect(readFileSync(join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
+      .toBe('source: `orchestration/ts/src`\n')
+
+    const ownerRoot = join(fixtureRoot, 'owner-path')
+    packageRoot = ownerRoot
+    repoRoot = ownerRoot
+    writeManifest(['loop-start'])
+    writeSkill(
+      'loop-start',
+      'source: `{{ORCHESTRATION_PACKAGE_PATH_PREFIX}}src`\n',
+    )
+
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters())
+
+    expect(readFileSync(join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
+      .toBe('source: `src`\n')
   })
 
   it('refreshes exact generated copies and retains unlisted repository skills', () => {

--- a/tests/stubProject.ts
+++ b/tests/stubProject.ts
@@ -1,6 +1,8 @@
 import type { ProjectAdapter } from '../src/adapters/project.ts'
+import { createClaudeSharedSkills } from '../src/adapters/shared-skills-claude.ts'
 
 export const stubProject: ProjectAdapter = {
+  sharedSkills: [createClaudeSharedSkills()],
   preCommitChecks: [],
   name: 'test',
   pullRequest: {


### PR DESCRIPTION
## Features
- None

## Bug Fixes
- Merges whose commits rebase to empty against the run branch (a duplicate of a change already landed) now resolve as no-change — closing their issues and leaving the merge-failure counter alone — instead of counting as consecutive merge failures and stopping the loop. Observed live when a re-implemented fix duplicated `de36a98`.
- `triggerScanIfIdle` and the failed-task/startup-failure recovery paths fail closed: counter or state writes that previously only warned now stop the cycle rather than silently continuing with inconsistent lifecycle state.
- `runCycleSuite` stops the cycle gate when a suite step's `repairWhenMissing` fails, instead of warning and letting a broken suite pass.
- `prepareBranchTopology` no longer returns direct mode before reading the recorded topology, so an integration-branch run resumes with its original topology.
- `coreUpdate.syncSkills` treats a commit failure after `git add` as a hard stop for the cycle instead of a warning that leaves staged, uncommitted skill changes behind.
- `forge-github.prStatus` rethrows unexpected GitHub failures instead of converting every error into a "no PR" answer that could green-light a gate.
- `cmdLoop --daemon` waits for daemon initialization readiness before reporting success, so a start that dies during initialization is reported as a failure.
- `restart.startLoopReplacement` verifies the predecessor's process tree actually shut down (portable check, not a bare `ChildProcess.kill()`).
- Interactive-agent skill targets moved behind the runner adapter seam instead of hard-coding Claude's `.claude/skills` path.
- The shared loop-start skill renders its source paths correctly (#124).

## Security
- None

## Project Operations
- SPEC.md documents the `review-c<n>` task slugs created by automatic review, and drops stale wording items (#161-#163, #168).
- New tests: issue-queue post-assignment claim race, cycle-suite missing-Docker probe, and broader shared-skills coverage.

## Risks
- The empty-rebase change alters merge-failure semantics: a duplicate implementation now closes its issue as no-change instead of surfacing as a failure. A genuinely broken merge (rebase conflict, gate failure) keeps its failure path, pinned by test.
- Several previously-warning paths now stop the loop (fail closed). Consumers pulling this subtree may see loops stop where they previously limped on — that is the intended behavior change.
