### PR TITLE
feat: autonomous scan loop — 3 features, 16 fixes, 1 security fix

### DIFF
--- a/.claude/skills/.orchestration-core-sync.json
+++ b/.claude/skills/.orchestration-core-sync.json
@@ -6,9 +6,9 @@
     "git-pr": "b631462e5fd0ea3d9b6d974d17fa02f38aee09f336d9d401616ef5d9c96c536a",
     "git-review": "c71b70fc4064c1bd626b43b40b94530daadcaf8cd3af5ecd65fbb1739f423b61",
     "loop-delegate": "9f32215042f497eb3c0def1d841a109d190bda8d1614925686ec9ef185fec285",
-    "loop-setup": "3241c77cf74cc2591cb7cf2e694e904baf7f6225f8e151d184e867128d8da26a",
-    "loop-start": "7c0f00fbcca9c0c2d4a1cd8e6c5f230ce2a7b1d23fb93603f6df9bfe637064aa",
-    "loop-stop": "1574efbe1187d48675c9cb3244af16daa6e13d72ec75190f97b830de7c6e059c",
+    "loop-setup": "7492bfad12e4532d63e9d94180be0330918d95250724c9d1738520fdcc214123",
+    "loop-start": "73d9abfe5ec82e0cf6ef4694d477ed38c3f337cadc7623af658ccf9f5a57e8f8",
+    "loop-stop": "c59772c406edc59dd065e4a4a9573a2a9765f52028cf829c0219ac8902bb6251",
     "skill-create": "6657e1650e63fc255cb3b2b286b1f2a5161d4dfe126a170504b6df1d8b4fc09e"
   }
 }

--- a/.claude/skills/loop-setup/SKILL.md
+++ b/.claude/skills/loop-setup/SKILL.md
@@ -44,6 +44,16 @@ Edit the generated `orchestration/project/project-<name>.ts` from the decisions 
 only when init created it in this run. If an adapter already existed, report it and ask
 before changing it; deliberate divergence is not a repair target.
 
+Shared skills rendered into `.agents/skills/` or `.claude/skills/` and recorded in that
+directory's `.orchestration-core-sync.json` are core-owned. Do not edit their rendered
+trees: clean syncs overwrite edits, deletions, and added support files. To add
+repository-specific guidance to shared skill `<name>`, write the fragment at
+`orchestration/project/skills/<name>.md`. The renderer places it at the automatic
+`{{ORCHESTRATION_PROJECT_GUIDANCE}}` injection point at the end of `SKILL.md`; when no
+fragment exists, the point renders to nothing. Skills absent from the managed index are
+repository-owned and remain untouched, so a repository may still supply a complete local
+skill beside the rendered ones.
+
 Keep `preCommitChecks` fast. The core-owned hook supplies the default-branch guard and
 selects these checks from staged paths. Do not create repository-owned hook scripts.
 

--- a/.claude/skills/loop-start/SKILL.md
+++ b/.claude/skills/loop-start/SKILL.md
@@ -11,6 +11,10 @@ Current state:
 
 !`npm run loop-status`
 
+To inspect repositories other than the working directory, pass `-- --repo <path>`.
+Repeat `--repo <path>` in the same `loop-status` invocation to get one fleet-status line
+per repository. The core does not remember repository paths between invocations.
+
 ## Before starting
 
 A second loop against the same repository will fight the first over the queue and the
@@ -21,11 +25,34 @@ The loop commits and merges on its own, so start it on a topic branch, never on 
 ## Starting
 
 ```bash
-npm run loop -- --daemon
+npm run loop -- --approve-mode local --daemon
 ```
 
+Add `--repo <path>` after `--` to start the loop for an explicitly named repository.
+The path must resolve to a Git repository containing `orchestration/`.
+
 `--daemon` is what puts it in the background; without it the loop holds the terminal.
-Settings go in front of the command:
+The command approves the default local queue explicitly. If
+`ISSUE_QUEUE_ENABLED=true`, replace `local` with `issue`; the loop refuses a mismatch.
+It prints the resolved configuration before asking for terminal confirmation or checking
+the non-interactive approval flag.
+Settings may go in front of the command, or in `orchestration/config.json` under the same
+uppercase names. Manage that file with `npm run config -- list`,
+`get <SETTING>`, `set <SETTING> <value>`, and `unset <SETTING>`; do not hand-edit it. File
+values take precedence over environment variables, which take precedence over defaults.
+The configuration command writes through a temporary file and renames it atomically. The
+loop picks up valid file changes at the next use and logs old and new values; a malformed
+file or invalid value stops the run and reports the file, setting, and failure instead of
+using the last good or environment value.
+
+`FORGE` and `RUNNER` stay pinned because changing the owning component abandons in-flight
+work. `ISSUE_QUEUE_ENABLED` and `WORKER_MODE` stay pinned because mode changes strand
+claimed issues. `INTEGRATION_BRANCH` stays pinned to avoid splitting a run across branches.
+`UPSTREAM_REMOTE` and `UPSTREAM_BRANCH` stay pinned so the run cannot switch the core source
+it was built on. Changes to these seven settings are logged as ignored until restart; every
+other setting is live.
+
+Settings:
 
 | Variable | Default | Effect |
 |----------|---------|--------|
@@ -38,15 +65,17 @@ Settings go in front of the command:
 | `REVIEW_EVERY_N_CYCLES` | 1 | Review every Nth cycle (the final cycle is always reviewed) |
 | `MAX_FINAL_REVIEW_ROUNDS` | 4 | Final-cycle rounds before the loop stops instead of promoting unresolved findings |
 | `MAX_BURST_FAILURES` | 3 | Task failures in one poll before the loop stops and blames the environment |
+| `MAX_ISSUE_RETRIES` | 3 | Consecutive task failures per issue before parking it as `loop:retry-exhausted` |
+| `INTEGRATION_BRANCH` | empty | Separate task/merge/PR branch; when set, the daemon checkout stays fixed for the run |
 | `ISSUE_QUEUE_ENABLED` | false | Findings become claimable forge issues instead of local queue entries (each concurrent worker requires a distinct forge account) |
 | `ISSUE_LEASE_HOURS` | 3 | Hours a claimed issue may sit untouched before its lease is reaped back to ready |
 | `CI_GATE_ENABLED` | false | Whether the gate waits for CI — a draft PR has no checks, so waiting would hang |
 | `MAX_CONSECUTIVE_MERGE_FAILURES` | 3 | Merges failing in a row before it stops — the task finished, its verification did not |
 | `SCAN_ENABLED` | true | Set false to work the existing queue without scanning |
 | `SCAN_PARALLEL` | 2 | Scans per cycle, splitting the checklist between them (1 = single full scan, up to 4) |
-| `SCAN_EFFORT` | high | Codex reasoning effort for scan tasks |
+| `SCAN_EFFORT` | medium | Codex reasoning effort for scan tasks |
 | `TASK_EFFORT` | medium | Codex reasoning effort for queued tasks (`delegate --effort` overrides per task) |
-| `REVIEW_EFFORT` | high | Codex reasoning effort for automatic review tasks |
+| `REVIEW_EFFORT` | medium | Codex reasoning effort for automatic review tasks |
 | `TASK_GATE` | full | `light` runs compile/lint per task and the full suites once at each cycle gate — faster, but a suite break names no task |
 
 ## While it runs
@@ -55,7 +84,8 @@ Work can be handed to a running loop without stopping it — `/loop-delegate`
 turns a decision from the conversation into a queued task the loop picks up on
 its next poll, ahead of any future scan.
 
-The daemon holds the code it started with. **Editing the loop source under `src` changes
+The daemon holds the code it started with. **Editing the loop source under
+`src` changes
 nothing until the loop is restarted**, and reporting that a fix took effect without
 restarting is how a fix gets credited that never ran.
 

--- a/.claude/skills/loop-stop/SKILL.md
+++ b/.claude/skills/loop-stop/SKILL.md
@@ -10,11 +10,18 @@ Current state:
 
 !`npm run loop-status`
 
+To inspect repositories other than the working directory, pass `-- --repo <path>`.
+Repeat `--repo <path>` in the same `loop-status` invocation to get one fleet-status line
+per repository. The core does not remember repository paths between invocations.
+
 ## Stopping
 
 ```bash
 npm run stop
 ```
+
+Add `-- --repo <path>` to stop the loop for an explicitly named repository. The path
+must resolve to a Git repository containing `orchestration/`.
 
 This writes a stop file. The loop notices it on its next poll, so it exits within
 `POLL_INTERVAL` seconds — 30 by default. The command also terminates every live task

--- a/README.md
+++ b/README.md
@@ -80,9 +80,18 @@ task dispatch, leaving any staged output available for diagnosis. Loop commands 
 rendered for
 the installed package location (`npm run` here, `npm run -C orchestration/ts` in the
 layout below).
-The sync tracks the exact content it generated: a consumer edit, deletion, or added
-support file is reported and retained, while repository skills absent from the manifest
-are never touched. Canonical skills live outside a nested runner skill directory,
+Every shared `SKILL.md` has one renderer-supplied injection point named
+`{{ORCHESTRATION_PROJECT_GUIDANCE}}` at its end. A consumer can supply the fragment for
+skill `<name>` at `orchestration/project/skills/<name>.md`, outside the vendored
+`orchestration/ts` subtree. The renderer adds Markdown separation before a non-empty
+fragment and emits nothing at the injection point when the file is absent, so consumers
+without fragments receive the same output as before.
+The sync tracks the exact content it generated. A rendered skill recorded in
+`.orchestration-core-sync.json` is core-owned; direct edits, deletions, and added support
+files are overwritten by a clean sync. Put repository-specific additions in the project
+fragment instead. A repository skill absent from the managed index is repository-owned
+and is never touched. Canonical
+skills live outside a nested runner skill directory,
 so importing the package does not expose a second qualified copy of each shared skill.
 
 Nothing here decides that shipping is safe. Deployment stays a human action.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ deleted paths, and an on-demand diff reader; the adapter supplies the repository
 vocabulary and path rules. If the repository intentionally has no PR checks, it may
 explicitly declare
 `ciChecksExpected: false`; otherwise zero checks never satisfy an enabled CI gate.
+An adapter may also list manual cross-environment verification commands for operators:
+
+```ts
+manualEnvironmentChecks: [{
+  environment: 'Linux',
+  command: 'npm run test:linux',
+}],
+```
+
+Each `command` is a complete, repository-owned command that a person runs from the
+consumer repository root, against the run branch, in the named `environment`. The loop
+never executes these commands. On the final promotion path for a non-empty run, it logs
+the environment that ran the automated gate and states that the branch was not run in
+other environments. It then logs every `manualEnvironmentChecks` entry, including its
+command and the fact that it was not run for the branch. These status lines are operator
+guidance; they do not block or delay promotion.
+
 The core-owned pre-commit hook keeps its branch guard repository-neutral by reading the
 tracking remote's advertised default branch. It fails closed when that branch cannot be
 resolved, so repositories using names such as `trunk` receive the same protection without

--- a/README.md
+++ b/README.md
@@ -228,6 +228,20 @@ head to the loop, `loop-status` says what is in flight, `ci-wait` waits on a pul
 checks without believing a partial rollup, and `deploy` dispatches a deployment workflow
 and verifies the revision that actually came up.
 
+Every command accepts `--repo <path>` to act on that repository instead of the repository
+containing the working directory. The path may name the repository or a directory inside
+it; the CLI resolves its Git root and requires that root to contain `orchestration/`.
+Without `--repo`, repository discovery is unchanged. Repeat the option for fleet status:
+
+```bash
+npm run loop-status -- --repo ../service-a --repo ../service-b
+```
+
+With multiple repositories, `loop-status` prints one named line per repository with its
+running state, run branch, queued count, and in-flight count. With zero or one explicit
+repository, it retains the existing detailed single-repository output. Repository paths
+are supplied per invocation; the core keeps no repository registry or checkout inventory.
+
 If you promote a run's pull request by hand, record that completed run with
 `npm run shipped -- <pr-number-or-url>` (or the equivalent direct `node` command for a
 subtree installation). The command requires exactly one positive PR number, optionally

--- a/SPEC.md
+++ b/SPEC.md
@@ -407,6 +407,10 @@ are not parsed by `loadConfig` and are not operator-file settings.
     for a person instead of promoting a branch its own review keeps rejecting.
     Review tasks commit nothing and are exempt from the merge commit check.
 18. After the final cycle passes the same gate, the PR is promoted from draft,
+    the event log names the host environment where the run verification executed and
+    states that the branch was not run elsewhere. Repository adapters may also declare
+    manual cross-environment checks; the log names each check and its command while
+    explicitly recording that the loop did not run it for the branch.
     `LOOP_DONE: <PR URL>` is emitted to the machine-marker sink and as a formatted
     `loop.log` copy, session state is cleaned up, and the loop exits. When the run branch
     has no commits beyond the fetched default branch, the PR, CI, and review

--- a/SPEC.md
+++ b/SPEC.md
@@ -58,6 +58,15 @@ from or equivalent to `orchestration/tests/*.sh`.
   marker as an exact standalone line, while a background loop writes that exact line to
   `logs/loop-markers.log`. The corresponding result is represented separately by an
   aligned display event in `loop.log`.
+- Every command accepts a global `--repo <path>` option. When present, Git resolves the
+  named path to its repository root and the CLI verifies both that it is a Git repository
+  and that its root contains an `orchestration/` directory before dispatch. Without the
+  option, repository discovery from the working directory is unchanged. All commands
+  accept one repository; `loop-status` additionally accepts repeated `--repo` options.
+  For two or more repositories it emits one line per repository naming the root, loop
+  running state, recorded run branch, queued count, and in-flight count. Its existing
+  detailed output is unchanged for a single repository. Paths are supplied per command;
+  the core stores no repository registry, configuration inventory, or checkout list.
 - `report-upstream` requires one explicit, non-blank description. `--help` prints its
   usage, unknown flag-shaped arguments fail before forge access, and `--dry-run` prints
   the exact title and body without filing. An interactive invocation prints that same

--- a/SPEC.md
+++ b/SPEC.md
@@ -330,9 +330,18 @@ are not parsed by `loadConfig` and are not operator-file settings.
     command prefix because the canonical sources already use that agent's format. Both use
     `npm run` as the command prefix in the owning repository and
     `npm run -C <package-path>` in a subtree consumer, and duplicate destinations are
-    served once. The
-    sync replaces only a tree whose content matches its recorded last output; consumer
-    divergence is warned and retained, and skills absent from the manifest are untouched.
+    served once. The renderer supplies one named
+    `{{ORCHESTRATION_PROJECT_GUIDANCE}}` injection point at the end of every shared
+    `SKILL.md`. For skill `<name>`, it reads the repository-owned fragment
+    `orchestration/project/skills/<name>.md`, outside a consumer's vendored package
+    subtree, and inserts it with Markdown separation. An absent fragment renders the point
+    to no bytes, preserving the prior output exactly. The sync replaces only a tree
+    recorded in its
+    `.orchestration-core-sync.json` managed index is core-owned, and a clean sync overwrites
+    edits, deletions, and added support files in its rendered tree; repository-specific
+    additions belong in the fragment. A skill absent from the managed index is
+    repository-owned and remains
+    entirely untouched.
     In a subtree consumer, before writing any destination, the sync verifies that every
     managed destination has no staged changes. An unverifiable or non-clean managed index
     is fatal and stops the cycle before any destination is served. A destination rendering

--- a/checks/english-only.ts
+++ b/checks/english-only.ts
@@ -12,13 +12,6 @@ import { fileURLToPath } from 'node:url'
 
 const PACKAGE_ROOT = resolve(import.meta.dirname, '..')
 
-// Accented forms admitted by the repository's English examples. Keep these explicit:
-// script-wide ranges also admit non-English Latin orthographies such as Vietnamese.
-const ENGLISH_LATIN: ReadonlySet<string> = new Set([
-  '\u00e9', // e with acute, as in cafe
-  '\u0301', // combining acute accent, for the decomposed spelling of the same word
-])
-
 // Typography and symbols the core's sources use. Each is explicit so adding a new
 // non-ASCII character remains a decision instead of silently widening the rule.
 const PUNCTUATION: ReadonlySet<string> = new Set([
@@ -59,7 +52,6 @@ const ESCAPED_NON_ENGLISH_FIXTURE_LINES: ReadonlyMap<string, ReadonlySet<string>
 const permitted = (character: string): boolean =>
   character.codePointAt(0)! < 128
   || PUNCTUATION.has(character)
-  || ENGLISH_LATIN.has(character)
 
 const decodedEscapes = (line: string): string => line.replace(
   /\\(?:u\{([\da-f]{1,6})\}|u([\da-f]{4})|x([\da-f]{2}))/gi,

--- a/orchestration/project/project-core.ts
+++ b/orchestration/project/project-core.ts
@@ -18,6 +18,10 @@ export const coreProject: ProjectAdapter = {
   name: 'core',
   sharedSkills: [createClaudeSharedSkills()],
   verifyDependencyIsolation: true,
+  manualEnvironmentChecks: [{
+    environment: 'Linux',
+    command: 'npm run test:linux',
+  }],
   integrationWorktreeSetup: [{
     label: 'Core dependencies',
     cwd: '',

--- a/orchestration/project/safe-npm-ci.ts
+++ b/orchestration/project/safe-npm-ci.ts
@@ -39,6 +39,8 @@ export function safeNpmCi(
   )
   let previousMoved = false
   let activated = false
+  let primaryFailure: unknown
+  let hasPrimaryFailure = false
 
   try {
     for (const input of INSTALL_INPUTS) {
@@ -73,13 +75,25 @@ export function safeNpmCi(
         runtime.warn(`Installed dependencies; old dependency backup remains at ${previousModules}: ${detail}`)
       }
     }
+  } catch (error) {
+    primaryFailure = error
+    hasPrimaryFailure = true
+    throw error
   } finally {
     // Once activation succeeds the staged directory no longer contains node_modules.
     // On every failure the checkout's original tree is either untouched or restored.
     try {
       runtime.remove(stagingRoot)
     } catch (error) {
-      if (!activated) throw error
+      if (!activated) {
+        if (hasPrimaryFailure) {
+          throw new AggregateError(
+            [primaryFailure, error],
+            'Dependency setup and staging cleanup both failed',
+          )
+        }
+        throw error
+      }
       const detail = error instanceof Error ? error.message : String(error)
       runtime.warn(`Installed dependencies; staging cleanup remains at ${stagingRoot}: ${detail}`)
     }

--- a/skills/loop-setup/SKILL.md
+++ b/skills/loop-setup/SKILL.md
@@ -44,6 +44,16 @@ Edit the generated `orchestration/project/project-<name>.ts` from the decisions 
 only when init created it in this run. If an adapter already existed, report it and ask
 before changing it; deliberate divergence is not a repair target.
 
+Shared skills rendered into `.agents/skills/` or `.claude/skills/` and recorded in that
+directory's `.orchestration-core-sync.json` are core-owned. Do not edit their rendered
+trees: clean syncs overwrite edits, deletions, and added support files. To add
+repository-specific guidance to shared skill `<name>`, write the fragment at
+`orchestration/project/skills/<name>.md`. The renderer places it at the automatic
+`{{ORCHESTRATION_PROJECT_GUIDANCE}}` injection point at the end of `SKILL.md`; when no
+fragment exists, the point renders to nothing. Skills absent from the managed index are
+repository-owned and remain untouched, so a repository may still supply a complete local
+skill beside the rendered ones.
+
 Keep `preCommitChecks` fast. The core-owned hook supplies the default-branch guard and
 selects these checks from staged paths. Do not create repository-owned hook scripts.
 

--- a/skills/loop-start/SKILL.md
+++ b/skills/loop-start/SKILL.md
@@ -11,6 +11,10 @@ Current state:
 
 !`{{ORCHESTRATION_COMMAND_PREFIX}} loop-status`
 
+To inspect repositories other than the working directory, pass `-- --repo <path>`.
+Repeat `--repo <path>` in the same `loop-status` invocation to get one fleet-status line
+per repository. The core does not remember repository paths between invocations.
+
 ## Before starting
 
 A second loop against the same repository will fight the first over the queue and the
@@ -23,6 +27,9 @@ The loop commits and merges on its own, so start it on a topic branch, never on 
 ```bash
 {{ORCHESTRATION_COMMAND_PREFIX}} loop -- --approve-mode local --daemon
 ```
+
+Add `--repo <path>` after `--` to start the loop for an explicitly named repository.
+The path must resolve to a Git repository containing `orchestration/`.
 
 `--daemon` is what puts it in the background; without it the loop holds the terminal.
 The command approves the default local queue explicitly. If

--- a/skills/loop-stop/SKILL.md
+++ b/skills/loop-stop/SKILL.md
@@ -10,11 +10,18 @@ Current state:
 
 !`{{ORCHESTRATION_COMMAND_PREFIX}} loop-status`
 
+To inspect repositories other than the working directory, pass `-- --repo <path>`.
+Repeat `--repo <path>` in the same `loop-status` invocation to get one fleet-status line
+per repository. The core does not remember repository paths between invocations.
+
 ## Stopping
 
 ```bash
 {{ORCHESTRATION_COMMAND_PREFIX}} stop
 ```
+
+Add `-- --repo <path>` to stop the loop for an explicitly named repository. The path
+must resolve to a Git repository containing `orchestration/`.
 
 This writes a stop file. The loop notices it on its next poll, so it exits within
 `POLL_INTERVAL` seconds — 30 by default. The command also terminates every live task

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -1,6 +1,7 @@
 {
   "commandPrefixPlaceholder": "{{ORCHESTRATION_COMMAND_PREFIX}}",
   "packagePathPrefixPlaceholder": "{{ORCHESTRATION_PACKAGE_PATH_PREFIX}}",
+  "projectGuidancePlaceholder": "{{ORCHESTRATION_PROJECT_GUIDANCE}}",
   "skills": [
     "git-commit",
     "git-merge",

--- a/src/adapters/forge-github.ts
+++ b/src/adapters/forge-github.ts
@@ -72,6 +72,18 @@ const githubIssueSchema = z.object({
 
 const githubIssueListSchema = z.array(githubIssueSchema)
 const closedGithubIssueListSchema = z.array(githubIssueSchema.extend({ state: z.literal('CLOSED') }))
+const restGithubIssueSchema = z.object({
+  number: z.number(),
+  state: z.enum(['open', 'closed']),
+  title: z.string(),
+  body: z.string().nullable(),
+  user: githubAuthorSchema,
+  labels: z.array(z.object({ name: z.string() })),
+  assignees: z.array(z.object({ login: z.string() })),
+  updated_at: z.string(),
+  pull_request: z.unknown().optional(),
+})
+const restGithubIssuePagesSchema = z.array(z.array(restGithubIssueSchema))
 const issueCommentsSchema = z.object({
   comments: z.array(z.object({
     body: z.string(),
@@ -88,6 +100,7 @@ const rateLimitSchema = z.object({
 export type RollupEntry = z.infer<typeof rollupEntrySchema>
 export type GithubWorkflowRun = z.infer<typeof workflowRunSchema>
 type GithubIssue = z.infer<typeof githubIssueSchema>
+type RestGithubIssue = z.infer<typeof restGithubIssueSchema>
 
 const WRITE_PERMISSIONS = new Set(['write', 'maintain', 'admin'])
 
@@ -319,6 +332,32 @@ export function createGithubForge(
     updatedAt: issue.updatedAt,
   })
 
+  const listGithubIssues = async (
+    state: 'open' | 'closed',
+    label: string,
+  ): Promise<GithubIssue[]> => {
+    const repository = await issueQueueRepository()
+    const encodedRepository = repository.split('/').map(encodeURIComponent).join('/')
+    const endpoint = `repos/${encodedRepository}/issues?state=${state}`
+      + `&labels=${encodeURIComponent(label)}&per_page=100`
+    const args = ['api', '--paginate', '--slurp', endpoint]
+    const pages = parseGhJson(args, await checkedGh(repoRoot, args), restGithubIssuePagesSchema)
+    const issues = pages.flat()
+      // GitHub's REST issues endpoint includes pull requests. The forge contract does not.
+      .filter((issue) => issue.pull_request === undefined)
+      .map((issue: RestGithubIssue): GithubIssue => ({
+        number: issue.number,
+        state: issue.state === 'open' ? 'OPEN' : 'CLOSED',
+        title: issue.title,
+        body: issue.body ?? '',
+        author: issue.user,
+        labels: issue.labels,
+        assignees: issue.assignees,
+        updatedAt: issue.updated_at,
+      }))
+    return issues
+  }
+
   return {
     resolveGitRemote(remote: string): string {
       return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(remote)
@@ -526,15 +565,10 @@ export function createGithubForge(
     },
 
     async listOpenIssues(label: string): Promise<ForgeIssue[]> {
-      const repository = await issueQueueRepository()
-      const args = ['issue', 'list', '--state', 'open',
-        '--repo', repository,
-        '--label', label, '--limit', '200',
-        '--json', 'number,state,title,body,author,labels,assignees,updatedAt']
-      const stdout = await checkedGh(repoRoot, args)
+      const listedIssues = await listGithubIssues('open', label)
       const permissionCache = new Map<string, Promise<boolean>>()
-      const issues = parseGhJson(args, stdout, githubIssueListSchema)
-        .filter((issue) => {
+      const issues = githubIssueListSchema.parse(listedIssues)
+        .filter((issue: GithubIssue) => {
           if (issue.state === 'OPEN') return true
           report(`dropped issue #${issue.number} with state ${issue.state} from open issue listing`)
           return false
@@ -543,14 +577,9 @@ export function createGithubForge(
     },
 
     async listClosedIssues(label: string): Promise<ForgeIssue[]> {
-      const repository = await issueQueueRepository()
-      const args = ['issue', 'list', '--state', 'closed',
-        '--repo', repository,
-        '--label', label, '--limit', '200',
-        '--json', 'number,state,title,body,author,labels,assignees,updatedAt']
-      const stdout = await checkedGh(repoRoot, args)
+      const listedIssues = await listGithubIssues('closed', label)
       const permissionCache = new Map<string, Promise<boolean>>()
-      return Promise.all(parseGhJson(args, stdout, closedGithubIssueListSchema)
+      return Promise.all(closedGithubIssueListSchema.parse(listedIssues)
         .map((issue) => normalizeIssue(issue, permissionCache)))
     },
 

--- a/src/adapters/os-posix.ts
+++ b/src/adapters/os-posix.ts
@@ -5,6 +5,9 @@ import type { OperatingSystem } from './os.ts'
 
 const PROCESS_EXIT_TIMEOUT_MS = 5_000
 const PROCESS_EXIT_POLL_MS = 50
+const VERIFICATION_ENVIRONMENT_LABEL = process.platform === 'darwin'
+  ? 'macOS'
+  : process.platform === 'linux' ? 'Linux' : process.platform
 
 export interface PosixOperatingSystemRuntime {
   signalProcessGroup(processGroupId: number, signal?: NodeJS.Signals | number): void
@@ -135,6 +138,7 @@ export function createOperatingSystem(
   }
 
   return {
+    verificationEnvironmentLabel: () => VERIFICATION_ENVIRONMENT_LABEL,
     async launchDaemon(options) {
       const output = openSync(options.outputFile, 'a')
       let child

--- a/src/adapters/os-windows.ts
+++ b/src/adapters/os-windows.ts
@@ -182,6 +182,7 @@ export function createOperatingSystem(
   }
 
   return {
+    verificationEnvironmentLabel: () => 'Windows',
     async launchDaemon(options) {
       const pid = await (runtime.startDaemon ?? startWindowsProcess)(options)
       return {

--- a/src/adapters/os.ts
+++ b/src/adapters/os.ts
@@ -33,6 +33,8 @@ export interface DaemonProcess {
 }
 
 export interface OperatingSystem {
+  /** User-facing label for the environment that exercised local verification. */
+  verificationEnvironmentLabel(): string
   launchDaemon(options: DaemonLaunchOptions): Promise<DaemonProcess>
   processTreeRootPid(env?: NodeJS.ProcessEnv): number
   /** Stable identity for this particular use of a PID, or undefined when unverifiable. */

--- a/src/adapters/project.ts
+++ b/src/adapters/project.ts
@@ -58,6 +58,13 @@ export interface InfrastructureFailure {
   remediation: string
 }
 
+export interface ManualEnvironmentCheck {
+  /** Environment exercised by this opt-in check, such as Linux. */
+  environment: string
+  /** Repository-owned command a person can run before promotion. */
+  command: string
+}
+
 export interface WorktreeSetupStep {
   label: string
   /** Directory the command runs in, relative to the new worktree root. */
@@ -117,6 +124,8 @@ export interface ProjectAdapter {
   preCommitChecks: MergeCheck[]
   /** Suites the cycle gate runs against the branch tip. Steps default to light gates only. */
   cycleSuite(): SuiteStep[]
+  /** Cross-environment checks available to a person but never run automatically by the loop. */
+  manualEnvironmentChecks?: ManualEnvironmentCheck[]
   /** Repository-specific probe used when a cycle suite step needs Docker. */
   cycleSuiteDockerProbe?: DockerProbe
   /** Classify repository-specific infrastructure failures found in command output. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,8 @@ import {
 } from './merge.ts'
 import { deploy } from './deploy.ts'
 import {
-  isScanTaskId, logFile, orchPaths, packageFile, packageScriptCommand, type OrchPaths,
+  absolutePackageScriptCommand, isScanTaskId, logFile, orchPaths, packageFile,
+  type OrchPaths,
 } from './paths.ts'
 import { pruneTasks } from './prune.ts'
 import { branchAcceptsCommits, runPreCommitChecks } from './preCommit.ts'
@@ -1003,7 +1004,7 @@ const cmdLoop: Command = async (paths, args) => {
     // A daemon child inherits the launcher's approved mode. The launcher already
     // reported it, and raw child output would bypass the aligned daemon log helper.
     if (markerOutput === undefined) {
-      const runner = await loadRunner(config.runner, { env: process.env })
+      const runner = await loadRunner(config.runner, { env: process.env, repoRoot: paths.repoRoot })
       reportResolvedLoopConfig(paths, config, runner, console.log)
     }
     if (!await approveLoopStart(config, approvedMode)) return 1
@@ -1034,7 +1035,7 @@ const cmdLoop: Command = async (paths, args) => {
     )
     const daemonArgs = [
       packageFile('src', 'cli.ts'), 'loop', '--marker-output', markerLog,
-      '--approve-mode', queueMode(config),
+      '--approve-mode', queueMode(config), '--repo', paths.repoRoot,
     ]
     // The daemon must work on the repository this launcher was pointed at. Starting it
     // in the package directory instead made it resolve its own checkout as the
@@ -1059,8 +1060,8 @@ const cmdLoop: Command = async (paths, args) => {
     daemon.release()
     console.log(`Started the loop in the background (PID=${daemonPid})`)
     console.log(`Log: ${loopLog}`)
-    console.log(`Check: ${packageScriptCommand(paths.repoRoot, 'loop-status')}`)
-    console.log(`Stop: ${packageScriptCommand(paths.repoRoot, 'stop')}`)
+    console.log(`Check: ${absolutePackageScriptCommand(paths.repoRoot, 'loop-status')}`)
+    console.log(`Stop: ${absolutePackageScriptCommand(paths.repoRoot, 'stop')}`)
     return 0
   }
   const startupResultFile = process.env[LOOP_STARTUP_RESULT_FILE_ENV]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,11 +76,37 @@ async function loadProject(pathsRoot: string) {
   return projectModule.loadProject(pathsRoot)
 }
 
-function repoRoot(): string {
-  return execFileSync('git', ['rev-parse', '--show-toplevel'], {
-    encoding: 'utf8',
-    windowsHide: true,
-  }).trim()
+function repoRoot(repository?: string): string {
+  const args = repository === undefined
+    ? ['rev-parse', '--show-toplevel']
+    : ['-C', repository, 'rev-parse', '--show-toplevel']
+  let root: string
+  try {
+    root = execFileSync('git', args, {
+      encoding: 'utf8',
+      windowsHide: true,
+    }).trim()
+  } catch {
+    if (repository !== undefined) {
+      throw new Error(`Repository path '${repository}' is not a git repository.`)
+    }
+    throw new Error('The working directory is not inside a git repository.')
+  }
+  if (repository !== undefined) {
+    const orchestration = join(root, 'orchestration')
+    let isDirectory = false
+    try {
+      isDirectory = statSync(orchestration).isDirectory()
+    } catch {
+      // Report a missing directory consistently for absent paths and non-directory entries.
+    }
+    if (!isDirectory) {
+      throw new Error(
+        `Repository '${root}' is missing its orchestration directory: ${orchestration}`,
+      )
+    }
+  }
+  return root
 }
 
 function loadRepositoryConfig(paths: OrchPaths, env: NodeJS.ProcessEnv = process.env): LoopConfig {
@@ -787,24 +813,51 @@ const cmdQueue: Command = async (paths) => {
   return cmdStatus(paths, [])
 }
 
-const cmdLoopStatus: Command = async (paths) => {
-  // A compact answer to "is it running, and what is in flight". Always exits 0 so it
-  // is safe to embed in a skill preamble.
+interface LoopStatusSummary {
+  running: boolean
+  pid?: number
+  runBranch: string
+  queued: number
+  inFlight: number
+}
+
+function loopStatusSummary(paths: OrchPaths): LoopStatusSummary {
   const pidFile = join(paths.queueDir, 'loop.pid')
   const ownerPid = existsSync(pidFile)
     ? currentProcessMarkerPid(readFileSync(pidFile, 'utf8'))
     : undefined
-  if (ownerPid !== undefined) {
-    console.log(`loop: running (PID=${ownerPid})`)
-  } else {
-    console.log('loop: not running')
-  }
-
   const backlog = join(paths.queueDir, 'backlog.txt')
   const queued = existsSync(backlog)
     ? readFileSync(backlog, 'utf8').split(/\r?\n/).filter((line) => line !== '').length
     : 0
-  console.log(queued === 0 ? 'queued: none' : `queued: ${queued}`)
+  const inFlight = listTaskIds(paths).filter((taskId) => {
+    const status = readStatus(paths, taskId)?.status
+    return status === 'running' || status === 'completed' || status === 'failed'
+  }).length
+  const runBranchFile = join(paths.queueDir, 'run-branch.txt')
+  const runBranch = existsSync(runBranchFile)
+    ? readFileSync(runBranchFile, 'utf8').trim() || 'none'
+    : 'none'
+  return {
+    running: ownerPid !== undefined,
+    ...(ownerPid === undefined ? {} : { pid: ownerPid }),
+    runBranch,
+    queued,
+    inFlight,
+  }
+}
+
+const cmdLoopStatus: Command = async (paths) => {
+  // A compact answer to "is it running, and what is in flight". Always exits 0 so it
+  // is safe to embed in a skill preamble.
+  const summary = loopStatusSummary(paths)
+  if (summary.pid !== undefined) {
+    console.log(`loop: running (PID=${summary.pid})`)
+  } else {
+    console.log('loop: not running')
+  }
+
+  console.log(summary.queued === 0 ? 'queued: none' : `queued: ${summary.queued}`)
 
   // Only tasks that still need a decision; merged and cleaned-up ones need none.
   console.log('in flight:')
@@ -817,6 +870,18 @@ const cmdLoopStatus: Command = async (paths) => {
     }
   }
   if (!found) console.log('  (nothing)')
+  return 0
+}
+
+async function cmdMultiLoopStatus(repositoryRoots: string[]): Promise<number> {
+  for (const root of repositoryRoots) {
+    const paths = orchPaths(root)
+    const summary = loopStatusSummary(paths)
+    console.log(
+      `${root}: loop=${summary.running ? 'running' : 'not running'}; `
+      + `run branch=${summary.runBranch}; queued=${summary.queued}; in flight=${summary.inFlight}`,
+    )
+  }
   return 0
 }
 
@@ -1417,7 +1482,30 @@ const commands: Record<string, Command> = {
 }
 
 async function main(): Promise<number> {
-  const [commandName, ...args] = process.argv.slice(2)
+  const rawArgs = process.argv.slice(2)
+  const repositories: string[] = []
+  const positional: string[] = []
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i] as string
+    if (arg === '--repo') {
+      const value = rawArgs[++i]
+      if (value === undefined || value === '') {
+        console.error('ERROR: --repo requires a repository path')
+        return 1
+      }
+      repositories.push(value)
+    } else if (arg.startsWith('--repo=')) {
+      const value = arg.slice('--repo='.length)
+      if (value === '') {
+        console.error('ERROR: --repo requires a repository path')
+        return 1
+      }
+      repositories.push(value)
+    } else {
+      positional.push(arg)
+    }
+  }
+  const [commandName, ...args] = positional
   if (commandName === undefined || commandName === '') {
     console.error(`Usage: npm run <command>\nAvailable: ${Object.keys(commands).join(', ')}`)
     return 1
@@ -1428,8 +1516,15 @@ async function main(): Promise<number> {
     console.error(`Available commands: ${Object.keys(commands).join(', ')}`)
     return 1
   }
-  const paths = orchPaths(repoRoot(), commandName !== 'loop')
   try {
+    if (repositories.length > 1 && commandName !== 'loop-status') {
+      console.error('ERROR: only loop-status accepts more than one --repo option')
+      return 1
+    }
+    if (commandName === 'loop-status' && repositories.length > 1) {
+      return await cmdMultiLoopStatus(repositories.map((repository) => repoRoot(repository)))
+    }
+    const paths = orchPaths(repoRoot(repositories[0]), commandName !== 'loop')
     return await command(paths, args)
   } catch (error) {
     console.error((error as Error).message)

--- a/src/config.ts
+++ b/src/config.ts
@@ -337,9 +337,10 @@ export function loadConfig(
         const message = error instanceof Error ? error.message : String(error)
         if (observedStamp !== `error:${message}`) {
           observedStamp = `error:${message}`
-          emitError(`Could not inspect ${filePath}: ${message}`)
+          refreshError = new Error(`Could not inspect ${filePath}: ${message}`)
+          emitError(refreshError.message)
         }
-        return
+        throw refreshError
       }
     }
     if (stamp === observedStamp) {

--- a/src/issueQueue.ts
+++ b/src/issueQueue.ts
@@ -494,15 +494,11 @@ async function reconcileOpenFindings(
         issueSuppressesFingerprint(paths, issue, fingerprint)))
     .map((issue) => [issue.number, issue]))
   if (createdIssueNumber !== undefined && !issues.has(createdIssueNumber)) {
-    try {
-      const created = await forge.getIssue(createdIssueNumber)
-      if (created.state === 'open'
-        && isTrustedFingerprintOwner(created)
-        && hasExactFingerprints(created, fingerprints)) {
-        issues.set(created.number, created)
-      }
-    } catch {
-      // A concurrent close can make a just-created issue disappear from the open set.
+    const created = await forge.getIssue(createdIssueNumber)
+    if (created.state === 'open'
+      && isTrustedFingerprintOwner(created)
+      && hasExactFingerprints(created, fingerprints)) {
+      issues.set(created.number, created)
     }
   }
   const ordered = [...issues.values()].sort((a, b) => a.number - b.number)
@@ -513,12 +509,7 @@ async function reconcileOpenFindings(
     await withIssueCoordination(forge, duplicate.number, async () => {
       // Assignment and labels may have changed since listOpenIssues returned. Re-read
       // inside the same critical section used by claims before closing.
-      let current: ForgeIssue
-      try {
-        current = await forge.getIssue(duplicate.number)
-      } catch {
-        return
-      }
+      const current = await forge.getIssue(duplicate.number)
       if (isReadyToClose(current, fingerprints)) {
         await closeDuplicate(forge, current.number, survivor, onMutation)
       }
@@ -605,12 +596,7 @@ export async function reconcileFindingFingerprints(
       && !isClaimed(issue)
       && coveredBy.every((owner) => owner !== undefined)) {
       await withIssueCoordination(forge, issue.number, async () => {
-        let current: ForgeIssue
-        try {
-          current = await forge.getIssue(issue.number)
-        } catch {
-          return
-        }
+        const current = await forge.getIssue(issue.number)
         if (isReadyToClose(current, fingerprints)) {
           await closeDuplicate(
             forge, issue.number, coveredBy[0] as number,

--- a/src/issueQueue.ts
+++ b/src/issueQueue.ts
@@ -1369,6 +1369,30 @@ async function releasePartialClaim(
   }
 }
 
+async function restoreReadyAfterClaimDrift(
+  forge: Forge,
+  issueNumber: number,
+  me: string,
+): Promise<void> {
+  await forge.unassignIssue(issueNumber, me)
+  const current = await forge.getIssue(issueNumber)
+  if (current.state !== 'open') return
+  if (!current.labels.includes(LABEL_READY)) {
+    await forge.addLabel(issueNumber, LABEL_READY)
+  }
+  for (const label of LIFECYCLE_LABELS) {
+    if (label !== LABEL_READY && current.labels.includes(label)) {
+      await forge.removeLabel(issueNumber, label)
+    }
+  }
+  const restored = await forge.getIssue(issueNumber)
+  if (restored.state === 'open'
+    && (restored.assignees.length !== 0
+      || !issueHasExactlyLifecycleLabel(restored, LABEL_READY))) {
+    throw new Error(`Issue #${issueNumber} did not reach the single ${LABEL_READY} lifecycle state`)
+  }
+}
+
 async function releasePartialQuarantine(
   forge: Forge,
   issueNumber: number,
@@ -1435,10 +1459,12 @@ async function claimRemoteIssue(
     throw error
   }
   const winner = [...afterAssignment.assignees].sort()[0]
-  if (afterAssignment.state !== 'open'
-    || !issueHasExactlyLifecycleLabel(afterAssignment, LABEL_READY)
-    || winner !== me) {
+  if (afterAssignment.state !== 'open' || winner !== me) {
     await forge.unassignIssue(issue.number, me)
+    return { outcome: 'lost-race', issueNumber: issue.number }
+  }
+  if (!issueHasExactlyLifecycleLabel(afterAssignment, LABEL_READY)) {
+    await restoreReadyAfterClaimDrift(forge, issue.number, me)
     return { outcome: 'lost-race', issueNumber: issue.number }
   }
   try {
@@ -1457,10 +1483,12 @@ async function claimRemoteIssue(
   }
 
   const claimed = await forge.getIssue(issue.number)
-  if (claimed.state !== 'open'
-    || !issueHasExactlyLifecycleLabel(claimed, LABEL_IN_PROGRESS)
-    || [...claimed.assignees].sort()[0] !== me) {
+  if (claimed.state !== 'open' || [...claimed.assignees].sort()[0] !== me) {
     await forge.unassignIssue(issue.number, me)
+    return { outcome: 'lost-race', issueNumber: issue.number }
+  }
+  if (!issueHasExactlyLifecycleLabel(claimed, LABEL_IN_PROGRESS)) {
+    await restoreReadyAfterClaimDrift(forge, issue.number, me)
     return { outcome: 'lost-race', issueNumber: issue.number }
   }
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -28,7 +28,9 @@ import {
 import { buildPrBody, GENERATED_BODY_MARKER, prTitle } from './prbody.ts'
 import { refreshTask, listTaskIds, noChangeMarkerPresent } from './refresh.ts'
 import { readStatus, transitionStatus } from './status.ts'
-import { startTask, StartupProcessRetainedError } from './start.ts'
+import {
+  startTask, StartupOwnershipUnknownError, StartupProcessRetainedError,
+} from './start.ts'
 import { enqueueTask, newTaskSpec, specFile } from './tasks.ts'
 import {
   terminateLiveTaskProcesses, type TaskProcessTermination,
@@ -2539,6 +2541,14 @@ export function createLoop(deps: LoopDeps) {
           previousGateFailures.delete(`task-startup-${entry.taskId}`)
           running += 1
         } catch (error) {
+          if (error instanceof StartupOwnershipUnknownError) {
+            event(
+              'ERROR', shortTaskId(entry.taskId),
+              'runner returned an invalid PID; task ownership is unknown, task retained and loop stopped',
+            )
+            writeFileSync(stopFile, '')
+            break
+          }
           if (error instanceof StartupProcessRetainedError) {
             event(
               'ERROR', shortTaskId(entry.taskId),

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -28,7 +28,7 @@ import {
 import { buildPrBody, GENERATED_BODY_MARKER, prTitle } from './prbody.ts'
 import { refreshTask, listTaskIds, noChangeMarkerPresent } from './refresh.ts'
 import { readStatus, transitionStatus } from './status.ts'
-import { startTask } from './start.ts'
+import { startTask, StartupProcessRetainedError } from './start.ts'
 import { enqueueTask, newTaskSpec, specFile } from './tasks.ts'
 import {
   terminateLiveTaskProcesses, type TaskProcessTermination,
@@ -77,6 +77,7 @@ export interface LoopDeps {
   orchestrationDepsRuntime?: OrchestrationDepsRuntime | undefined
   terminateTaskProcesses?: (() => TaskProcessTermination) | undefined
   enqueueTask?: typeof enqueueTask
+  startTask?: typeof startTask
   updateCoreBeforeCycle?: (cycle: number) => Promise<CoreUpdateOutcome>
   projectAdapterChanged?: () => boolean
   branchGuard?: (() => string | undefined) | undefined
@@ -132,6 +133,7 @@ export function createLoop(deps: LoopDeps) {
     orchestrationDepsRuntime,
     terminateTaskProcesses = () => terminateLiveTaskProcesses(paths),
     enqueueTask: enqueueTaskImpl = enqueueTask,
+    startTask: startTaskImpl = startTask,
   } = deps
   const queueFile = join(paths.queueDir, 'backlog.txt')
   const stopFile = join(paths.queueDir, 'stop')
@@ -2031,7 +2033,7 @@ export function createLoop(deps: LoopDeps) {
         : `This scan runs alongside ${nScans - 1} partner scan(s). Perform only sections ${sectionGroups[i - 1]!.join(', ')}; the partners cover the rest. Stay inside them — overlapping findings merge away, duplicated reading does not.`
       writeFileSync(specFile(paths, scanId), scanSpecification(scanId, scope))
       try {
-        await startTask(paths, runner, scanId, {
+        await startTaskImpl(paths, runner, scanId, {
           effort: config.scanEffort as 'high',
           model: config.scanModel === '' ? undefined : config.scanModel,
           setup: project.scanWorktreeSetup,
@@ -2503,7 +2505,7 @@ export function createLoop(deps: LoopDeps) {
           ? readFileSync(effortFile, 'utf8').replace(/[\s\r\n]/g, '')
           : config.taskEffort
         try {
-          await startTask(paths, runner, entry.taskId, {
+          await startTaskImpl(paths, runner, entry.taskId, {
             effort: effort as 'medium',
             model: config.taskModel === '' ? undefined : config.taskModel,
           })
@@ -2519,6 +2521,14 @@ export function createLoop(deps: LoopDeps) {
           previousGateFailures.delete(`task-startup-${entry.taskId}`)
           running += 1
         } catch (error) {
+          if (error instanceof StartupProcessRetainedError) {
+            event(
+              'ERROR', shortTaskId(entry.taskId),
+              `startup process tree PID ${error.pid} survived; task retained and loop stopped`,
+            )
+            writeFileSync(stopFile, '')
+            break
+          }
           const issueNumbers = issueNumbersForTask(paths, entry.taskId)
           if (config.issueQueueEnabled && issueNumbers.length > 0) {
             recordIssueFailure(paths, entry.taskId)

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -44,6 +44,7 @@ import { currentBranchPushRemote, currentBranchTrackingRemote } from './gitRemot
 import { LoopWarningLog } from './loopLog.ts'
 import { newestChecksByName } from './ciWait.ts'
 import { execShellSync } from './shell.ts'
+import { operatingSystem, type OperatingSystem } from './adapters/os.ts'
 import {
   updateCoreBeforeCycle, type CoreUpdateOutcome,
 } from './coreUpdate.ts'
@@ -84,6 +85,7 @@ export interface LoopDeps {
   projectAdapterChanged?: () => boolean
   branchGuard?: (() => string | undefined) | undefined
   prepareIntegrationWorktree?: (() => void) | undefined
+  os?: OperatingSystem | undefined
 }
 
 interface QueueEntry {
@@ -99,13 +101,6 @@ interface FindingDispatch {
 
 const IDLE_LOG_MAX_INTERVAL_MS = 5 * 60 * 1000
 const MAX_CONSECUTIVE_ISSUE_RELEASE_FAILURES = 3
-
-function platformName(platform: NodeJS.Platform): string {
-  if (platform === 'win32') return 'Windows'
-  if (platform === 'darwin') return 'macOS'
-  if (platform === 'linux') return 'Linux'
-  return platform
-}
 
 function formatIdleDuration(milliseconds: number): string {
   const totalSeconds = Math.floor(milliseconds / 1000)
@@ -143,6 +138,7 @@ export function createLoop(deps: LoopDeps) {
     terminateTaskProcesses = () => terminateLiveTaskProcesses(paths),
     enqueueTask: enqueueTaskImpl = enqueueTask,
     startTask: startTaskImpl = startTask,
+    os = operatingSystem,
   } = deps
   const queueFile = join(paths.queueDir, 'backlog.txt')
   const stopFile = join(paths.queueDir, 'stop')
@@ -1647,17 +1643,6 @@ export function createLoop(deps: LoopDeps) {
       }
       return false
     }
-    const gateEnvironment = platformName(process.platform)
-    event(
-      'Status', 'Environments',
-      `run verification exercised ${gateEnvironment}; promoted branch was not run in any other environment`,
-    )
-    for (const check of project.manualEnvironmentChecks ?? []) {
-      event(
-        'Status', `${check.environment} check`,
-        `not run for this branch; run ${check.command}`,
-      )
-    }
     if (status.isDraft) {
       try {
         await forge.markPrReady(branch)
@@ -1687,6 +1672,17 @@ export function createLoop(deps: LoopDeps) {
       }
     }
     if (status.state !== 'open' || status.isDraft) return false
+    const gateEnvironment = os.verificationEnvironmentLabel()
+    event(
+      'Status', 'Environments',
+      `run verification exercised ${gateEnvironment}; promoted branch was not run in any other environment`,
+    )
+    for (const check of project.manualEnvironmentChecks ?? []) {
+      event(
+        'Status', `${check.environment} check`,
+        `not run for this branch; run ${check.command}`,
+      )
+    }
     // The body reflects branch history, so it also lists intermediate changes that were
     // later reverted — the need to rewrite it must be impossible to overlook.
     marker(`LOOP_DONE: ${prUrl}`)

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -98,6 +98,13 @@ interface FindingDispatch {
 const IDLE_LOG_MAX_INTERVAL_MS = 5 * 60 * 1000
 const MAX_CONSECUTIVE_ISSUE_RELEASE_FAILURES = 3
 
+function platformName(platform: NodeJS.Platform): string {
+  if (platform === 'win32') return 'Windows'
+  if (platform === 'darwin') return 'macOS'
+  if (platform === 'linux') return 'Linux'
+  return platform
+}
+
 function formatIdleDuration(milliseconds: number): string {
   const totalSeconds = Math.floor(milliseconds / 1000)
   if (totalSeconds < 60) return `${totalSeconds}s`
@@ -1637,6 +1644,17 @@ export function createLoop(deps: LoopDeps) {
         )
       }
       return false
+    }
+    const gateEnvironment = platformName(process.platform)
+    event(
+      'Status', 'Environments',
+      `run verification exercised ${gateEnvironment}; promoted branch was not run in any other environment`,
+    )
+    for (const check of project.manualEnvironmentChecks ?? []) {
+      event(
+        'Status', `${check.environment} check`,
+        `not run for this branch; run ${check.command}`,
+      )
     }
     if (status.isDraft) {
       try {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -54,6 +54,20 @@ export function packageScriptCommand(
   return `${packageCommandPrefix(repoRoot, packageRoot)} ${script}`
 }
 
+function shellPathArgument(path: string): string {
+  return `'${path.replaceAll('\\', '/').replaceAll("'", "'\\''")}'`
+}
+
+/** Render a package command that can be copied and run from any working directory. */
+export function absolutePackageScriptCommand(
+  repoRoot: string,
+  script: string,
+  packageRoot = PACKAGE_ROOT,
+): string {
+  const command = `npm run -C ${shellPathArgument(packageRoot)} ${script}`
+  return `${command} -- --repo ${shellPathArgument(repoRoot)}`
+}
+
 export interface OrchPaths {
   root: string
   repoRoot: string

--- a/src/sharedSkills.ts
+++ b/src/sharedSkills.ts
@@ -161,14 +161,16 @@ function renderedSkill(
   return filesIn(source).map((file) => {
     let contents = file.contents
     if (file.path === 'SKILL.md') {
+      const sourceContents = contents.toString('utf8')
       const injection = guidance === ''
         ? ''
-        : `${contents.toString('utf8').endsWith('\n') ? '\n' : '\n\n'}${guidance}`
+        : `${sourceContents.endsWith('\n') ? '\n' : '\n\n'}${guidance}`
+      // The injection point is synthetic and always follows the canonical skill. A
+      // literal placeholder in the skill's prose documents the mechanism and must stay.
+      const withInjectionPoint = `${sourceContents}${manifest.projectGuidancePlaceholder}`
+      const injectionPoint = withInjectionPoint.length - manifest.projectGuidancePlaceholder.length
       contents = Buffer.from(
-        `${contents.toString('utf8')}${manifest.projectGuidancePlaceholder}`.replaceAll(
-          manifest.projectGuidancePlaceholder,
-          injection,
-        ),
+        `${withInjectionPoint.slice(0, injectionPoint)}${injection}`,
       )
     }
     return {

--- a/src/sharedSkills.ts
+++ b/src/sharedSkills.ts
@@ -25,6 +25,7 @@ interface SharedSkillTarget {
 interface SharedSkillsManifest {
   commandPrefixPlaceholder: string
   packagePathPrefixPlaceholder: string
+  projectGuidancePlaceholder: string
   skills: string[]
 }
 
@@ -36,6 +37,11 @@ interface SharedSkillsState {
 interface RenderedFile {
   path: string
   contents: Buffer
+}
+
+/** Repository-owned guidance appended at the shared skill's named injection point. */
+export function projectGuidanceFileForSkill(repoRoot: string, skill: string): string {
+  return join(repoRoot, 'orchestration', 'project', 'skills', `${skill}.md`)
 }
 
 export interface SharedSkillsSyncResult {
@@ -61,10 +67,12 @@ export function sharedSkillManagedTargets(
   packageRoot: string,
   adapters: readonly SharedSkillsAdapter[],
 ): SharedSkillManagedTarget[] {
-  const manifest = readManifest(packageRoot)
+  readManifest(packageRoot)
   return skillTargets(repoRoot, adapters).map((target) => {
-    const paths = [join(target.destinationRoot, STATE_FILE)]
-    paths.push(...manifest.skills.map((skill) => join(target.destinationRoot, skill)))
+    const stateFile = join(target.destinationRoot, STATE_FILE)
+    const state = readState(stateFile)
+    const paths = [stateFile]
+    paths.push(...Object.keys(state.skills).map((skill) => join(target.destinationRoot, skill)))
     for (const legacyRoot of target.legacyRoots) {
       const stateFile = join(legacyRoot, STATE_FILE)
       if (!existsSync(stateFile)) continue
@@ -87,9 +95,11 @@ function readManifest(packageRoot: string): SharedSkillsManifest {
   const parsed = object(JSON.parse(readFileSync(file, 'utf8')))
   const placeholder = parsed?.commandPrefixPlaceholder
   const packagePathPrefixPlaceholder = parsed?.packagePathPrefixPlaceholder
+  const projectGuidancePlaceholder = parsed?.projectGuidancePlaceholder
   const skills = parsed?.skills
   if (typeof placeholder !== 'string' || placeholder === ''
     || typeof packagePathPrefixPlaceholder !== 'string' || packagePathPrefixPlaceholder === ''
+    || typeof projectGuidancePlaceholder !== 'string' || projectGuidancePlaceholder === ''
     || !Array.isArray(skills)
     || skills.some((skill) => typeof skill !== 'string'
       || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(skill))) {
@@ -101,6 +111,7 @@ function readManifest(packageRoot: string): SharedSkillsManifest {
   return {
     commandPrefixPlaceholder: placeholder,
     packagePathPrefixPlaceholder,
+    projectGuidancePlaceholder,
     skills: skills as string[],
   }
 }
@@ -145,15 +156,31 @@ function renderedSkill(
   if (!existsSync(join(source, 'SKILL.md'))) {
     throw new Error(`shared skill has no SKILL.md: ${source}`)
   }
-  return filesIn(source).map((file) => ({
-    ...file,
-    contents: target.renderFile(file.contents, {
-      repoRoot,
-      packageRoot,
-      commandPrefixPlaceholder: manifest.commandPrefixPlaceholder,
-      packagePathPrefixPlaceholder: manifest.packagePathPrefixPlaceholder,
-    }),
-  }))
+  const guidanceFile = projectGuidanceFileForSkill(repoRoot, skill)
+  const guidance = existsSync(guidanceFile) ? readFileSync(guidanceFile, 'utf8') : ''
+  return filesIn(source).map((file) => {
+    let contents = file.contents
+    if (file.path === 'SKILL.md') {
+      const injection = guidance === ''
+        ? ''
+        : `${contents.toString('utf8').endsWith('\n') ? '\n' : '\n\n'}${guidance}`
+      contents = Buffer.from(
+        `${contents.toString('utf8')}${manifest.projectGuidancePlaceholder}`.replaceAll(
+          manifest.projectGuidancePlaceholder,
+          injection,
+        ),
+      )
+    }
+    return {
+      ...file,
+      contents: target.renderFile(contents, {
+        repoRoot,
+        packageRoot,
+        commandPrefixPlaceholder: manifest.commandPrefixPlaceholder,
+        packagePathPrefixPlaceholder: manifest.packagePathPrefixPlaceholder,
+      }),
+    }
+  })
 }
 
 /** Every directory this repository's skills must appear in, each listed once. */
@@ -265,8 +292,8 @@ function migrateLegacySkills(
 
 /**
  * Materialize the package's declared shared skills into one target directory. The state
- * records the exact rendered tree last written, so later syncs never mistake a person's
- * edit (including an added support file or a deletion) for an old generated copy.
+ * records which skill trees the core owns. Later syncs replace those trees, including
+ * consumer edits, added support files, and deletions; unrecorded skills remain untouched.
  */
 function syncTarget(
   repoRoot: string,
@@ -312,10 +339,14 @@ function syncTarget(
       }
       const currentHash = hashFiles(filesIn(destination))
       if (currentHash === desiredHash) {
-        if (previousHash === desiredHash) managedPaths.push(destination)
+        if (previousHash !== undefined) {
+          nextState.skills[skill] = desiredHash
+          managedPaths.push(destination)
+          if (previousHash !== desiredHash) updated.push(reported(skill))
+        }
         continue
       }
-      if (previousHash === undefined || currentHash !== previousHash) {
+      if (previousHash === undefined) {
         conflicts.push(reported(skill))
         continue
       }
@@ -327,7 +358,11 @@ function syncTarget(
       continue
     }
     if (previousHash !== undefined) {
-      conflicts.push(reported(skill))
+      replaceDirectory(destination, desiredFiles, os)
+      nextState.skills[skill] = desiredHash
+      updated.push(reported(skill))
+      changedPaths.push(destination)
+      managedPaths.push(destination)
       continue
     }
     replaceDirectory(destination, desiredFiles, os)

--- a/src/start.ts
+++ b/src/start.ts
@@ -35,6 +35,14 @@ export class StartupProcessRetainedError extends AggregateError {
   }
 }
 
+/** The runner started, but did not identify the process that now owns the worktree. */
+export class StartupOwnershipUnknownError extends Error {
+  constructor(pid: number) {
+    super(`Runner returned invalid PID ${String(pid)}; process ownership could not be established.`)
+    this.name = 'StartupOwnershipUnknownError'
+  }
+}
+
 export function worktreeAddArgs(worktree: string, branch: string): string[] {
   return ['worktree', 'add', '--quiet', worktree, '-b', branch]
 }
@@ -119,6 +127,9 @@ export async function startTask(
       effort: options.effort,
       model: options.model,
     })
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+      throw new StartupOwnershipUnknownError(pid)
+    }
     launchedPid = pid
     // Ownership must survive a failure to acquire or publish the status record. The
     // loop consults this registry before deciding whether failed startup work is safe
@@ -129,6 +140,10 @@ export async function startTask(
     return { outcome: 'started', pid }
   } catch (error) {
     const detail = error instanceof Error ? error.stack ?? error.message : String(error)
+    if (error instanceof StartupOwnershipUnknownError) {
+      appendFileSync(log, `Task startup ownership is unknown:\n${detail}\n`)
+      throw error
+    }
     if (launchedPid !== undefined) {
       try {
         operatingSystem.terminateProcessTree(launchedPid)

--- a/src/start.ts
+++ b/src/start.ts
@@ -6,6 +6,7 @@ import type { WorktreeSetupStep } from './adapters/project.ts'
 import type { Runner, RunnerStartOptions } from './adapters/runner.ts'
 import { branchName, finalMessageFile, logFile, worktreeDir, type OrchPaths } from './paths.ts'
 import { execShellSync } from './shell.ts'
+import { recordTaskProcess } from './processRegistry.ts'
 import { readStatus, writeStatus } from './status.ts'
 import { specFile } from './tasks.ts'
 
@@ -18,6 +19,20 @@ export interface StartOptions {
   model?: string | undefined
   setup?: WorktreeSetupStep[] | undefined
   report?: ((line: string) => void) | undefined
+}
+
+/** Startup failed, but the launched runner still owns the task and must be retained. */
+export class StartupProcessRetainedError extends AggregateError {
+  readonly pid: number
+
+  constructor(pid: number, startupError: unknown, terminationError: unknown) {
+    super(
+      [startupError, terminationError],
+      `Task startup failed and process tree ${pid} could not be stopped.`,
+    )
+    this.name = 'StartupProcessRetainedError'
+    this.pid = pid
+  }
 }
 
 export function worktreeAddArgs(worktree: string, branch: string): string[] {
@@ -105,6 +120,10 @@ export async function startTask(
       model: options.model,
     })
     launchedPid = pid
+    // Ownership must survive a failure to acquire or publish the status record. The
+    // loop consults this registry before deciding whether failed startup work is safe
+    // to release or retry.
+    recordTaskProcess(paths, taskId, pid)
     await writeStatus(paths, taskId, 'running', pid)
     options.report?.(`Started. task_id=${taskId} pid=${pid} log=${log}`)
     return { outcome: 'started', pid }
@@ -124,10 +143,7 @@ export async function startTask(
           log,
           `Task startup failed:\n${detail}\nProcess tree cleanup failed:\n${terminationDetail}\n`,
         )
-        throw new AggregateError(
-          [error, terminationError],
-          `Task startup failed and process tree ${launchedPid} could not be stopped.`,
-        )
+        throw new StartupProcessRetainedError(launchedPid, error, terminationError)
       }
     }
     appendFileSync(log, `Task startup failed:\n${detail}\n`)

--- a/tests/__snapshots__/runner-codex.test.ts.snap
+++ b/tests/__snapshots__/runner-codex.test.ts.snap
@@ -292,6 +292,16 @@ Edit the generated \`orchestration/project/project-<name>.ts\` from the decision
 only when init created it in this run. If an adapter already existed, report it and ask
 before changing it; deliberate divergence is not a repair target.
 
+Shared skills rendered into \`.agents/skills/\` or \`.claude/skills/\` and recorded in that
+directory's \`.orchestration-core-sync.json\` are core-owned. Do not edit their rendered
+trees: clean syncs overwrite edits, deletions, and added support files. To add
+repository-specific guidance to shared skill \`<name>\`, write the fragment at
+\`orchestration/project/skills/<name>.md\`. The renderer places it at the automatic
+\`{{ORCHESTRATION_PROJECT_GUIDANCE}}\` injection point at the end of \`SKILL.md\`; when no
+fragment exists, the point renders to nothing. Skills absent from the managed index are
+repository-owned and remain untouched, so a repository may still supply a complete local
+skill beside the rendered ones.
+
 Keep \`preCommitChecks\` fast. The core-owned hook supplies the default-branch guard and
 selects these checks from staged paths. Do not create repository-owned hook scripts.
 

--- a/tests/__snapshots__/runner-codex.test.ts.snap
+++ b/tests/__snapshots__/runner-codex.test.ts.snap
@@ -327,6 +327,10 @@ Current state:
 
 Run \`npm run loop-status\` and use its output as context before continuing.
 
+To inspect repositories other than the working directory, pass \`-- --repo <path>\`.
+Repeat \`--repo <path>\` in the same \`loop-status\` invocation to get one fleet-status line
+per repository. The core does not remember repository paths between invocations.
+
 ## Before starting
 
 A second loop against the same repository will fight the first over the queue and the
@@ -339,6 +343,9 @@ The loop commits and merges on its own, so start it on a topic branch, never on 
 \`\`\`bash
 npm run loop -- --approve-mode local --daemon
 \`\`\`
+
+Add \`--repo <path>\` after \`--\` to start the loop for an explicitly named repository.
+The path must resolve to a Git repository containing \`orchestration/\`.
 
 \`--daemon\` is what puts it in the background; without it the loop holds the terminal.
 The command approves the default local queue explicitly. If
@@ -420,11 +427,18 @@ Current state:
 
 Run \`npm run loop-status\` and use its output as context before continuing.
 
+To inspect repositories other than the working directory, pass \`-- --repo <path>\`.
+Repeat \`--repo <path>\` in the same \`loop-status\` invocation to get one fleet-status line
+per repository. The core does not remember repository paths between invocations.
+
 ## Stopping
 
 \`\`\`bash
 npm run stop
 \`\`\`
+
+Add \`-- --repo <path>\` to stop the loop for an explicitly named repository. The path
+must resolve to a Git repository containing \`orchestration/\`.
 
 This writes a stop file. The loop notices it on its next poll, so it exits within
 \`POLL_INTERVAL\` seconds — 30 by default. The command also terminates every live task

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -9,7 +9,9 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { issueCompletionForIssue, recordIssuesForTask } from '../src/issueQueue.ts'
-import { branchName, finalMessageFile, orchPaths, statusFile, worktreeDir } from '../src/paths.ts'
+import {
+  absolutePackageScriptCommand, branchName, finalMessageFile, orchPaths, statusFile, worktreeDir,
+} from '../src/paths.ts'
 import { recordTaskProcess } from '../src/processRegistry.ts'
 import { processMarker, processMarkerText } from '../src/processMarker.ts'
 import { writeStatus } from '../src/status.ts'
@@ -681,6 +683,54 @@ describe('manually promoted run ending', () => {
 })
 
 describe('loop daemon ownership', () => {
+  it('keeps a cross-repository daemon and its reported commands bound to the target', async () => {
+    const callerRoot = realpathSync.native(mkdtempSync(join(tmpdir(), 'orch-cli-caller-')))
+    extraRoots.push(callerRoot)
+    mkdirSync(join(repoRoot, 'orchestration'))
+    writeFileSync(join(repoRoot, 'relative-runner.mjs'), [
+      "import { join } from 'node:path'",
+      'export default {',
+      '  sharedSkills: {',
+      "    destinationRoot: (root) => join(root, '.test-runner', 'skills'),",
+      '    renderFile: (contents) => contents,',
+      '  },',
+      '  start: async () => process.pid,',
+      '}',
+      '',
+    ].join('\n'))
+
+    const result = spawnSync(
+      process.execPath,
+      [CLI, 'loop', '--approve-mode', 'local', '--daemon', '--repo', repoRoot],
+      {
+        cwd: callerRoot,
+        env: {
+          ...CORE_ENV,
+          AUTO_PR: 'false',
+          ISSUE_QUEUE_ENABLED: 'false',
+          MAX_SCAN_CYCLES: '0',
+          RUNNER: './relative-runner.mjs',
+          SCAN_ENABLED: 'true',
+        },
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: CLI_TIMEOUT_MS,
+      },
+    )
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout).toContain('Started the loop in the background')
+    expect(result.stdout).toContain(
+      `Check: ${absolutePackageScriptCommand(repoRoot, 'loop-status')}`,
+    )
+    expect(result.stdout).toContain(`Stop: ${absolutePackageScriptCommand(repoRoot, 'stop')}`)
+    const match = /Started the loop in the background \(PID=(\d+)\)/.exec(result.stdout)
+    expect(match).not.toBeNull()
+    const daemonPid = Number(match?.[1])
+    testProcesses.trackPid(daemonPid, { tree: true })
+    await waitUntil(() => !pidIsAlive(daemonPid), 'cross-repository daemon did not stop')
+  })
+
   it('refuses a non-interactive start without an approved mode before side effects', () => {
     const result = spawnSync(process.execPath, [CLI, 'loop'], {
       cwd: repoRoot,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -54,6 +54,7 @@ const CORE_ENV = {
 }
 
 let repoRoot: string
+let extraRoots: string[]
 const testProcesses = new TestProcessRegistry()
 
 beforeEach(() => {
@@ -61,6 +62,7 @@ beforeEach(() => {
   // (RUNNER~1 for runneradmin), while paths the CLI reports are canonical. Compare like
   // with like, or the assertions differ only in a place no developer machine reproduces.
   repoRoot = realpathSync.native(mkdtempSync(join(tmpdir(), 'orch-cli-')))
+  extraRoots = []
   const init = spawnSync('git', ['init'], { cwd: repoRoot, windowsHide: true })
   expect(init.status).toBe(0)
 })
@@ -68,6 +70,7 @@ beforeEach(() => {
 afterEach(async () => {
   await testProcesses.cleanup()
   rmSync(repoRoot, { recursive: true, force: true })
+  for (const root of extraRoots) rmSync(root, { recursive: true, force: true })
 })
 
 function daemonFile(name: string): string {
@@ -193,6 +196,120 @@ describe('command registry', () => {
       vi.doUnmock('node:child_process')
       vi.resetModules()
     }
+  })
+})
+
+describe('repository selection', () => {
+  it('resolves an explicit repository other than the working directory', () => {
+    const otherRepo = join(repoRoot, 'other-repository')
+    mkdirSync(otherRepo)
+    expect(spawnSync('git', ['init'], { cwd: otherRepo, windowsHide: true }).status).toBe(0)
+    mkdirSync(join(otherRepo, 'orchestration'))
+
+    const result = spawnSync(
+      process.execPath,
+      [CLI, 'new', 'explicit-repository-task', '--repo', otherRepo],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: CLI_TIMEOUT_MS,
+      },
+    )
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(existsSync(join(otherRepo, 'orchestration', 'tasks', 'explicit-repository-task.md')))
+      .toBe(true)
+    expect(existsSync(join(repoRoot, 'orchestration', 'tasks', 'explicit-repository-task.md')))
+      .toBe(false)
+  })
+
+  it('continues to resolve the repository from the working directory without the option', () => {
+    const result = spawnSync(process.execPath, [CLI, 'new', 'working-directory-task'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: CLI_TIMEOUT_MS,
+    })
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(existsSync(join(repoRoot, 'orchestration', 'tasks', 'working-directory-task.md')))
+      .toBe(true)
+  })
+
+  it('reports an explicit path that is not a git repository', () => {
+    const notRepository = mkdtempSync(join(tmpdir(), 'orch-cli-not-repo-'))
+    extraRoots.push(notRepository)
+
+    const result = spawnSync(
+      process.execPath,
+      [CLI, 'loop-status', '--repo', notRepository],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: CLI_TIMEOUT_MS,
+      },
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain(`Repository path '${notRepository}' is not a git repository.`)
+  })
+
+  it('reports an explicit git repository without an orchestration directory', () => {
+    const repository = join(repoRoot, 'repository-without-orchestration')
+    mkdirSync(repository)
+    expect(spawnSync('git', ['init'], { cwd: repository, windowsHide: true }).status).toBe(0)
+
+    const result = spawnSync(
+      process.execPath,
+      [CLI, 'loop-status', '--repo', repository],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: CLI_TIMEOUT_MS,
+      },
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('is missing its orchestration directory')
+    expect(result.stderr).toContain(join(repository, 'orchestration'))
+  })
+
+  it('reports two repositories with one fleet-status line each', async () => {
+    const firstPaths = orchPaths(repoRoot)
+    writeFileSync(join(firstPaths.queueDir, 'loop.pid'), processMarkerText(processMarker(process.pid)))
+    writeFileSync(join(firstPaths.queueDir, 'run-branch.txt'), 'run/first\n')
+    writeFileSync(join(firstPaths.queueDir, 'backlog.txt'), 'first:0\nsecond:1\n')
+    await writeStatus(firstPaths, 'first-in-flight', 'running')
+
+    const secondRepo = join(repoRoot, 'second-repository')
+    mkdirSync(secondRepo)
+    expect(spawnSync('git', ['init'], { cwd: secondRepo, windowsHide: true }).status).toBe(0)
+    const secondPaths = orchPaths(secondRepo)
+    writeFileSync(join(secondPaths.queueDir, 'run-branch.txt'), 'run/second\n')
+    await writeStatus(secondPaths, 'second-completed', 'completed')
+    await writeStatus(secondPaths, 'second-failed', 'failed')
+
+    const firstRoot = git(['rev-parse', '--show-toplevel']).trim()
+    const secondRoot = git(['rev-parse', '--show-toplevel'], secondRepo).trim()
+    const result = spawnSync(
+      process.execPath,
+      [CLI, 'loop-status', '--repo', repoRoot, '--repo', secondRepo],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: CLI_TIMEOUT_MS,
+      },
+    )
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout.trim().split(/\r?\n/)).toEqual([
+      `${firstRoot}: loop=running; run branch=run/first; queued=2; in flight=1`,
+      `${secondRoot}: loop=not running; run branch=run/second; queued=0; in flight=2`,
+    ])
   })
 })
 

--- a/tests/config-inspection.test.ts
+++ b/tests/config-inspection.test.ts
@@ -1,0 +1,50 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ inspectionError: undefined as Error | undefined }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    statSync: (...args: Parameters<typeof actual.statSync>) => {
+      if (mocks.inspectionError !== undefined) throw mocks.inspectionError
+      return actual.statSync(...args)
+    },
+  }
+})
+
+import { loadConfig } from '../src/config.ts'
+
+let temporaryDirectory: string | undefined
+
+afterEach(() => {
+  mocks.inspectionError = undefined
+  if (temporaryDirectory !== undefined) {
+    rmSync(temporaryDirectory, { recursive: true, force: true })
+    temporaryDirectory = undefined
+  }
+})
+
+describe('loadConfig inspection failures', () => {
+  it('stops serving stale values after a non-ENOENT inspection failure', () => {
+    temporaryDirectory = mkdtempSync(join(tmpdir(), 'orch-config-inspection-'))
+    const filePath = join(temporaryDirectory, 'config.json')
+    writeFileSync(filePath, JSON.stringify({ MAX_PARALLEL: 6 }))
+    const events: string[] = []
+    const config = loadConfig({}, {
+      filePath,
+      onEvent: (event) => events.push(event.message),
+    })
+    expect(config.maxParallel).toBe(6)
+
+    const error = Object.assign(new Error('access denied'), { code: 'EACCES' })
+    mocks.inspectionError = error
+
+    expect(() => config.maxParallel).toThrow(`Could not inspect ${filePath}: access denied`)
+    expect(() => config.maxParallel).toThrow(`Could not inspect ${filePath}: access denied`)
+    expect(events).toEqual([`Could not inspect ${filePath}: access denied`])
+  })
+})

--- a/tests/consumer-smoke.test.ts
+++ b/tests/consumer-smoke.test.ts
@@ -91,6 +91,8 @@ describe('consumer startup', () => {
       'loop',
       '--marker-output',
       markerLog,
+      '--repo',
+      repository,
     ]
 
     const command = restartModule.loopRestartCommand(invocation)

--- a/tests/core-update.test.ts
+++ b/tests/core-update.test.ts
@@ -115,6 +115,7 @@ beforeEach(() => {
   writeFileSync(join(upstreamRoot, 'skills', 'manifest.json'), JSON.stringify({
     commandPrefixPlaceholder: '{{ORCHESTRATION_COMMAND_PREFIX}}',
     packagePathPrefixPlaceholder: '{{ORCHESTRATION_PACKAGE_PATH_PREFIX}}',
+    projectGuidancePlaceholder: '{{ORCHESTRATION_PROJECT_GUIDANCE}}',
     skills: ['loop-start'],
   }))
   writeUpstreamSkill('version one: {{ORCHESTRATION_COMMAND_PREFIX}} loop\n')
@@ -308,18 +309,17 @@ describe('pre-cycle core update', () => {
     expect(git(repoRoot, ['status', '--porcelain'])).toBe('')
   })
 
-  it('preserves and reports a divergent interactive shared skill', async () => {
+  it('overwrites and commits a changed managed interactive shared skill', async () => {
     const interactiveSkill = join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md')
     writeFileSync(interactiveSkill, 'consumer command\n')
     commit(repoRoot, 'chore: customize interactive skill fixture')
     const loop = makeLoop(config())
 
     expect(await loop.poll(), events.join('\n')).toBe('continue')
-    expect(readFileSync(interactiveSkill, 'utf8').replaceAll('\r', '')).toBe('consumer command\n')
+    expect(readFileSync(interactiveSkill, 'utf8').replaceAll('\r', ''))
+      .toBe("version one: npm run -C 'orchestration/ts' loop\n")
     expect(git(repoRoot, ['status', '--porcelain'])).toBe('')
-    expect(events).toContain(
-      'WARN shared skill .claude/skills/loop-start differs from the last synced copy; left unchanged',
-    )
+    expect(events).toContain('Updated skill refreshed .claude/skills/loop-start')
   })
 
   it('stops before starting a cycle when a shared skill target fails to synchronize', async () => {
@@ -341,7 +341,7 @@ describe('pre-cycle core update', () => {
     expect(events.some((line) => line.includes('simulated target failure'))).toBe(false)
   })
 
-  it('pulls core changes but preserves and reports a committed consumer skill divergence', async () => {
+  it('pulls core changes and overwrites a committed managed skill edit', async () => {
     const installed = join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md')
     writeFileSync(installed, 'consumer command\n')
     commit(repoRoot, 'chore: customize loop skill')
@@ -350,11 +350,9 @@ describe('pre-cycle core update', () => {
     const loop = makeLoop(config())
 
     expect(await loop.poll(), events.join('\n')).toBe('restart')
-    expect(readFileSync(installed, 'utf8').replaceAll('\r', '')).toBe('consumer command\n')
+    expect(readFileSync(installed, 'utf8').replaceAll('\r', '')).toBe('upstream command\n')
     expect(git(repoRoot, ['status', '--porcelain'])).toBe('')
-    expect(events).toContain(
-      'WARN shared skill .agents/skills/loop-start differs from the last synced copy; left unchanged',
-    )
+    expect(events).toContain('Updated skill refreshed .agents/skills/loop-start')
   })
 
   it('requires managed staged changes to be cleared before syncing any destination', async () => {

--- a/tests/english-only.test.ts
+++ b/tests/english-only.test.ts
@@ -13,9 +13,8 @@ afterEach(() => {
 describe('English-only source check', () => {
   const characters = (...codePoints: number[]): string => String.fromCodePoint(...codePoints)
 
-  it('accepts ASCII, English typography, and borrowed Latin letters', () => {
-    expect(scanText(`A cafe${characters(0x301)} is not the same spelling as cafe.`)).toEqual([])
-    expect(scanText(`A caf${characters(0xe9)} menu — previous ← next →`)).toEqual([])
+  it('accepts ASCII and English typography', () => {
+    expect(scanText('A cafe menu — previous ← next →')).toEqual([])
   })
 
   it('reports non-English scripts, full-width punctuation, and invisible characters', () => {
@@ -37,11 +36,11 @@ describe('English-only source check', () => {
   })
 
   it('rejects non-English Latin letters and combining marks', () => {
-    const violations = scanText(`Ti${characters(0x1ebf)}ng Vi${characters(0x1ec7)}t va${characters(0x300)} tie${characters(0x302)}ng`)
+    const violations = scanText(`caf${characters(0xe9)} cafe${characters(0x301)} Ti${characters(0x1ebf)}ng Vi${characters(0x1ec7)}t va${characters(0x300)} tie${characters(0x302)}ng`)
 
     expect(violations).toHaveLength(1)
     expect(violations[0]?.codePoints).toEqual([
-      'U+1EBF', 'U+1EC7', 'U+0300', 'U+0302',
+      'U+00E9', 'U+0301', 'U+1EBF', 'U+1EC7', 'U+0300', 'U+0302',
     ])
   })
 

--- a/tests/forge-github.test.ts
+++ b/tests/forge-github.test.ts
@@ -30,6 +30,24 @@ const openIssueFixture = {
   futureIssueField: 'ignored',
 }
 
+function restIssue(issue: Record<string, unknown>): Record<string, unknown> {
+  return {
+    number: issue.number,
+    state: typeof issue.state === 'string' ? issue.state.toLowerCase() : issue.state,
+    title: issue.title,
+    body: issue.body,
+    user: issue.author,
+    labels: issue.labels,
+    assignees: issue.assignees,
+    updated_at: issue.updatedAt,
+    ...('pull_request' in issue ? { pull_request: issue.pull_request } : {}),
+  }
+}
+
+function restPages(issues: Record<string, unknown>[]): string {
+  return JSON.stringify([issues.map(restIssue)])
+}
+
 function forgeReturning(output: unknown): Forge {
   const command: GithubCommand = async (_root, args) => {
     if (args[0] === 'repo') return JSON.stringify({ nameWithOwner: 'example/repo' })
@@ -39,6 +57,9 @@ function forgeReturning(output: unknown): Forge {
         permission: login === 'outside-user' ? 'none' : 'admin',
         role_name: login === 'outside-user' ? null : 'admin',
       })
+    }
+    if (args.includes('--paginate') && Array.isArray(output)) {
+      return restPages(output as Record<string, unknown>[])
     }
     return JSON.stringify(output)
   }
@@ -254,15 +275,15 @@ describe('GitHub issue queue repository targeting', () => {
     const command: GithubCommand = async (_root, args) => {
       calls.push(args)
       if (args[0] === 'repo') return JSON.stringify({ nameWithOwner: 'consumer/project' })
+      if (args.includes('--paginate')) {
+        return restPages(args.at(-1)?.includes('state=closed')
+          ? [{ ...openIssueFixture, state: 'CLOSED' }]
+          : [openIssueFixture])
+      }
       if (args[0] === 'api') return JSON.stringify({ permission: 'write' })
       if (args[0] === 'label' && args[1] === 'list') return '[]'
       if (args[0] === 'issue' && args[1] === 'create') {
         return 'https://github.com/consumer/project/issues/42\n'
-      }
-      if (args[0] === 'issue' && args[1] === 'list') {
-        return JSON.stringify(args.includes('closed')
-          ? [{ ...openIssueFixture, state: 'CLOSED' }]
-          : [openIssueFixture])
       }
       if (args[0] === 'issue' && args[1] === 'view') {
         return JSON.stringify(args.includes('comments')
@@ -315,6 +336,43 @@ describe('GitHub issue queue repository targeting', () => {
     })).rejects.toThrow('Unable to resolve the current repository for the issue queue')
     expect(calls).toEqual([['repo', 'view', '--json', 'nameWithOwner']])
   })
+
+  it.each([
+    { state: 'open' as const, list: (forge: Forge) => forge.listOpenIssues('loop:finding') },
+    { state: 'closed' as const, list: (forge: Forge) => forge.listClosedIssues('loop:finding') },
+  ])('fetches every page when more than 200 $state issues match', async ({ state, list }) => {
+    const calls: string[][] = []
+    const issues = Array.from({ length: 205 }, (_, index) => ({
+      ...openIssueFixture,
+      number: index + 1,
+      state: state.toUpperCase(),
+      body: index === 0 ? null : openIssueFixture.body,
+    }))
+    const pages = [issues.slice(0, 100), issues.slice(100, 200), issues.slice(200)]
+      .map((page) => page.map(restIssue))
+    pages[2]?.push(restIssue({
+      ...openIssueFixture,
+      number: 206,
+      state: state.toUpperCase(),
+      pull_request: { url: 'https://api.github.com/repos/example/repo/pulls/206' },
+    }))
+    const command: GithubCommand = async (_root, args) => {
+      calls.push(args)
+      if (args[0] === 'repo') return JSON.stringify({ nameWithOwner: 'example/repo' })
+      if (args.includes('--paginate')) return JSON.stringify(pages)
+      return JSON.stringify({ permission: 'write' })
+    }
+
+    const listed = await list(createGithubForge('repo-root', command))
+
+    expect(listed).toHaveLength(205)
+    expect(listed[0]?.body).toBe('')
+    expect(listed.at(-1)?.number).toBe(205)
+    expect(calls.filter((args) => args.includes('--paginate'))).toEqual([[
+      'api', '--paginate', '--slurp',
+      `repos/example/repo/issues?state=${state}&labels=loop%3Afinding&per_page=100`,
+    ]])
+  })
 })
 
 describe('GitHub author permissions', () => {
@@ -329,7 +387,7 @@ describe('GitHub author permissions', () => {
     const command: GithubCommand = async (_root, args) => {
       calls.push(args)
       if (args[0] === 'repo') return JSON.stringify({ nameWithOwner: 'example/repo' })
-      if (args[0] === 'issue') return JSON.stringify(issues)
+      if (args.includes('--paginate')) return restPages(issues)
       const login = args[1]?.split('/').at(-2)
       const permission = login === 'read-member' ? 'read'
         : login === 'triage-collaborator' ? 'triage'
@@ -342,16 +400,15 @@ describe('GitHub author permissions', () => {
 
     expect(normalized.map((issue) => issue.author.hasWriteAccess))
       .toEqual([false, false, true, true])
-    expect(calls.filter((args) => args[0] === 'api')).toHaveLength(3)
+    expect(calls.filter((args) => args[1]?.includes('/collaborators/'))).toHaveLength(3)
   })
 
   it('observes permission revocation on the fresh issue read used by a claim', async () => {
     let permission = 'write'
     const command: GithubCommand = async (_root, args) => {
       if (args[0] === 'repo') return JSON.stringify({ nameWithOwner: 'example/repo' })
-      if (args[0] === 'issue') {
-        return JSON.stringify(args[1] === 'list' ? [openIssueFixture] : openIssueFixture)
-      }
+      if (args.includes('--paginate')) return restPages([openIssueFixture])
+      if (args[0] === 'issue') return JSON.stringify(openIssueFixture)
       return JSON.stringify({ permission })
     }
     const forge = createGithubForge('repo-root', command)
@@ -445,7 +502,7 @@ describe('GitHub forge JSON schemas', () => {
     expect((error as ForgeRateLimitError).resetAt.toISOString()).toBe('2026-08-11T08:00:00.000Z')
     expect(calls.map((args) => args.join(' '))).toEqual([
       'repo view --json nameWithOwner',
-      'issue list --state open --repo example/repo --label loop:finding --limit 200 --json number,state,title,body,author,labels,assignees,updatedAt',
+      'api --paginate --slurp repos/example/repo/issues?state=open&labels=loop%3Afinding&per_page=100',
       'api rate_limit',
     ])
   })
@@ -550,12 +607,15 @@ describe('GitHub forge JSON schemas', () => {
       'repo-root',
       async (_root, args) => {
         if (args[0] === 'repo') return JSON.stringify({ nameWithOwner: 'example/repo' })
+        if (args.includes('--paginate')) {
+          return restPages([
+            openIssueFixture,
+            { ...openIssueFixture, number: 358, state: 'CLOSED' },
+            { ...openIssueFixture, number: 359 },
+          ])
+        }
         if (args[0] === 'api') return JSON.stringify({ permission: 'write' })
-        return JSON.stringify([
-          openIssueFixture,
-          { ...openIssueFixture, number: 358, state: 'CLOSED' },
-          { ...openIssueFixture, number: 359 },
-        ])
+        return '[]'
       },
       (message) => reports.push(message),
     )
@@ -668,14 +728,14 @@ describe('GitHub forge JSON schemas', () => {
       {
         output: [{ ...openIssueFixture, number: '357' }],
         invoke: (forge) => forge.listOpenIssues('loop:ready'),
-        command: 'gh issue list',
-        path: '[0].number',
+        command: 'gh api',
+        path: '[0][0].number',
       },
       {
         output: [{ ...openIssueFixture, state: 'CLOSED', updatedAt: 42 }],
         invoke: (forge) => forge.listClosedIssues('loop:done'),
-        command: 'gh issue list',
-        path: '[0].updatedAt',
+        command: 'gh api',
+        path: '[0][0].updated_at',
       },
       {
         output: { comments: [{
@@ -707,11 +767,12 @@ describe('gh JSON field selections', () => {
     'reactionGroups', 'state', 'stateReason', 'title', 'updatedAt', 'url',
   ])
 
-  it('asks issue list and issue view only for fields gh supports', async () => {
+  it('asks issue view only for fields gh supports', async () => {
     const calls: string[][] = []
     const command: GithubCommand = async (_root, args) => {
       calls.push(args)
       if (args[0] === 'repo') return JSON.stringify({ nameWithOwner: 'example/repo' })
+      if (args.includes('--paginate')) return '[[]]'
       if (args[0] === 'api') return JSON.stringify({ permission: 'admin', role_name: 'admin' })
       if (args[1] === 'view') return JSON.stringify(openIssueFixture)
       return '[]'
@@ -723,10 +784,10 @@ describe('gh JSON field selections', () => {
     await forge.getIssue(1)
 
     const selections = calls
-      .filter((args) => args[0] === 'issue' && (args[1] === 'list' || args[1] === 'view'))
+      .filter((args) => args[0] === 'issue' && args[1] === 'view')
       .map((args) => args[args.indexOf('--json') + 1] as string)
 
-    expect(selections.length).toBe(3)
+    expect(selections.length).toBe(1)
     for (const selection of selections) {
       for (const field of selection.split(',')) {
         expect(ISSUE_FIELDS.has(field), `gh does not offer ${field} on issues`).toBe(true)

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -299,6 +299,17 @@ describe('issue body round-trip', () => {
 })
 
 describe('publishFinding', () => {
+  it('propagates a failed re-read of a newly created finding', async () => {
+    forge.listOpenIssues = async () => []
+    forge.getIssue = async () => {
+      throw new Error('created issue re-read unavailable')
+    }
+
+    await expect(publishFinding(
+      forge, paths, '[BUG] `src/a/b.ts` breaks', 'scan-1',
+    )).rejects.toThrow('created issue re-read unavailable')
+  })
+
   it('reports an immediate duplicate while the remote issue list still lags', async () => {
     forge.listOpenIssues = async () => []
     const firstDescription = '[BUG] `src/a/b.ts` Remove empty .live-event-form rules'
@@ -533,6 +544,28 @@ describe('publishFinding', () => {
         `${fingerprintOf(findingA)} ${combined.issueNumber}`,
         `${fingerprintOf(findingB)} ${combined.issueNumber}`,
       ]))
+  })
+
+  it('propagates a failed re-read while reconciling a subsumed finding', async () => {
+    const findingA = '[BUG] `src/a.ts` breaks'
+    const findingB = '[TEST] `src/b.test.ts` lacks coverage'
+    await publishFinding(
+      forge, paths, `1. ${findingA}\n2. ${findingB}`, 'review-1', 'high',
+      'Review round fixes', [findingA, findingB],
+    )
+    const individual = await forge.createIssue({
+      title: findingA,
+      body: buildIssueBody(findingA, 'scan-1'),
+      labels: [LABEL_FINDING, LABEL_READY],
+    })
+    const getIssue = forge.getIssue.bind(forge)
+    forge.getIssue = async (issueNumber) => {
+      if (issueNumber === individual) throw new Error('subsumed issue re-read unavailable')
+      return getIssue(issueNumber)
+    }
+
+    await expect(reconcileFindingFingerprints(forge, paths))
+      .rejects.toThrow('subsumed issue re-read unavailable')
   })
 
   it('keeps a partially overlapping issue that carries an unmatched finding', async () => {

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -1467,6 +1467,32 @@ describe('issue claim release', () => {
     expect(parked).toEqual([[issueNumber, 3]])
   })
 
+  it('does not report a parked release when the forge accepts but ignores the mutation', async () => {
+    const issueNumber = await forge.createIssue({
+      title: 'persistently failing issue', body: '',
+      labels: [LABEL_FINDING, LABEL_IN_PROGRESS], assignees: ['worker-a'],
+    })
+    recordIssuesForTask(paths, 'failed-task', [issueNumber])
+    recordIssueFailure(paths, 'failed-task')
+    recordIssueReleaseIntent(paths, 'failed-task', [issueNumber])
+    forge.addLabel = async () => {}
+    const parked: Array<[number, number]> = []
+
+    const failures = await reconcileIssueReleaseIntent(forge, paths, 'failed-task', {
+      maxIssueRetries: 1,
+      onPark: (number, count) => parked.push([number, count]),
+    })
+
+    expect(failures).toMatchObject([{
+      issueNumber,
+      error: {
+        message: `Issue #${issueNumber} did not reach the single ${LABEL_RETRY_EXHAUSTED} lifecycle state`,
+      },
+    }])
+    expect(parked).toEqual([])
+    expect(existsSync(join(paths.queueDir, 'issue-release-intent', 'failed-task'))).toBe(true)
+  })
+
   it('clears an issue failure streak when its task completes successfully', () => {
     const issueNumber = 42
     recordIssuesForTask(paths, 'successful-task', [issueNumber])
@@ -1541,6 +1567,20 @@ describe('issue claim release', () => {
     expect(issue.labels).toEqual(labels)
   })
 
+  it('rejects a claim release when the forge accepts but ignores the mutation', async () => {
+    const issueNumber = await forge.createIssue({
+      title: 'startup claim', body: '', labels: [LABEL_FINDING, LABEL_IN_PROGRESS],
+      assignees: ['worker-a'],
+    })
+    forge.unassignIssue = async () => {}
+
+    await expect(releaseIssueClaim(forge, issueNumber, 'worker-a')).rejects.toThrow(
+      `Issue #${issueNumber} did not reach the single ${LABEL_READY} lifecycle state`,
+    )
+
+    expect((await forge.getIssue(issueNumber)).assignees).toEqual(['worker-a'])
+  })
+
   it.each([
     {
       failure: 'unassign:worker-a',
@@ -1613,6 +1653,26 @@ describe('issue claim release', () => {
     const issue = await forge.getIssue(issueNumber)
     expect(issue.assignees).toEqual(assignees)
     expect(issue.labels).toEqual(labels)
+  })
+
+  it('keeps release intent when the forge accepts but ignores a ready mutation', async () => {
+    const issueNumber = await forge.createIssue({
+      title: 'claimed issue', body: '', labels: [LABEL_FINDING, LABEL_IN_PROGRESS],
+      assignees: ['worker-a'],
+    })
+    recordIssuesForTask(paths, 'task-release', [issueNumber])
+    recordIssueReleaseIntent(paths, 'task-release', [issueNumber])
+    forge.addLabel = async () => {}
+
+    const failures = await reconcileIssueReleaseIntent(forge, paths, 'task-release')
+
+    expect(failures).toMatchObject([{
+      issueNumber,
+      error: {
+        message: `Issue #${issueNumber} did not reach the single ${LABEL_READY} lifecycle state`,
+      },
+    }])
+    expect(existsSync(join(paths.queueDir, 'issue-release-intent', 'task-release'))).toBe(true)
   })
 })
 

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -1096,6 +1096,34 @@ describe('claimIssueGroup', () => {
     expect(after.labels).not.toContain(LABEL_IN_PROGRESS)
   })
 
+  it('reports both claim verification and assignment release failures', async () => {
+    const issueNumber = await readyIssue('[BUG] `src/a/b.ts` breaks during claim verification')
+    const issue = await forge.getIssue(issueNumber)
+    const getIssue = forge.getIssue.bind(forge)
+    const verificationFailure = new Error('getIssue failed after assignment')
+    const releaseFailure = new Error('unassignIssue failed during compensation')
+    let reads = 0
+    forge.getIssue = async (number) => {
+      if (number === issueNumber && ++reads === 2) throw verificationFailure
+      return getIssue(number)
+    }
+    forge.unassignIssue = async () => { throw releaseFailure }
+
+    const failure = await claimIssueGroup(
+      forge, paths, [issue], 'worker-a', appendRequirements,
+    ).then(() => undefined, (error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect(failure).toMatchObject({
+      message: `Claim verification and compensation both failed for issue #${issueNumber}`,
+      errors: [verificationFailure, releaseFailure],
+    })
+    const retained = await getIssue(issueNumber)
+    expect(retained.assignees).toEqual(['worker-a'])
+    expect(retained.labels).toContain(LABEL_READY)
+    expect(retained.labels).not.toContain(LABEL_IN_PROGRESS)
+  })
+
   it.each([
     ['adding in-progress', 'addLabel'],
     ['removing ready', 'removeLabel'],
@@ -1121,6 +1149,33 @@ describe('claimIssueGroup', () => {
     expect(after.labels).not.toContain(LABEL_IN_PROGRESS)
     expect(existsSync(join(paths.queueDir, 'backlog.txt'))).toBe(false)
     expect(readdirSync(paths.tasksDir)).toEqual([])
+  })
+
+  it('reports both claim mutation and assignment release failures', async () => {
+    const issueNumber = await readyIssue('[BUG] `src/a/b.ts` breaks during label mutation')
+    const issue = await forge.getIssue(issueNumber)
+    const removeLabel = forge.removeLabel.bind(forge)
+    const mutationFailure = new Error('removeLabel failed after applying')
+    const releaseFailure = new Error('unassignIssue failed during compensation')
+    forge.removeLabel = async (number, label) => {
+      await removeLabel(number, label)
+      if (number === issueNumber && label === LABEL_READY) throw mutationFailure
+    }
+    forge.unassignIssue = async () => { throw releaseFailure }
+
+    const failure = await claimIssueGroup(
+      forge, paths, [issue], 'worker-a', appendRequirements,
+    ).then(() => undefined, (error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect(failure).toMatchObject({
+      message: `Claim mutation and compensation both failed for issue #${issueNumber}`,
+      errors: [mutationFailure, releaseFailure],
+    })
+    const retained = forge.issues.get(issueNumber)
+    expect(retained?.assignees).toEqual(['worker-a'])
+    expect(retained?.labels).toContain(LABEL_IN_PROGRESS)
+    expect(retained?.labels).not.toContain(LABEL_READY)
   })
 
   it.each([
@@ -1180,6 +1235,34 @@ describe('claimIssueGroup', () => {
     expect(readFileSync(join(paths.queueDir, 'backlog.txt'), 'utf8')).toContain(retry.taskId)
   })
 
+  it('reports both task materialization and claim release failures', async () => {
+    const description = '[BUG] `src/a/b.ts` fails while materializing a task'
+    const issueNumber = await readyIssue(description)
+    const issue = await forge.getIssue(issueNumber)
+    const materializationFailure = new Error('append failed')
+    const releaseFailure = new Error('unassignIssue failed during compensation')
+    let failedTaskId: string | undefined
+    forge.unassignIssue = async () => { throw releaseFailure }
+
+    const failure = await claimIssueGroup(forge, paths, [issue], 'worker-a', (taskId) => {
+      failedTaskId = taskId
+      throw materializationFailure
+    }).then(() => undefined, (error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect(failure).toMatchObject({
+      message: `Claim group materialization and compensation both failed for issues #${issueNumber}`,
+      errors: [materializationFailure, releaseFailure],
+    })
+    if (failedTaskId === undefined) throw new Error('expected append to be attempted')
+    expect(existsSync(specFile(paths, failedTaskId))).toBe(false)
+    expect(existingTaskIdForDesc(paths, 'auto', description)).toBeUndefined()
+    const retained = forge.issues.get(issueNumber)
+    expect(retained?.assignees).toEqual(['worker-a'])
+    expect(retained?.labels).toContain(LABEL_IN_PROGRESS)
+    expect(retained?.labels).not.toContain(LABEL_READY)
+  })
+
   it('quarantines an unparseable issue with an actionable reason', async () => {
     const issueNumber = await forge.createIssue({
       title: 'hand-written', body: 'no structure here', labels: [LABEL_FINDING, LABEL_READY],
@@ -1220,6 +1303,35 @@ describe('claimIssueGroup', () => {
     expect(after.labels).toContain(LABEL_READY)
     expect(after.labels).not.toContain(LABEL_IN_PROGRESS)
     expect(after.labels).not.toContain(LABEL_MERGE_FAILED)
+  })
+
+  it('reports both issue quarantine and assignment release failures', async () => {
+    const issueNumber = await forge.createIssue({
+      title: 'hand-written', body: 'no structure here', labels: [LABEL_FINDING, LABEL_READY],
+    })
+    const commentIssue = forge.commentIssue.bind(forge)
+    const quarantineFailure = new Error('commentIssue failed after applying')
+    const releaseFailure = new Error('unassignIssue failed during compensation')
+    forge.commentIssue = async (number, comment) => {
+      await commentIssue(number, comment)
+      throw quarantineFailure
+    }
+    forge.unassignIssue = async () => { throw releaseFailure }
+
+    const failure = await claimIssueGroup(
+      forge, paths, [await forge.getIssue(issueNumber)], 'worker-a', appendRequirements,
+    ).then(() => undefined, (error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect(failure).toMatchObject({
+      message: `Issue quarantine and compensation both failed for issue #${issueNumber}`,
+      errors: [quarantineFailure, releaseFailure],
+    })
+    const retained = forge.issues.get(issueNumber)
+    expect(retained?.assignees).toEqual(['worker-a'])
+    expect(retained?.labels).toContain(LABEL_IN_PROGRESS)
+    expect(retained?.labels).not.toContain(LABEL_READY)
+    expect(retained?.labels).not.toContain(LABEL_MERGE_FAILED)
   })
 
   it('names an empty requirement when quarantining an issue', async () => {

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -1088,14 +1088,45 @@ describe('claimIssueGroup', () => {
     expect(after.labels).toContain(LABEL_READY)
   })
 
-  it('releases its assignment when the lifecycle changes immediately after assignment', async () => {
-    const issueNumber = await readyIssue('[BUG] `src/a/b.ts` changes during assignment')
+  it.each([
+    ['loses its lifecycle label', async (number: number) => {
+      await forge.removeLabel(number, LABEL_READY)
+    }],
+    ['gains a conflicting lifecycle label', async (number: number) => {
+      await forge.addLabel(number, LABEL_MERGE_FAILED)
+    }],
+  ] as const)(
+    'restores a claimable ready state when an issue %s immediately after assignment',
+    async (_description, driftLifecycle) => {
+      const issueNumber = await readyIssue('[BUG] `src/a/b.ts` changes during assignment')
+      const issue = await forge.getIssue(issueNumber)
+      const assignIssue = forge.assignIssue.bind(forge)
+      forge.assignIssue = async (number, assignee) => {
+        await assignIssue(number, assignee)
+        if (number === issueNumber) await driftLifecycle(number)
+      }
+
+      const result = await claimIssueGroup(forge, paths, [issue], 'worker-a', appendRequirements)
+
+      expect(result).toEqual({ outcome: 'lost-race', issueNumber })
+      const after = await forge.getIssue(issueNumber)
+      expect(after.assignees).toEqual([])
+      expect(after.labels).toEqual([LABEL_FINDING, LABEL_READY])
+      expect(existsSync(join(paths.queueDir, 'backlog.txt'))).toBe(false)
+      expect(readdirSync(paths.tasksDir)).toEqual([])
+    },
+  )
+
+  it('restores ready when the lifecycle drifts after claim label mutation', async () => {
+    const issueNumber = await readyIssue('[BUG] `src/a/b.ts` changes after label mutation')
     const issue = await forge.getIssue(issueNumber)
-    const assignIssue = forge.assignIssue.bind(forge)
-    const removeLabel = forge.removeLabel.bind(forge)
-    forge.assignIssue = async (number, assignee) => {
-      await assignIssue(number, assignee)
-      if (number === issueNumber) await removeLabel(number, LABEL_READY)
+    const getIssue = forge.getIssue.bind(forge)
+    let reads = 0
+    forge.getIssue = async (number) => {
+      if (number === issueNumber && ++reads === 3) {
+        await forge.addLabel(number, LABEL_MERGE_FAILED)
+      }
+      return getIssue(number)
     }
 
     const result = await claimIssueGroup(forge, paths, [issue], 'worker-a', appendRequirements)
@@ -1103,9 +1134,28 @@ describe('claimIssueGroup', () => {
     expect(result).toEqual({ outcome: 'lost-race', issueNumber })
     const after = await forge.getIssue(issueNumber)
     expect(after.assignees).toEqual([])
-    expect(after.labels).not.toContain(LABEL_IN_PROGRESS)
-    expect(existsSync(join(paths.queueDir, 'backlog.txt'))).toBe(false)
-    expect(readdirSync(paths.tasksDir)).toEqual([])
+    expect(after.labels).toEqual([LABEL_FINDING, LABEL_READY])
+  })
+
+  it('rejects lifecycle-drift compensation that does not restore ready', async () => {
+    const issueNumber = await readyIssue('[BUG] `src/a/b.ts` cannot restore ready')
+    const issue = await forge.getIssue(issueNumber)
+    const assignIssue = forge.assignIssue.bind(forge)
+    const removeLabel = forge.removeLabel.bind(forge)
+    forge.assignIssue = async (number, assignee) => {
+      await assignIssue(number, assignee)
+      if (number === issueNumber) await removeLabel(number, LABEL_READY)
+    }
+    forge.addLabel = async () => {}
+
+    await expect(claimIssueGroup(forge, paths, [issue], 'worker-a', appendRequirements))
+      .rejects.toThrow(
+        `Issue #${issueNumber} did not reach the single ${LABEL_READY} lifecycle state`,
+      )
+
+    const after = await forge.getIssue(issueNumber)
+    expect(after.assignees).toEqual([])
+    expect(after.labels).toEqual([LABEL_FINDING])
   })
 
   it('releases the assignment when the first post-assignment read fails', async () => {

--- a/tests/lib.test.ts
+++ b/tests/lib.test.ts
@@ -11,7 +11,7 @@ import { descSlug, newTaskId, shortTaskId, taskIdForDesc } from '../src/ids.ts'
 import {
   branchName, finalMessageFile, isInspectionTaskId, isReviewTaskId,
   isScanTaskId,
-  orchPaths, packageScriptCommand, statusFile, type OrchPaths,
+  absolutePackageScriptCommand, orchPaths, packageScriptCommand, statusFile, type OrchPaths,
 } from '../src/paths.ts'
 import { taskProcessPid } from '../src/processRegistry.ts'
 import { readStatus, transitionStatus, writeStatus } from '../src/status.ts'
@@ -207,6 +207,15 @@ describe('status files', () => {
 })
 
 describe('package script commands', () => {
+  it('renders a repository-specific command that is independent of the working directory', () => {
+    const packageRoot = join(repoRoot, 'orchestration', 'core package')
+    const expectedPackageRoot = packageRoot.replaceAll('\\', '/')
+    const expectedRepoRoot = repoRoot.replaceAll('\\', '/')
+
+    expect(absolutePackageScriptCommand(repoRoot, 'loop-status', packageRoot))
+      .toBe(`npm run -C '${expectedPackageRoot}' loop-status -- --repo '${expectedRepoRoot}'`)
+  })
+
   it('runs scripts directly when the package is the repository root', () => {
     expect(packageScriptCommand(repoRoot, 'loop-status', repoRoot))
       .toBe('npm run loop-status')

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -7,6 +7,7 @@ import { ForgeRateLimitError, type Forge, type PrStatus } from '../src/adapters/
 import { normalizeEntry } from '../src/adapters/forge-github.ts'
 import type { ProjectAdapter } from '../src/adapters/project.ts'
 import type { Runner } from '../src/adapters/runner.ts'
+import { operatingSystem } from '../src/adapters/os.ts'
 import { loadConfig, type LoopConfig } from '../src/config.ts'
 import {
   buildIssueBody, issueCompletionForIssue, issueNumbersForTask, issuePromotionForIssue,
@@ -1729,25 +1730,29 @@ describe('cycle gate', () => {
     expect(readFileSync(join(paths.queueDir, 'scan-count.txt'), 'utf8')).toBe('0\n')
   })
 
-  it('reports the environment exercised by the final gate before promotion', async () => {
+  it('reports the OS-adapter environment only after promotion is confirmed', async () => {
     initializeGitRepo()
     configureRemoteDefaultBranch()
     writeFileSync(join(paths.queueDir, 'scan-count.txt'), '1\n')
+    const environmentLabel = vi.spyOn(operatingSystem, 'verificationEnvironmentLabel')
+      .mockReturnValue('adapter-provided environment')
     const loop = makeLoop({ scanEnabled: false, autoPr: true, reviewEnabled: false })
     loop.initializeSessionStateForBranch()
     fakeForge.markPrReady = async () => {
+      expect(logged.some((line) => line.startsWith('Status Environments'))).toBe(false)
       forgeStatus = { ...forgeStatus, isDraft: false }
     }
 
-    expect(await loop.poll()).toBe('done')
-
-    const environment = process.platform === 'win32'
-      ? 'Windows'
-      : process.platform === 'darwin' ? 'macOS' : process.platform === 'linux' ? 'Linux' : process.platform
-    expect(logged).toContain(
-      `Status Environments  run verification exercised ${environment}; `
-      + 'promoted branch was not run in any other environment',
-    )
+    try {
+      expect(await loop.poll()).toBe('done')
+      expect(environmentLabel).toHaveBeenCalledOnce()
+      expect(logged).toContain(
+        'Status Environments  run verification exercised adapter-provided environment; '
+        + 'promoted branch was not run in any other environment',
+      )
+    } finally {
+      environmentLabel.mockRestore()
+    }
   })
 
   it('names an available cross-platform check that was not run for the branch', async () => {
@@ -3171,7 +3176,10 @@ describe('completion marker output', () => {
     git(['remote', 'add', 'origin', remote])
     git(['push', '-u', 'origin', 'main'])
     git(['symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/main'])
-    const loop = makeLoop()
+    const loop = makeLoop({}, {
+      ...stubProject,
+      manualEnvironmentChecks: [{ environment: 'Linux', command: 'npm run test:linux' }],
+    })
     fakeForge.markPrReady = async () => {
       throw new Error('promotion failed')
     }
@@ -3187,6 +3195,8 @@ describe('completion marker output', () => {
     expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
     expect(logged.some((line) => line.startsWith('LOOP_DONE:'))).toBe(false)
     expect(logged).not.toContain('Completed Loop        PR https://example.test/pull/1')
+    expect(logged.some((line) => line.startsWith('Status Environments'))).toBe(false)
+    expect(logged.some((line) => line.startsWith('Status Linux check'))).toBe(false)
   })
 
   it('reports repeated pre-promotion status errors and stops the loop', async () => {
@@ -3215,6 +3225,7 @@ describe('completion marker output', () => {
       'ERROR could not check PR status before promotion: status unavailable (repeated 2 times)',
     )
     expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(logged.some((line) => line.startsWith('Status Environments'))).toBe(false)
   })
 
   it('reports repeated post-promotion status errors and stops the loop', async () => {
@@ -3243,6 +3254,7 @@ describe('completion marker output', () => {
       'ERROR could not confirm PR status after promotion: confirmation unavailable (repeated 2 times)',
     )
     expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(logged.some((line) => line.startsWith('Status Environments'))).toBe(false)
   })
 
   it('does not emit LOOP_DONE until the forge confirms the PR is ready', async () => {
@@ -3259,6 +3271,7 @@ describe('completion marker output', () => {
     expect(prStatusCalls).toBe(3)
     expect(logged.some((line) => line.startsWith('LOOP_DONE:'))).toBe(false)
     expect(logged).not.toContain('Completed Loop        PR https://example.test/pull/1')
+    expect(logged.some((line) => line.startsWith('Status Environments'))).toBe(false)
   })
 
   it('keeps the final gate state until draft promotion is confirmed', async () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1699,6 +1699,53 @@ describe('cycle gate', () => {
     expect(readFileSync(join(paths.queueDir, 'scan-count.txt'), 'utf8')).toBe('0\n')
   })
 
+  it('reports the environment exercised by the final gate before promotion', async () => {
+    initializeGitRepo()
+    configureRemoteDefaultBranch()
+    writeFileSync(join(paths.queueDir, 'scan-count.txt'), '1\n')
+    const loop = makeLoop({ scanEnabled: false, autoPr: true, reviewEnabled: false })
+    loop.initializeSessionStateForBranch()
+    fakeForge.markPrReady = async () => {
+      forgeStatus = { ...forgeStatus, isDraft: false }
+    }
+
+    expect(await loop.poll()).toBe('done')
+
+    const environment = process.platform === 'win32'
+      ? 'Windows'
+      : process.platform === 'darwin' ? 'macOS' : process.platform === 'linux' ? 'Linux' : process.platform
+    expect(logged).toContain(
+      `Status Environments  run verification exercised ${environment}; `
+      + 'promoted branch was not run in any other environment',
+    )
+  })
+
+  it('names an available cross-platform check that was not run for the branch', async () => {
+    initializeGitRepo()
+    configureRemoteDefaultBranch()
+    writeFileSync(join(paths.queueDir, 'scan-count.txt'), '1\n')
+    const project: ProjectAdapter = {
+      ...stubProject,
+      manualEnvironmentChecks: [{ environment: 'Linux', command: 'npm run test:linux' }],
+    }
+    const loop = makeLoop(
+      { scanEnabled: false, autoPr: true, reviewEnabled: false },
+      project,
+    )
+    loop.initializeSessionStateForBranch()
+    fakeForge.markPrReady = async () => {
+      forgeStatus = { ...forgeStatus, isDraft: false }
+    }
+
+    expect(await loop.poll()).toBe('done')
+
+    expect(logged).toContain(
+      formatEventLine(
+        'Status', 'Linux check', 'not run for this branch; run npm run test:linux',
+      ),
+    )
+  })
+
   it('concludes an empty run without retrying pull request creation', async () => {
     initializeGitRepo()
     configureRemoteDefaultBranch()

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -28,6 +28,7 @@ import { forgetTaskProcess, recordTaskProcess } from '../src/processRegistry.ts'
 import { currentProcessStartIdentity } from '../src/processOwner.ts'
 import { GENERATED_BODY_MARKER } from '../src/prbody.ts'
 import { readStatus } from '../src/status.ts'
+import { StartupProcessRetainedError, startTask } from '../src/start.ts'
 import { enqueueTask } from '../src/tasks.ts'
 import type { TaskProcessTermination } from '../src/taskProcesses.ts'
 import { frameUntrustedText, repositoryInspectionPreamble } from '../src/templates.ts'
@@ -91,6 +92,7 @@ function makeLoop(
   runner: Runner = makeRunner(),
   enqueueTaskImpl: NonNullable<LoopDeps['enqueueTask']> = enqueueTask,
   terminateTaskProcesses?: () => TaskProcessTermination,
+  startTaskImpl: typeof startTask = startTask,
 ): Loop {
   const config = { ...loadConfig({}), ...overrides }
   return createLoop({
@@ -104,6 +106,7 @@ function makeLoop(
     orchestrationDepsRuntime,
     enqueueTask: enqueueTaskImpl,
     terminateTaskProcesses,
+    startTask: startTaskImpl,
   })
 }
 
@@ -2618,6 +2621,55 @@ describe('failure announcement and burst stop (via poll)', () => {
     expect(reclaimed.labels).toContain(LABEL_IN_PROGRESS)
     expect(reclaimed.labels).not.toContain(LABEL_READY)
     expect(reclaimed.assignees).toEqual(['worker-a'])
+  })
+
+  it('stops without releasing or retrying a claimed task whose startup process survives', async () => {
+    initializeGitRepo()
+    const description = '[BUG] retain work owned by a surviving startup process'
+    const retainedPid = process.pid
+    const retainedStarts: string[] = []
+    const retainStartup: typeof startTask = async (startPaths, _runner, taskId) => {
+      retainedStarts.push(taskId)
+      recordTaskProcess(startPaths, taskId, retainedPid)
+      throw new StartupProcessRetainedError(
+        retainedPid,
+        new Error('status persistence failed'),
+        new Error('process tree survived'),
+      )
+    }
+    const loop = makeLoop(
+      { issueQueueEnabled: true, scanEnabled: false, maxParallel: 1 },
+      stubProject,
+      undefined,
+      () => new Date(2026, 7, 8, 12, 0, 0),
+      makeRunner(),
+      enqueueTask,
+      undefined,
+      retainStartup,
+    )
+    loop.initializeSessionStateForBranch()
+    const issueNumber = await fakeForge.createIssue({
+      title: 'retained startup process',
+      body: buildIssueBody(description, 'scan-task'),
+      labels: [LABEL_FINDING, LABEL_READY],
+    })
+
+    expect(await loop.poll()).toBe('continue')
+
+    const taskId = retainedStarts[0]!
+    const retained = await fakeForge.getIssue(issueNumber)
+    expect(retained.labels).toContain(LABEL_IN_PROGRESS)
+    expect(retained.labels).not.toContain(LABEL_READY)
+    expect(retained.assignees).toEqual(['worker-a'])
+    expect(readStatus(paths, taskId)).toBeUndefined()
+    expect(existsSync(join(paths.tasksDir, `${taskId}.md`))).toBe(true)
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(logText()).toContain(
+      `startup process tree PID ${retainedPid} survived; task retained and loop stopped`,
+    )
+
+    expect(await loop.poll()).toBe('stopped')
+    expect(retainedStarts).toEqual([taskId])
   })
 
   it('persists a startup-failure release and stops after three failed reconciliations', async () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -2719,6 +2719,49 @@ describe('failure announcement and burst stop (via poll)', () => {
     expect(retainedStarts).toEqual([taskId])
   })
 
+  it('stops without releasing a claim when the runner returns an invalid PID', async () => {
+    initializeGitRepo()
+    const description = '[BUG] retain a claimed task with unknown runner ownership'
+    const attemptedTaskIds: string[] = []
+    const runner: Runner = {
+      sharedSkills: fakeRunnerSharedSkills,
+      start: async (options) => {
+        attemptedTaskIds.push(options.specFile.replace(/^.*[\\/]/, '').replace(/\.md$/, ''))
+        return 0
+      },
+    }
+    const loop = makeLoop(
+      { issueQueueEnabled: true, scanEnabled: false, maxParallel: 1 },
+      stubProject,
+      undefined,
+      () => new Date(2026, 7, 8, 12, 0, 0),
+      runner,
+    )
+    loop.initializeSessionStateForBranch()
+    const issueNumber = await fakeForge.createIssue({
+      title: 'unknown runner ownership',
+      body: buildIssueBody(description, 'scan-task'),
+      labels: [LABEL_FINDING, LABEL_READY],
+    })
+
+    expect(await loop.poll()).toBe('continue')
+
+    const taskId = attemptedTaskIds[0]!
+    const retained = await fakeForge.getIssue(issueNumber)
+    expect(retained.labels).toContain(LABEL_IN_PROGRESS)
+    expect(retained.labels).not.toContain(LABEL_READY)
+    expect(retained.assignees).toEqual(['worker-a'])
+    expect(readStatus(paths, taskId)).toBeUndefined()
+    expect(existsSync(worktreeDir(paths, taskId))).toBe(true)
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(logText()).toContain(
+      'runner returned an invalid PID; task ownership is unknown, task retained and loop stopped',
+    )
+
+    expect(await loop.poll()).toBe('stopped')
+    expect(attemptedTaskIds).toEqual([taskId])
+  })
+
   it('persists a startup-failure release and stops after three failed reconciliations', async () => {
     initializeGitRepo()
     const description = '[BUG] retain a claimed task until its issue can be released'

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -464,6 +464,36 @@ describe('forge poll budget', () => {
     }
   })
 
+  it('does not claim from a poll whose duplicate re-read cannot be verified', async () => {
+    const loop = makeLoop({
+      issueQueueEnabled: true, scanEnabled: false, autoMerge: false, maxParallel: 1,
+    })
+    loop.initializeSessionStateForBranch()
+    const description = '[BUG] `src/shared.ts` duplicate finding'
+    await fakeForge.createIssue({
+      title: description,
+      body: buildIssueBody(description, 'scan-1'),
+      labels: [LABEL_FINDING, LABEL_READY],
+    })
+    const duplicate = await fakeForge.createIssue({
+      title: description,
+      body: buildIssueBody(description, 'scan-2'),
+      labels: [LABEL_FINDING, LABEL_READY],
+    })
+    const getIssue = fakeForge.getIssue.bind(fakeForge)
+    fakeForge.getIssue = async (issueNumber) => {
+      if (issueNumber === duplicate) throw new Error('duplicate re-read unavailable')
+      return getIssue(issueNumber)
+    }
+
+    await expect(loop.poll()).resolves.toBe('continue')
+
+    expect(runnerStarts).toEqual([])
+    expect(logText()).toContain(
+      'WARN issue queue unreachable: duplicate re-read unavailable',
+    )
+  })
+
   it('shows two review-origin fixes in the task log', async () => {
     initializeGitRepo()
     const loop = makeLoop({

--- a/tests/os.test.ts
+++ b/tests/os.test.ts
@@ -22,6 +22,13 @@ describe('operating-system adapters', () => {
     expect(createPosixOperatingSystem()).not.toHaveProperty('platform')
   })
 
+  it('labels the local verification environment without exposing the platform selector', () => {
+    expect(createWindowsOperatingSystem().verificationEnvironmentLabel()).toBe('Windows')
+    expect(createPosixOperatingSystem().verificationEnvironmentLabel()).toBe(
+      process.platform === 'darwin' ? 'macOS' : process.platform === 'linux' ? 'Linux' : process.platform,
+    )
+  })
+
   it('launches a POSIX daemon without exposing the platform choice to callers', async () => {
     const root = mkdtempSync(join(tmpdir(), 'orch-os-'))
     const child = Object.assign(new EventEmitter(), {

--- a/tests/pathComparison.ts
+++ b/tests/pathComparison.ts
@@ -1,0 +1,6 @@
+import { realpathSync } from 'node:fs'
+
+export function resolvedPath(path: string): string {
+  const resolved = realpathSync.native(path)
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved
+}

--- a/tests/project-core.test.ts
+++ b/tests/project-core.test.ts
@@ -35,6 +35,13 @@ describe('core project verification', () => {
       .toContain('node orchestration/project/safe-npm-ci.ts')
   })
 
+  it('declares the opt-in Linux verification command', () => {
+    expect(coreProject.manualEnvironmentChecks).toContainEqual({
+      environment: 'Linux',
+      command: 'npm run test:linux',
+    })
+  })
+
   it('leaves the merge gate as the sole source of Vitest worker flags', () => {
     expect(packageJson.scripts.test).toBe('node scripts/run-tests.mjs')
     const command = coreProject.mergeChecks('full')[0]?.command ?? ''

--- a/tests/restart.test.ts
+++ b/tests/restart.test.ts
@@ -140,6 +140,75 @@ describe('loop replacement startup', () => {
     expect(child.unref).not.toHaveBeenCalled()
   })
 
+  it('keeps the predecessor PID when readiness names the wrong replacement', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orch-restart-'))
+    fixtureRoots.push(root)
+    const readyFile = join(root, 'ready')
+    const pidFile = join(root, 'loop.pid')
+    const predecessorMarker = processMarkerText(processMarker(process.pid))
+    writeFileSync(pidFile, predecessorMarker)
+    const child = fakeChild(43218)
+    const os = fakeOperatingSystem(child, () => {
+      setTimeout(() => writeFileSync(readyFile, '99999\n'), 0)
+    })
+    const onReady = vi.fn((pid: number) => {
+      publishLoopReplacementPid(pidFile, process.pid, pid)
+    })
+
+    await expect(startLoopReplacement(readyFile, {
+      env: environmentWithoutWrapper(),
+      operatingSystem: os,
+      outputFile: join(root, 'loop.log'),
+      packageRoot: root,
+      onReady,
+      startupTimeoutMs: 1_000,
+    })).resolves.toEqual({
+      ok: false,
+      pid: 43218,
+      error: 'replacement published an unexpected PID (99999)',
+    })
+    expect(onReady).not.toHaveBeenCalled()
+    expect(readFileSync(pidFile, 'utf8')).toBe(predecessorMarker)
+    expect(os.terminateProcessTree).toHaveBeenCalledWith(43218)
+    expect(child.unref).not.toHaveBeenCalled()
+  })
+
+  it('keeps the predecessor PID when the replacement dies after publishing readiness', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orch-restart-'))
+    fixtureRoots.push(root)
+    const readyFile = join(root, 'ready')
+    const pidFile = join(root, 'loop.pid')
+    const predecessorMarker = processMarkerText(processMarker(process.pid))
+    writeFileSync(pidFile, predecessorMarker)
+    const child = fakeChild(43219)
+    const os = fakeOperatingSystem(child, () => {
+      setTimeout(() => {
+        writeFileSync(readyFile, '43219\n')
+        Object.assign(child, { exitCode: 1 })
+      }, 0)
+    })
+    const onReady = vi.fn((pid: number) => {
+      publishLoopReplacementPid(pidFile, process.pid, pid)
+    })
+
+    await expect(startLoopReplacement(readyFile, {
+      env: environmentWithoutWrapper(),
+      operatingSystem: os,
+      outputFile: join(root, 'loop.log'),
+      packageRoot: root,
+      onReady,
+      startupTimeoutMs: 1_000,
+    })).resolves.toEqual({
+      ok: false,
+      pid: 43219,
+      error: 'replacement exited before becoming ready',
+    })
+    expect(onReady).not.toHaveBeenCalled()
+    expect(readFileSync(pidFile, 'utf8')).toBe(predecessorMarker)
+    expect(os.processTreeIsAlive).toHaveBeenCalledWith(43219)
+    expect(child.unref).not.toHaveBeenCalled()
+  })
+
   it('upgrades a legacy bare-PID reservation only when the ready replacement is published', () => {
     const root = mkdtempSync(join(tmpdir(), 'orch-restart-'))
     fixtureRoots.push(root)

--- a/tests/runner-survival.test.ts
+++ b/tests/runner-survival.test.ts
@@ -1,15 +1,16 @@
 import { spawnSync } from 'node:child_process'
 import {
-  existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync,
+  existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { afterEach, expect, it } from 'vitest'
 import { operatingSystem } from '../src/adapters/os.ts'
 import {
   LOOP_RESTART_PREDECESSOR_PID_ENV, LOOP_RESTART_READY_FILE_ENV,
 } from '../src/restart.ts'
+import { resolvedPath } from './pathComparison.ts'
 import { TestProcessRegistry } from './testProcess.ts'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
@@ -137,8 +138,8 @@ it('launches the real CLI daemon through the independent hidden-console wrapper'
   await waitUntil(() => processIsAlive(daemonPid), 'CLI daemon did not survive its launcher')
   const probes = readFileSync(probeFile, 'utf8').trim().split(/\r?\n/)
     .map((line) => JSON.parse(line) as SpawnProbe)
-  const daemonSpawn = probes.find((probe) => probe.command === process.execPath
-    && probe.args.includes('--marker-output'))
+  const daemonSpawn = probes.find((probe) => probe.args.includes('--marker-output'))
+  expect(resolvedPath(daemonSpawn?.command ?? '')).toBe(resolvedPath(process.execPath))
   if (process.platform === 'win32') {
     // The wrapper owns the independent hidden console. The daemon is deliberately
     // attached to it so every console tool in the daemon tree inherits that console.
@@ -153,12 +154,10 @@ it('launches the real CLI daemon through the independent hidden-console wrapper'
   // The daemon must inherit the repository the launcher was pointed at. Started in the
   // package directory instead, it resolves its own checkout as the repository and the
   // startup dependency install reinstalls the package it is running from.
-  expect(resolve(daemonSpawn?.cwd ?? '').toLowerCase())
-    .toBe(realpathSync.native(root).toLowerCase())
+  expect(resolvedPath(daemonSpawn?.cwd ?? '')).toBe(resolvedPath(root))
   const repoOption = daemonSpawn?.args.indexOf('--repo') ?? -1
   expect(repoOption).toBeGreaterThan(-1)
-  expect(resolve(daemonSpawn?.args[repoOption + 1] ?? '').toLowerCase())
-    .toBe(realpathSync.native(root).toLowerCase())
+  expect(resolvedPath(daemonSpawn?.args[repoOption + 1] ?? '')).toBe(resolvedPath(root))
 
   mkdirSync(dirname(stopFile), { recursive: true })
   writeFileSync(stopFile, '')

--- a/tests/runner-survival.test.ts
+++ b/tests/runner-survival.test.ts
@@ -155,6 +155,10 @@ it('launches the real CLI daemon through the independent hidden-console wrapper'
   // startup dependency install reinstalls the package it is running from.
   expect(resolve(daemonSpawn?.cwd ?? '').toLowerCase())
     .toBe(realpathSync.native(root).toLowerCase())
+  const repoOption = daemonSpawn?.args.indexOf('--repo') ?? -1
+  expect(repoOption).toBeGreaterThan(-1)
+  expect(resolve(daemonSpawn?.args[repoOption + 1] ?? '').toLowerCase())
+    .toBe(realpathSync.native(root).toLowerCase())
 
   mkdirSync(dirname(stopFile), { recursive: true })
   writeFileSync(stopFile, '')

--- a/tests/safe-npm-ci.test.ts
+++ b/tests/safe-npm-ci.test.ts
@@ -46,6 +46,23 @@ describe('safe npm clean install', () => {
     expect(readFileSync(marker, 'utf8')).toBe('working\n')
   })
 
+  it('reports both the install and staging cleanup failures', () => {
+    const installFailure = new Error('install failed')
+    const cleanupFailure = new Error('cleanup failed')
+    const failed = runtime({
+      install: () => { throw installFailure },
+      remove: () => { throw cleanupFailure },
+    })
+
+    try {
+      safeNpmCi(root, failed)
+      expect.fail('safeNpmCi should throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError)
+      expect((error as AggregateError).errors).toEqual([installFailure, cleanupFailure])
+    }
+  })
+
   it('activates a complete staged dependency tree', () => {
     const oldMarker = writeDependency(join(root, 'node_modules'), 'old-dependency', 'old\n')
     const installed = runtime({

--- a/tests/shared-skills.test.ts
+++ b/tests/shared-skills.test.ts
@@ -124,6 +124,28 @@ describe('shared skill sync', () => {
       .toContain('## Repository guidance')
   })
 
+  it('preserves a literal guidance token while injecting repository guidance once', () => {
+    writeSkill('loop-start', [
+      'The synthetic endpoint is `{{ORCHESTRATION_PROJECT_GUIDANCE}}`.',
+      '',
+    ].join('\n'))
+    const guidance = join(repoRoot, 'orchestration', 'project', 'skills', 'loop-start.md')
+    mkdirSync(dirname(guidance), { recursive: true })
+    writeFileSync(guidance, '## Repository guidance\n\nUse the consumer queue.\n')
+
+    syncSharedSkills(repoRoot, packageRoot, [interactiveSharedSkills])
+
+    expect(readFileSync(join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
+      .toBe([
+        'The synthetic endpoint is `{{ORCHESTRATION_PROJECT_GUIDANCE}}`.',
+        '',
+        '## Repository guidance',
+        '',
+        'Use the consumer queue.',
+        '',
+      ].join('\n'))
+  })
+
   it('renders exactly the canonical skill when repository guidance is absent', () => {
     syncSharedSkills(repoRoot, packageRoot, [interactiveSharedSkills])
 

--- a/tests/shared-skills.test.ts
+++ b/tests/shared-skills.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createClaudeRunner } from '../src/adapters/runner-claude.ts'
 import type { Runner } from '../src/adapters/runner.ts'
 import { createClaudeSharedSkills } from '../src/adapters/shared-skills-claude.ts'
-import { syncSharedSkills } from '../src/sharedSkills.ts'
+import { sharedSkillManagedTargets, syncSharedSkills } from '../src/sharedSkills.ts'
 import { fakeRunnerSharedSkills } from './fakeRunner.ts'
 
 let fixtureRoot: string
@@ -29,6 +29,7 @@ function writeManifest(skills: string[]): void {
   writeFileSync(join(packageRoot, 'skills', 'manifest.json'), `${JSON.stringify({
     commandPrefixPlaceholder: '{{ORCHESTRATION_COMMAND_PREFIX}}',
     packagePathPrefixPlaceholder: '{{ORCHESTRATION_PACKAGE_PATH_PREFIX}}',
+    projectGuidancePlaceholder: '{{ORCHESTRATION_PROJECT_GUIDANCE}}',
     skills,
   }, null, 2)}\n`)
 }
@@ -103,7 +104,34 @@ describe('shared skill sync', () => {
       .toBe('source: `src`\n')
   })
 
-  it('refreshes exact generated copies and retains unlisted repository skills', () => {
+  it('renders repository guidance at the shared skill injection point', () => {
+    const guidance = join(repoRoot, 'orchestration', 'project', 'skills', 'loop-start.md')
+    mkdirSync(dirname(guidance), { recursive: true })
+    writeFileSync(guidance, '## Repository guidance\n\nUse the consumer queue.\n')
+
+    syncSharedSkills(repoRoot, packageRoot, skillAdapters())
+
+    expect(readFileSync(join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
+      .toBe([
+        "npm run -C 'orchestration/ts' loop -- --daemon",
+        '',
+        '## Repository guidance',
+        '',
+        'Use the consumer queue.',
+        '',
+      ].join('\n'))
+    expect(readFileSync(join(repoRoot, '.claude', 'skills', 'loop-start', 'SKILL.md'), 'utf8'))
+      .toContain('## Repository guidance')
+  })
+
+  it('renders exactly the canonical skill when repository guidance is absent', () => {
+    syncSharedSkills(repoRoot, packageRoot, [interactiveSharedSkills])
+
+    expect(readFileSync(join(repoRoot, '.claude', 'skills', 'git-commit', 'SKILL.md'), 'utf8'))
+      .toBe('Commit without a command.\n')
+  })
+
+  it('refreshes exact generated copies and leaves an unmanaged repository skill untouched', () => {
     const localSkill = join(repoRoot, '.agents', 'skills', 'verify-changes', 'SKILL.md')
     mkdirSync(join(repoRoot, '.agents', 'skills', 'verify-changes'), { recursive: true })
     writeFileSync(localSkill, 'repository gates\n')
@@ -153,7 +181,7 @@ describe('shared skill sync', () => {
     )).toBe('updated commit instructions\n')
   })
 
-  it('reports and preserves a generated skill that the consumer changed', () => {
+  it('overwrites a changed managed skill across rendered targets', () => {
     syncSharedSkills(repoRoot, packageRoot, skillAdapters())
     const installed = join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md')
     writeFileSync(installed, 'consumer version\n')
@@ -161,19 +189,39 @@ describe('shared skill sync', () => {
 
     const result = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
-    expect(result.conflicts).toEqual(['.agents/skills/loop-start'])
-    expect(result.updated).toEqual(['.claude/skills/loop-start'])
-    expect(readFileSync(installed, 'utf8')).toBe('consumer version\n')
+    expect(result.conflicts).toEqual([])
+    expect(result.updated).toEqual([
+      '.agents/skills/loop-start', '.claude/skills/loop-start',
+    ])
+    expect(readFileSync(installed, 'utf8')).toBe('upstream version\n')
   })
 
-  it('treats deletion of a managed skill as deliberate divergence', () => {
+  it('leaves a manifest skill untouched when the managed index does not record it', () => {
+    const localSkill = join(repoRoot, '.agents', 'skills', 'loop-start', 'SKILL.md')
+    mkdirSync(dirname(localSkill), { recursive: true })
+    writeFileSync(localSkill, 'repository-owned workflow\n')
+
+    const result = syncSharedSkills(repoRoot, packageRoot, [runner.sharedSkills])
+
+    expect(result.conflicts).toEqual(['.agents/skills/loop-start'])
+    expect(readFileSync(localSkill, 'utf8')).toBe('repository-owned workflow\n')
+    const state = JSON.parse(readFileSync(
+      join(repoRoot, '.agents', 'skills', '.orchestration-core-sync.json'), 'utf8',
+    )) as { skills: Record<string, string> }
+    expect(state.skills).not.toHaveProperty('loop-start')
+    expect(sharedSkillManagedTargets(repoRoot, packageRoot, [runner.sharedSkills])[0]
+      ?.managedPaths).not.toContain(join(repoRoot, '.agents', 'skills', 'loop-start'))
+  })
+
+  it('restores a deleted managed skill', () => {
     syncSharedSkills(repoRoot, packageRoot, skillAdapters())
     rmSync(join(repoRoot, '.agents', 'skills', 'loop-start'), { recursive: true })
 
     const result = syncSharedSkills(repoRoot, packageRoot, skillAdapters())
 
-    expect(result.conflicts).toEqual(['.agents/skills/loop-start'])
-    expect(existsSync(join(repoRoot, '.agents', 'skills', 'loop-start'))).toBe(false)
+    expect(result.conflicts).toEqual([])
+    expect(result.updated).toEqual(['.agents/skills/loop-start'])
+    expect(existsSync(join(repoRoot, '.agents', 'skills', 'loop-start'))).toBe(true)
   })
 
   it('removes hash-matching legacy copies and their one-time migration state', () => {

--- a/tests/start.test.ts
+++ b/tests/start.test.ts
@@ -8,8 +8,8 @@ import type { Runner } from '../src/adapters/runner.ts'
 import {
   branchName, logFile, orchPaths, statusFile, worktreeDir, type OrchPaths,
 } from '../src/paths.ts'
-import { recordTaskProcess } from '../src/processRegistry.ts'
-import { startTask, worktreeAddArgs } from '../src/start.ts'
+import { recordTaskProcess, taskProcessPid } from '../src/processRegistry.ts'
+import { startTask, StartupProcessRetainedError, worktreeAddArgs } from '../src/start.ts'
 import { readStatus } from '../src/status.ts'
 import { specFile } from '../src/tasks.ts'
 import { fakeRunnerSharedSkills } from './fakeRunner.ts'
@@ -189,16 +189,24 @@ describe('startTask', () => {
     writeFileSync(specFile(paths, taskId), '# cleanup failure\n')
     vi.spyOn(operatingSystem, 'terminateProcessTree').mockReturnValue(true)
     vi.spyOn(operatingSystem, 'processTreeIsAlive').mockReturnValue(true)
+    vi.spyOn(operatingSystem, 'processStartIdentity').mockReturnValue('runner-start')
+    vi.spyOn(operatingSystem, 'processIsAlive').mockReturnValue(true)
     statusMocks.writeStatus.mockRejectedValueOnce(new Error('status persistence failed'))
 
-    await expect(startTask(paths, {
+    const startup = startTask(paths, {
       sharedSkills: fakeRunnerSharedSkills,
       start: vi.fn(async () => pid),
-    }, taskId, { effort: 'medium' }))
-      .rejects.toThrow(`Task startup failed and process tree ${pid} could not be stopped.`)
+    }, taskId, { effort: 'medium' })
+
+    await expect(startup).rejects.toMatchObject({
+      name: 'StartupProcessRetainedError',
+      pid,
+      message: `Task startup failed and process tree ${pid} could not be stopped.`,
+    } satisfies Partial<StartupProcessRetainedError>)
 
     expect(statusMocks.writeStatus).toHaveBeenCalledTimes(1)
     expect(readStatus(paths, taskId)).toBeUndefined()
+    expect(taskProcessPid(paths, taskId)).toBe(pid)
     expect(readFileSync(logFile(paths, taskId), 'utf8')).toContain('Process tree cleanup failed')
   })
 })

--- a/tests/start.test.ts
+++ b/tests/start.test.ts
@@ -9,7 +9,9 @@ import {
   branchName, logFile, orchPaths, statusFile, worktreeDir, type OrchPaths,
 } from '../src/paths.ts'
 import { recordTaskProcess, taskProcessPid } from '../src/processRegistry.ts'
-import { startTask, StartupProcessRetainedError, worktreeAddArgs } from '../src/start.ts'
+import {
+  startTask, StartupOwnershipUnknownError, StartupProcessRetainedError, worktreeAddArgs,
+} from '../src/start.ts'
 import { readStatus } from '../src/status.ts'
 import { specFile } from '../src/tasks.ts'
 import { fakeRunnerSharedSkills } from './fakeRunner.ts'
@@ -154,6 +156,33 @@ describe('startTask', () => {
     expect(readStatus(paths, taskId)?.status).toBe('failed')
     expect(readFileSync(logFile(paths, taskId), 'utf8')).toContain('setup exploded')
   })
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'retains the task without publishing status when the runner returns invalid PID %s',
+    async (pid) => {
+      const taskId = `20260821_000000_001_invalid-pid-${String(pid).replace(/\W/g, '-')}`
+      writeFileSync(specFile(paths, taskId), '# invalid runner PID\n')
+      const terminateProcessTree = vi.spyOn(operatingSystem, 'terminateProcessTree')
+      const report = vi.fn()
+
+      await expect(startTask(paths, {
+        sharedSkills: fakeRunnerSharedSkills,
+        start: vi.fn(async () => pid),
+      }, taskId, { effort: 'medium', report })).rejects.toMatchObject({
+        name: 'StartupOwnershipUnknownError',
+        message: `Runner returned invalid PID ${String(pid)}; process ownership could not be established.`,
+      } satisfies Partial<StartupOwnershipUnknownError>)
+
+      expect(terminateProcessTree).not.toHaveBeenCalled()
+      expect(statusMocks.writeStatus).not.toHaveBeenCalled()
+      expect(readStatus(paths, taskId)).toBeUndefined()
+      expect(taskProcessPid(paths, taskId)).toBeUndefined()
+      expect(existsSync(worktreeDir(paths, taskId))).toBe(true)
+      expect(report).not.toHaveBeenCalledWith(expect.stringContaining('Started.'))
+      expect(readFileSync(logFile(paths, taskId), 'utf8'))
+        .toContain('Task startup ownership is unknown:')
+    },
+  )
 
   it('stops and verifies a launched process tree before recording status persistence failure', async () => {
     const taskId = '20260814_000000_001_status-failure'

--- a/tests/worker-launch.test.ts
+++ b/tests/worker-launch.test.ts
@@ -1,7 +1,8 @@
-import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { orchPaths } from '../src/paths.ts'
 import {
@@ -33,6 +34,95 @@ function dependencies(launchDaemon = vi.fn(() => 0)): WorkerCommandDependencies 
 
 const unsupportedConfig = 'export function loadConfig() { return {} }\n'
 const supportedConfig = 'export function loadConfig() { return { workerMode: true } }\n'
+const WORKER_MODULE = pathToFileURL(join(import.meta.dirname, '..', 'src', 'worker.ts')).href
+const PATHS_MODULE = pathToFileURL(join(import.meta.dirname, '..', 'src', 'paths.ts')).href
+
+interface LaunchProbe {
+  command: string
+  args: string[]
+  cwd: string
+  issueQueueEnabled: string | undefined
+  workerMode: string | undefined
+  parentSentinel: string | undefined
+}
+
+interface LaunchOutcome {
+  status?: number
+  error?: { name: string, message: string, code?: string }
+}
+
+function runProductionLaunchProbe(
+  daemonStatus: number,
+  spawnError = false,
+): { probe: LaunchProbe, outcome: LaunchOutcome } {
+  const preload = join(tempRoot, `worker-spawn-probe-${daemonStatus}-${spawnError}.cjs`)
+  const harness = join(tempRoot, `worker-launch-harness-${daemonStatus}-${spawnError}.ts`)
+  const probeFile = join(tempRoot, `worker-spawn-probe-${daemonStatus}-${spawnError}.json`)
+  const outcomeFile = join(tempRoot, `worker-launch-outcome-${daemonStatus}-${spawnError}.json`)
+  writeFileSync(preload, [
+    "const childProcess = require('node:child_process')",
+    "const { writeFileSync } = require('node:fs')",
+    "const { syncBuiltinESMExports } = require('node:module')",
+    'const originalSpawnSync = childProcess.spawnSync',
+    'childProcess.spawnSync = function (command, args, options) {',
+    "  if (args?.[0] === '--input-type=module') {",
+    "    return { status: 0, signal: null, stdout: '', stderr: '' }",
+    '  }',
+    "  if (args?.[1] === 'loop' && args?.includes('--daemon')) {",
+    '    writeFileSync(process.env.ORCH_WORKER_LAUNCH_PROBE, JSON.stringify({',
+    '      command, args, cwd: options?.cwd,',
+    '      issueQueueEnabled: options?.env?.ISSUE_QUEUE_ENABLED,',
+    '      workerMode: options?.env?.WORKER_MODE,',
+    '      parentSentinel: options?.env?.ORCH_WORKER_PARENT_SENTINEL,',
+    '    }))',
+    "    if (process.env.ORCH_WORKER_SPAWN_ERROR === 'true') {",
+    "      const error = Object.assign(new Error('synthetic daemon spawn failure'), { code: 'ENOENT' })",
+    "      return { error, status: null, signal: null, stdout: '', stderr: '' }",
+    '    }',
+    '    return { status: Number(process.env.ORCH_WORKER_DAEMON_STATUS), signal: null,',
+    "      stdout: '', stderr: '' }",
+    '  }',
+    '  return originalSpawnSync.apply(this, arguments)',
+    '}',
+    'syncBuiltinESMExports()',
+    '',
+  ].join('\n'))
+  writeFileSync(harness, [
+    `import { runWorkerCommand } from ${JSON.stringify(WORKER_MODULE)}`,
+    `import { orchPaths } from ${JSON.stringify(PATHS_MODULE)}`,
+    "import { writeFileSync } from 'node:fs'",
+    `const paths = orchPaths(${JSON.stringify(worker)})`,
+    'try {',
+    "  const status = await runWorkerCommand(paths, 'origin/main')",
+    '  writeFileSync(process.env.ORCH_WORKER_OUTCOME, JSON.stringify({ status }))',
+    '} catch (error) {',
+    '  writeFileSync(process.env.ORCH_WORKER_OUTCOME, JSON.stringify({ error: {',
+    '    name: error?.name, message: error?.message, code: error?.code,',
+    '  } }))',
+    '}',
+    '',
+  ].join('\n'))
+
+  const result = spawnSync(process.execPath, [harness], {
+    cwd: tempRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --require="${preload.replaceAll('\\', '\\\\')}"`.trim(),
+      ORCH_WORKER_DAEMON_STATUS: String(daemonStatus),
+      ORCH_WORKER_LAUNCH_PROBE: probeFile,
+      ORCH_WORKER_OUTCOME: outcomeFile,
+      ORCH_WORKER_PARENT_SENTINEL: 'preserved',
+      ORCH_WORKER_SPAWN_ERROR: String(spawnError),
+    },
+    windowsHide: true,
+  })
+  expect(result.status, result.stderr).toBe(0)
+  return {
+    probe: JSON.parse(readFileSync(probeFile, 'utf8')) as LaunchProbe,
+    outcome: JSON.parse(readFileSync(outcomeFile, 'utf8')) as LaunchOutcome,
+  }
+}
 
 beforeEach(() => {
   tempRoot = mkdtempSync(join(tmpdir(), 'orch-worker-launch-'))
@@ -134,5 +224,42 @@ describe('worker mode self-check', () => {
       .rejects.toThrow(/updated checkout does not support worker mode.*config\.workerMode is missing/)
     expect(readFileSync(join(worker, 'new.txt'), 'utf8').trim()).toBe('new code')
     expect(launch).not.toHaveBeenCalled()
+  })
+})
+
+describe('worker daemon subprocess boundary', () => {
+  beforeEach(() => {
+    commit(merger, 'orchestration/ts/src/config.ts', supportedConfig, 'feat: add worker support')
+    commit(merger, 'orchestration/ts/src/cli.ts', '// updated worker CLI\n', 'feat: add updated CLI')
+    git(merger, ['push', '-q', 'origin', 'HEAD:main'])
+  })
+
+  it('launches the updated issue-mode CLI from the repository with the worker environment', () => {
+    const { probe, outcome } = runProductionLaunchProbe(23)
+
+    expect(outcome).toEqual({ status: 23 })
+    expect(resolve(probe.command).toLowerCase()).toBe(resolve(process.execPath).toLowerCase())
+    expect(probe.args).toEqual([
+      join(worker, 'orchestration', 'ts', 'src', 'cli.ts'),
+      'loop', '--approve-mode', 'issue', '--daemon',
+    ])
+    expect(resolve(probe.cwd).toLowerCase()).toBe(realpathSync.native(worker).toLowerCase())
+    expect(probe).toMatchObject({
+      issueQueueEnabled: 'true',
+      workerMode: 'true',
+      parentSentinel: 'preserved',
+    })
+  })
+
+  it('surfaces a daemon spawn error from the production handoff', () => {
+    const { outcome } = runProductionLaunchProbe(0, true)
+
+    expect(outcome).toEqual({
+      error: {
+        name: 'Error',
+        message: 'synthetic daemon spawn failure',
+        code: 'ENOENT',
+      },
+    })
   })
 })

--- a/tests/worker-launch.test.ts
+++ b/tests/worker-launch.test.ts
@@ -1,13 +1,14 @@
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { orchPaths } from '../src/paths.ts'
 import {
   runWorkerCommand, verifyWorkerModeSupported, type WorkerCommandDependencies,
 } from '../src/worker.ts'
+import { resolvedPath } from './pathComparison.ts'
 
 let tempRoot: string
 let origin: string
@@ -238,12 +239,13 @@ describe('worker daemon subprocess boundary', () => {
     const { probe, outcome } = runProductionLaunchProbe(23)
 
     expect(outcome).toEqual({ status: 23 })
-    expect(resolve(probe.command).toLowerCase()).toBe(resolve(process.execPath).toLowerCase())
-    expect(probe.args).toEqual([
-      join(worker, 'orchestration', 'ts', 'src', 'cli.ts'),
+    expect(resolvedPath(probe.command)).toBe(resolvedPath(process.execPath))
+    expect(resolvedPath(probe.args[0] ?? ''))
+      .toBe(resolvedPath(join(worker, 'orchestration', 'ts', 'src', 'cli.ts')))
+    expect(probe.args.slice(1)).toEqual([
       'loop', '--approve-mode', 'issue', '--daemon',
     ])
-    expect(resolve(probe.cwd).toLowerCase()).toBe(realpathSync.native(worker).toLowerCase())
+    expect(resolvedPath(probe.cwd)).toBe(resolvedPath(worker))
     expect(probe).toMatchObject({
       issueQueueEnabled: 'true',
       workerMode: 'true',


### PR DESCRIPTION
## Features

- [Shared skills] A shared skill now carries a project injection point, so a consuming repository adds its own guidance to a core-owned skill instead of editing the rendered copy the next sync overwrites. The fragment lives outside the vendored subtree, following the shape `pitfallsFileForDesc` already established for task specifications, and a repository that supplies none renders exactly as before.
- [Commands] Every command can name the repository it acts on rather than taking whichever one the working directory sits in, and `loop-status` accepts several repositories and answers with one line each. One checkout now drives a fleet without changing directory. The core keeps no registry of repositories: the caller supplies the paths.
- [Cycle gate] Before promoting, the run reports which environments its verification actually exercised and which it did not, and names the cross-platform check it did not run. It does not run that check itself — it is slow and needs a container runtime the environment may not have, and a gate that hangs on a missing runtime is worse than one that reports honestly.

## Bug Fixes

- [Commands] Repository selection reached the foreground command but not the background daemon, the runner loaded during startup, or the `Check:` and `Stop:` commands the launcher prints, so targeting another repository worked for a status query and silently failed for a run.
- [Issue queue] Issue listings are paginated, so a queue longer than one page is now seen whole. A finding whose claim drifted is returned to ready, a no-op release no longer counts as a mutation, and a read failure during finding reconciliation propagates instead of being taken for an empty result.
- [Startup] A runner process ID that is not a positive integer is rejected rather than recorded, and a runner that survives a failed startup is retained rather than leaked.
- [Config] An error while inspecting configuration fails closed instead of resolving to a default, and the verified-environment status is deferred until the value it reports is known.
- [Dependencies] A cleanup failure in the npm setup path no longer replaces the installation error that caused it, so the reason dependency setup failed survives to the report.
- [Shared skills] A project guidance fragment containing a token the renderer recognises is preserved literally rather than substituted a second time.
- [Checks] The English-only fixture exemption is narrowed to the fixture that needs it.

## Security

- [Issue queue] A finding reconciliation read failure is propagated rather than treated as "no findings", so a forge error cannot quietly empty the set of open findings a gate depends on.

## Project Operations

- [Documentation] The manual environment checks a promotion does not run are documented alongside the automated ones.
- [Skills] The rendered interactive skills are re-rendered to match the sources after this run's changes to the launch contract.

## Risks

- `tests/worker-launch.test.ts` compared Windows paths as strings and passed on a checkout whose user name is short while failing on one long enough for an 8.3 short form. It failed this repository's Windows CI on the previous head and now compares resolved paths. That defect is the reason the cycle gate now reports the environments it did not verify: the gate had run the same suite on the same commit and passed.
- Verified for this branch: `node checks/english-only.ts`, `npm run typecheck`, and the suite pass on Windows; `npm run test:linux` passes in the Linux container with 952 tests. Both platforms also pass in CI.
- 44 files changed across the CLI, issue queue, shared skills, startup, and the operating-system adapters. The surface is wide and sits in the lifecycle code every consumer depends on.
- Repository selection is now part of the command contract. A caller that relied on the working directory alone is unaffected, since that remains the default.
