### PR TITLE
chore: stop soft-denying the branch deletion a merge performs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
     "soft_deny": [
       "$defaults",
       "Deleting files or directories recursively, including rm -rf and equivalents",
-      "Force-pushing, deleting a remote branch other than the head branch of a pull request in the same command that merges it, git reset --hard, git clean, or deleting a branch with git branch -D",
+      "Force-pushing, git reset --hard, git clean, or deleting a branch with git branch -D. Deleting the head branch of a pull request in the same command that merges it is this repository's normal merge flow and is not covered here",
       "Publishing to npm or changing the package version",
       "Repeating or extending an approved action beyond what was approved: a second or third run, a wider scope, or the same operation applied to something the user did not name",
       "Acting on the user's environment for the assistant's own convenience — starting a service to measure it, stopping one to free a port — when the user asked only for information"


### PR DESCRIPTION
## Features
- None

## Bug Fixes
- None

## Project Operations
- [Auto mode] The soft-deny rule covering destructive git operations no longer names remote branch deletion. Its carve-out for the head branch of a pull request deleted by the same command that merges it was stated inside the clause it qualified, which made `gh pr merge --delete-branch` read as the denied action and stopped the `git-merge` skill from running.

## Security
- None

## Risks
- Deleting a remote branch is no longer soft-denied. In this repository that happens only as the last step of a merge the `git-merge` skill has already gated on CI and a review. Force pushes, `git reset --hard`, `git clean`, and `git branch -D` remain denied, as does recursive deletion.
- This is a local development setting. It is not part of the `orchestration/` subtree and does not reach consuming repositories.
- Whether it is sufficient is unverified: the same soft-deny list begins with `$defaults`, whose contents are not visible from a non-interactive session, and the `update-config` skill was blocked in the same session by something this entry does not describe.