### PR TITLE
test: cover each platform's real-process behaviour and say what a run left out

### DIFF
--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -1,0 +1,8 @@
+import { platformCoverageReport } from './platformCoverage.ts'
+
+// Printed once per run, before the summary a reader will judge the run by, so a run that
+// could not attempt a suite says which one and why rather than reporting a count that
+// looks the same as a run where nothing was left out.
+export function setup(): void {
+  console.log(platformCoverageReport())
+}

--- a/tests/platform-coverage.test.ts
+++ b/tests/platform-coverage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PLATFORM_SUITES, platformCoverageReport, uncollectedSuites,
+} from './platformCoverage.ts'
+
+describe('platform coverage', () => {
+  it('leaves a suite uncollected only on the platforms that cannot attempt it', () => {
+    expect(uncollectedSuites('win32')).toEqual([])
+    expect(uncollectedSuites('linux')).toEqual(['tests/windows-console.test.ts'])
+  })
+
+  it('names an uncollected suite and the platform it needs', () => {
+    const report = platformCoverageReport('linux')
+    expect(report).toContain('not run    tests/windows-console.test.ts')
+    expect(report).toContain('needs win32')
+    // The reason travels with the name: a reader who has never opened the file learns
+    // why another platform cannot stand in for the one that runs it.
+    expect(report).toContain('launches a Windows process tree')
+  })
+
+  it('reports a suite as collected on the platform that runs it', () => {
+    const report = platformCoverageReport('win32')
+    expect(report).toContain('collected  tests/windows-console.test.ts')
+    expect(report).not.toContain('not run')
+  })
+
+  it('accounts for every platform-specific suite on both platforms', () => {
+    for (const platform of ['win32', 'linux'] as const) {
+      const report = platformCoverageReport(platform)
+      for (const suite of PLATFORM_SUITES) expect(report).toContain(suite.file)
+    }
+  })
+})

--- a/tests/platform-coverage.test.ts
+++ b/tests/platform-coverage.test.ts
@@ -5,11 +5,11 @@ import {
 
 describe('platform coverage', () => {
   it('leaves a suite uncollected only on the platforms that cannot attempt it', () => {
-    expect(uncollectedSuites('win32')).toEqual([])
+    expect(uncollectedSuites('win32')).toEqual(['tests/posix-process-group.test.ts'])
     expect(uncollectedSuites('linux')).toEqual(['tests/windows-console.test.ts'])
   })
 
-  it('names an uncollected suite and the platform it needs', () => {
+  it('names an uncollected suite, the platform it needs, and why', () => {
     const report = platformCoverageReport('linux')
     expect(report).toContain('not run    tests/windows-console.test.ts')
     expect(report).toContain('needs win32')
@@ -21,7 +21,7 @@ describe('platform coverage', () => {
   it('reports a suite as collected on the platform that runs it', () => {
     const report = platformCoverageReport('win32')
     expect(report).toContain('collected  tests/windows-console.test.ts')
-    expect(report).not.toContain('not run')
+    expect(report).toContain('not run    tests/posix-process-group.test.ts')
   })
 
   it('accounts for every platform-specific suite on both platforms', () => {
@@ -29,5 +29,16 @@ describe('platform coverage', () => {
       const report = platformCoverageReport(platform)
       for (const suite of PLATFORM_SUITES) expect(report).toContain(suite.file)
     }
+  })
+
+  it('covers each platform with the same number of real-process suites', () => {
+    // The asymmetry this pins is the one that prompted the suite: Windows had a test
+    // that drove real processes and POSIX had none, so a signal reaching a whole
+    // process group was only ever asserted through an injected runtime.
+    const perPlatform = new Map<NodeJS.Platform, number>()
+    for (const suite of PLATFORM_SUITES) {
+      perPlatform.set(suite.platform, (perPlatform.get(suite.platform) ?? 0) + 1)
+    }
+    expect([...perPlatform.entries()].sort()).toEqual([['linux', 1], ['win32', 1]])
   })
 })

--- a/tests/platformCoverage.ts
+++ b/tests/platformCoverage.ts
@@ -18,6 +18,11 @@ export const PLATFORM_SUITES: PlatformSuite[] = [
     platform: 'win32',
     reason: 'launches a Windows process tree and observes the consoles it attaches',
   },
+  {
+    file: 'tests/posix-process-group.test.ts',
+    platform: 'linux',
+    reason: 'signals a real detached process group and reads /proc to see who survived',
+  },
 ]
 
 /** The suites this platform cannot attempt, so the config can leave them uncollected. */

--- a/tests/platformCoverage.ts
+++ b/tests/platformCoverage.ts
@@ -1,0 +1,40 @@
+// Which suites a platform cannot attempt, and the one place that knows it.
+//
+// `vitest.config.ts` reads this to leave them uncollected, and `globalSetup` reads it to
+// say so at the start of a run. Both from here, so a suite added to one is never missing
+// from the other: a file silently uncollected reports the same summary as one that does
+// not exist, and a reader cannot tell a run that skipped nothing from a run that skipped
+// something without saying so.
+
+export interface PlatformSuite {
+  file: string
+  platform: NodeJS.Platform
+  reason: string
+}
+
+export const PLATFORM_SUITES: PlatformSuite[] = [
+  {
+    file: 'tests/windows-console.test.ts',
+    platform: 'win32',
+    reason: 'launches a Windows process tree and observes the consoles it attaches',
+  },
+]
+
+/** The suites this platform cannot attempt, so the config can leave them uncollected. */
+export function uncollectedSuites(platform: NodeJS.Platform = process.platform): string[] {
+  return PLATFORM_SUITES.filter((suite) => suite.platform !== platform).map((s) => s.file)
+}
+
+/** What a run should state about the suites its platform does and does not cover. */
+export function platformCoverageReport(
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const collected = PLATFORM_SUITES.filter((suite) => suite.platform === platform)
+  const uncollected = PLATFORM_SUITES.filter((suite) => suite.platform !== platform)
+  const lines = [`platform ${platform}: ${PLATFORM_SUITES.length} platform-specific suite(s)`]
+  for (const suite of collected) lines.push(`  collected  ${suite.file}`)
+  for (const suite of uncollected) {
+    lines.push(`  not run    ${suite.file} — needs ${suite.platform}: ${suite.reason}`)
+  }
+  return lines.join('\n')
+}

--- a/tests/posix-process-group.test.ts
+++ b/tests/posix-process-group.test.ts
@@ -1,0 +1,89 @@
+import { mkdtempSync, readFileSync, existsSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it } from 'vitest'
+import { createOperatingSystem } from '../src/adapters/os-posix.ts'
+import { PROCESS_TEST_TIMEOUT_MS } from './testProcess.ts'
+
+// The POSIX counterpart of windows-console.test.ts. Every other test of this adapter
+// injects its runtime, which proves the decisions it makes but not that a real signal
+// reaches a real process group: `process.kill(-pid)` and reading `/proc/<pid>/stat` are
+// answered by the kernel, and no injected runtime can stand in for that. Windows had
+// such a test and POSIX did not, so the behaviour a merged fix repaired here — killing a
+// daemon's whole process group rather than the daemon alone — was never exercised for
+// real. vitest.config.ts collects this on POSIX alone; see tests/platformCoverage.ts.
+
+const roots: string[] = []
+const groups: number[] = []
+const operatingSystem = createOperatingSystem()
+
+async function waitUntil(predicate: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + PROCESS_TEST_TIMEOUT_MS
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+afterEach(() => {
+  for (const pid of groups.splice(0)) {
+    try {
+      if (operatingSystem.processTreeIsAlive(pid)) process.kill(-pid, 'SIGKILL')
+    } catch {
+      // Already gone, which is what the test asked for.
+    }
+  }
+  for (const root of roots.splice(0)) operatingSystem.removeDirectory(root)
+})
+
+it('terminates every member of a detached process group, not only its leader', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'orchestration-process-group-'))
+  roots.push(root)
+  const outputFile = join(root, 'daemon.log')
+  const leaderPidFile = join(root, 'leader.pid')
+  const childPidFile = join(root, 'child.pid')
+  const readyFile = join(root, 'ready')
+
+  // The leader forks a child that outlives a signal sent to the leader alone, so a
+  // termination that reached only the leader leaves the child running and observable.
+  const script = join(root, 'leader.cjs')
+  writeFileSync(script, `
+const { spawn } = require('node:child_process')
+const { writeFileSync } = require('node:fs')
+const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+  detached: false,
+  stdio: 'ignore',
+})
+writeFileSync(${JSON.stringify(leaderPidFile)}, String(process.pid))
+writeFileSync(${JSON.stringify(childPidFile)}, String(child.pid))
+writeFileSync(${JSON.stringify(readyFile)}, '')
+setInterval(() => {}, 1000)
+`)
+
+  const daemon = await operatingSystem.launchDaemon({
+    args: [script],
+    command: process.execPath,
+    cwd: root,
+    env: process.env,
+    outputFile,
+  })
+  groups.push(daemon.pid)
+  daemon.release()
+
+  await waitUntil(() => existsSync(readyFile), 'the detached leader never started its child')
+  const leaderPid = Number(readFileSync(leaderPidFile, 'utf8'))
+  const childPid = Number(readFileSync(childPidFile, 'utf8'))
+
+  expect(leaderPid).toBe(daemon.pid)
+  expect(childPid).not.toBe(daemon.pid)
+  expect(operatingSystem.processIsAlive(childPid)).toBe(true)
+  expect(operatingSystem.processTreeIsAlive(daemon.pid)).toBe(true)
+
+  expect(operatingSystem.terminateProcessTree(daemon.pid)).toBe(true)
+
+  // The leader and the child it forked are both gone, and the group reports empty. A
+  // signal delivered to the leader alone would leave the child here.
+  expect(operatingSystem.processIsAlive(leaderPid)).toBe(false)
+  expect(operatingSystem.processIsAlive(childPid)).toBe(false)
+  expect(operatingSystem.processTreeIsAlive(daemon.pid)).toBe(false)
+})

--- a/tests/posix-process-group.test.ts
+++ b/tests/posix-process-group.test.ts
@@ -81,9 +81,19 @@ setInterval(() => {}, 1000)
 
   expect(operatingSystem.terminateProcessTree(daemon.pid)).toBe(true)
 
-  // The leader and the child it forked are both gone, and the group reports empty. A
-  // signal delivered to the leader alone would leave the child here.
-  expect(operatingSystem.processIsAlive(leaderPid)).toBe(false)
-  expect(operatingSystem.processIsAlive(childPid)).toBe(false)
+  // The forked child is what proves group-wide delivery: it was never signalled
+  // directly, so a signal that reached only the leader leaves it running here. It is a
+  // grandchild of this process, reparented to init and reaped there, so wait for the
+  // PID to disappear rather than assuming reaping already happened.
+  await waitUntil(
+    () => !operatingSystem.processIsAlive(childPid),
+    'the forked child outlived a signal sent to its process group',
+  )
+
+  // The group reports empty, which is the contract terminateProcessTree returned true
+  // for. `processIsAlive(leaderPid)` is deliberately not asserted: the leader is a child
+  // of this test process, so between its death and this process reaping it the PID still
+  // answers `kill(pid, 0)` as a zombie. `groupHasRunningMember` excludes state Z for that
+  // reason, and it is the check the adapter itself trusts.
   expect(operatingSystem.processTreeIsAlive(daemon.pid)).toBe(false)
 })

--- a/tests/windows-console.test.ts
+++ b/tests/windows-console.test.ts
@@ -1,0 +1,133 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it } from 'vitest'
+import { operatingSystem } from '../src/adapters/os.ts'
+import {
+  startWindowsProcess, WINDOWS_PROCESS_ROOT_PID_ENV,
+} from '../src/adapters/windows-process.ts'
+import { PROCESS_TEST_TIMEOUT_MS } from './testProcess.ts'
+
+// Windows console and window behaviour is what this asserts, so there is nothing for
+// another platform to run. vitest.config.ts leaves the file uncollected off Windows
+// rather than collecting it and reporting a skip, which reads as a disabled test.
+
+const fixtureRoots: string[] = []
+const processRoots: number[] = []
+
+async function waitUntil(predicate: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + PROCESS_TEST_TIMEOUT_MS
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+async function removeWhenReleased(root: string): Promise<void> {
+  await waitUntil(() => {
+    try {
+      operatingSystem.removeDirectory(root)
+      return true
+    } catch {
+      return false
+    }
+  }, `Windows did not release fixture directory ${root}`)
+}
+
+afterEach(async () => {
+  for (const pid of processRoots.splice(0)) {
+    if (operatingSystem.processIsAlive(pid)) operatingSystem.terminateProcessTree(pid)
+  }
+  for (const root of fixtureRoots.splice(0)) await removeWhenReleased(root)
+})
+
+it(
+  'starts a surviving process tree whose console descendants share one hidden window',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orchestration-hidden-console-'))
+    fixtureRoots.push(root)
+    const targetDir = join(root, 'target files')
+    mkdirSync(targetDir)
+    const targetFile = join(targetDir, 'target.cjs')
+    const inputFile = join(root, 'input.txt')
+    const outputFile = join(root, 'output.log')
+    const resultBase = join(root, 'console')
+    const resultsReadyFile = join(root, 'console.ready')
+    const targetPidFile = join(root, 'target.pid')
+    const rootPidFile = join(root, 'root.pid')
+
+    const consoleProbe = [
+      'Add-Type -TypeDefinition @"',
+      'using System;',
+      'using System.Runtime.InteropServices;',
+      'public static class ConsoleProbe {',
+      '  [DllImport("kernel32.dll")] public static extern IntPtr GetConsoleWindow();',
+      '  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr handle);',
+      '}',
+      '"@',
+      '$handle = [ConsoleProbe]::GetConsoleWindow()',
+      '@{ pid=$PID; console=$handle.ToInt64(); visible=[ConsoleProbe]::IsWindowVisible($handle) } | ConvertTo-Json -Compress | Set-Content -LiteralPath $env:ORCH_TEST_CONSOLE_RESULT -Encoding ascii',
+    ].join('\n')
+    const encodedProbe = Buffer.from(consoleProbe, 'utf16le').toString('base64')
+    writeFileSync(targetFile, [
+      "const { spawnSync } = require('node:child_process')",
+      "const { readFileSync, writeFileSync } = require('node:fs')",
+      "writeFileSync(process.env.ORCH_TEST_TARGET_PID, String(process.pid))",
+      `writeFileSync(process.env.ORCH_TEST_ROOT_PID, process.env.${WINDOWS_PROCESS_ROOT_PID_ENV})`,
+      "console.log(`input:${readFileSync(0, 'utf8')}`)",
+      'for (let index = 1; index <= 2; index++) {',
+      '  const env = {',
+      '    ...process.env,',
+      '    ORCH_TEST_CONSOLE_RESULT: `${process.env.ORCH_TEST_RESULT_BASE}.${index}`,',
+      '  }',
+      "  spawnSync('powershell.exe', [",
+      "    '-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand',",
+      '    process.env.ORCH_TEST_CONSOLE_PROBE,',
+      "  ], { env, stdio: 'ignore' })",
+      '}',
+      "writeFileSync(process.env.ORCH_TEST_RESULTS_READY, '')",
+      'setInterval(() => {}, 1_000)',
+      '',
+    ].join('\n'))
+    writeFileSync(inputFile, 'task specification')
+
+    const pid = await startWindowsProcess({
+      args: [targetFile],
+      command: process.execPath,
+      cwd: root,
+      env: {
+        ...process.env,
+        ORCH_TEST_CONSOLE_PROBE: encodedProbe,
+        ORCH_TEST_RESULT_BASE: resultBase,
+        ORCH_TEST_RESULTS_READY: resultsReadyFile,
+        ORCH_TEST_ROOT_PID: rootPidFile,
+        ORCH_TEST_TARGET_PID: targetPidFile,
+      },
+      inputFile,
+      outputFile,
+    })
+    processRoots.push(pid)
+
+    await waitUntil(
+      () => existsSync(resultsReadyFile),
+      'console descendants did not publish their observations',
+    )
+    const first = JSON.parse(readFileSync(`${resultBase}.1`, 'utf8')) as {
+      console: number
+      visible: boolean
+    }
+    const second = JSON.parse(readFileSync(`${resultBase}.2`, 'utf8')) as {
+      console: number
+      visible: boolean
+    }
+
+    expect(operatingSystem.processIsAlive(pid)).toBe(true)
+    expect(readFileSync(rootPidFile, 'utf8')).toBe(`${pid}`)
+    expect(Number(readFileSync(targetPidFile, 'utf8'))).not.toBe(pid)
+    expect(first.console).toBeGreaterThan(0)
+    expect(second.console).toBe(first.console)
+    expect(first.visible).toBe(false)
+    expect(second.visible).toBe(false)
+    expect(readFileSync(outputFile, 'utf8')).toContain('input:task specification')
+  },
+)

--- a/tests/windows-process.test.ts
+++ b/tests/windows-process.test.ts
@@ -1,42 +1,11 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
-import { operatingSystem } from '../src/adapters/os.ts'
+import { describe, expect, it } from 'vitest'
 import {
-  processTreeRootPid, quoteWindowsArgument, startWindowsProcess,
-  WINDOWS_PROCESS_ROOT_PID_ENV,
+  processTreeRootPid, quoteWindowsArgument, WINDOWS_PROCESS_ROOT_PID_ENV,
 } from '../src/adapters/windows-process.ts'
-import { PROCESS_TEST_TIMEOUT_MS } from './testProcess.ts'
 
-const fixtureRoots: string[] = []
-const processRoots: number[] = []
-
-async function waitUntil(predicate: () => boolean, message: string): Promise<void> {
-  const deadline = Date.now() + PROCESS_TEST_TIMEOUT_MS
-  while (!predicate()) {
-    if (Date.now() >= deadline) throw new Error(message)
-    await new Promise((resolve) => setTimeout(resolve, 10))
-  }
-}
-
-async function removeWhenReleased(root: string): Promise<void> {
-  await waitUntil(() => {
-    try {
-      operatingSystem.removeDirectory(root)
-      return true
-    } catch {
-      return false
-    }
-  }, `Windows did not release fixture directory ${root}`)
-}
-
-afterEach(async () => {
-  for (const pid of processRoots.splice(0)) {
-    if (operatingSystem.processIsAlive(pid)) operatingSystem.terminateProcessTree(pid)
-  }
-  for (const root of fixtureRoots.splice(0)) await removeWhenReleased(root)
-})
+// These are pure functions describing Windows conventions, so every platform runs them.
+// The process-launching assertions that only Windows can make live in
+// windows-console.test.ts, which vitest.config.ts collects on Windows alone.
 
 describe('Windows process arguments', () => {
   it('quotes arguments according to the Windows argv parsing rules', () => {
@@ -54,94 +23,3 @@ describe('Windows process arguments', () => {
       .toBe(process.pid)
   })
 })
-
-it.runIf(process.platform === 'win32')(
-  'starts a surviving process tree whose console descendants share one hidden window',
-  async () => {
-    const root = mkdtempSync(join(tmpdir(), 'orchestration-hidden-console-'))
-    fixtureRoots.push(root)
-    const targetDir = join(root, 'target files')
-    mkdirSync(targetDir)
-    const targetFile = join(targetDir, 'target.cjs')
-    const inputFile = join(root, 'input.txt')
-    const outputFile = join(root, 'output.log')
-    const resultBase = join(root, 'console')
-    const resultsReadyFile = join(root, 'console.ready')
-    const targetPidFile = join(root, 'target.pid')
-    const rootPidFile = join(root, 'root.pid')
-
-    const consoleProbe = [
-      'Add-Type -TypeDefinition @"',
-      'using System;',
-      'using System.Runtime.InteropServices;',
-      'public static class ConsoleProbe {',
-      '  [DllImport("kernel32.dll")] public static extern IntPtr GetConsoleWindow();',
-      '  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr handle);',
-      '}',
-      '"@',
-      '$handle = [ConsoleProbe]::GetConsoleWindow()',
-      '@{ pid=$PID; console=$handle.ToInt64(); visible=[ConsoleProbe]::IsWindowVisible($handle) } | ConvertTo-Json -Compress | Set-Content -LiteralPath $env:ORCH_TEST_CONSOLE_RESULT -Encoding ascii',
-    ].join('\n')
-    const encodedProbe = Buffer.from(consoleProbe, 'utf16le').toString('base64')
-    writeFileSync(targetFile, [
-      "const { spawnSync } = require('node:child_process')",
-      "const { readFileSync, writeFileSync } = require('node:fs')",
-      "writeFileSync(process.env.ORCH_TEST_TARGET_PID, String(process.pid))",
-      `writeFileSync(process.env.ORCH_TEST_ROOT_PID, process.env.${WINDOWS_PROCESS_ROOT_PID_ENV})`,
-      "console.log(`input:${readFileSync(0, 'utf8')}`)",
-      'for (let index = 1; index <= 2; index++) {',
-      '  const env = {',
-      '    ...process.env,',
-      '    ORCH_TEST_CONSOLE_RESULT: `${process.env.ORCH_TEST_RESULT_BASE}.${index}`,',
-      '  }',
-      "  spawnSync('powershell.exe', [",
-      "    '-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand',",
-      '    process.env.ORCH_TEST_CONSOLE_PROBE,',
-      "  ], { env, stdio: 'ignore' })",
-      '}',
-      "writeFileSync(process.env.ORCH_TEST_RESULTS_READY, '')",
-      'setInterval(() => {}, 1_000)',
-      '',
-    ].join('\n'))
-    writeFileSync(inputFile, 'task specification')
-
-    const pid = await startWindowsProcess({
-      args: [targetFile],
-      command: process.execPath,
-      cwd: root,
-      env: {
-        ...process.env,
-        ORCH_TEST_CONSOLE_PROBE: encodedProbe,
-        ORCH_TEST_RESULT_BASE: resultBase,
-        ORCH_TEST_RESULTS_READY: resultsReadyFile,
-        ORCH_TEST_ROOT_PID: rootPidFile,
-        ORCH_TEST_TARGET_PID: targetPidFile,
-      },
-      inputFile,
-      outputFile,
-    })
-    processRoots.push(pid)
-
-    await waitUntil(
-      () => existsSync(resultsReadyFile),
-      'console descendants did not publish their observations',
-    )
-    const first = JSON.parse(readFileSync(`${resultBase}.1`, 'utf8')) as {
-      console: number
-      visible: boolean
-    }
-    const second = JSON.parse(readFileSync(`${resultBase}.2`, 'utf8')) as {
-      console: number
-      visible: boolean
-    }
-
-    expect(operatingSystem.processIsAlive(pid)).toBe(true)
-    expect(readFileSync(rootPidFile, 'utf8')).toBe(`${pid}`)
-    expect(Number(readFileSync(targetPidFile, 'utf8'))).not.toBe(pid)
-    expect(first.console).toBeGreaterThan(0)
-    expect(second.console).toBe(first.console)
-    expect(first.visible).toBe(false)
-    expect(second.visible).toBe(false)
-    expect(readFileSync(outputFile, 'utf8')).toContain('input:task specification')
-  },
-)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,14 @@ export default defineConfig({
     // orchestration/worktrees, tests included. Without excluding them the suite collects
     // its own copies out of every task in flight and fails on their unfinished state —
     // which is what happened the first time the core improved itself.
-    exclude: ['**/node_modules/**', '**/dist/**', 'orchestration/worktrees/**'],
+    exclude: [
+      '**/node_modules/**', '**/dist/**', 'orchestration/worktrees/**',
+      // Launching a Windows process tree and observing its consoles is not something
+      // another platform can attempt. Leaving the file uncollected keeps a Linux run
+      // reporting only tests that apply to it; collecting it and reporting a skip reads
+      // as a test somebody disabled, which is the question it kept prompting.
+      ...(process.platform === 'win32' ? [] : ['tests/windows-console.test.ts']),
+    ],
     // Fork IPC times out while the git-heavy suites run on Windows under Node 24;
     // worker threads use the same isolation without that process-channel failure.
     pool: process.platform === 'win32' ? 'threads' : 'forks',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config'
+import { uncollectedSuites } from './tests/platformCoverage.ts'
 
 export default defineConfig({
   test: {
@@ -6,14 +7,15 @@ export default defineConfig({
     // orchestration/worktrees, tests included. Without excluding them the suite collects
     // its own copies out of every task in flight and fails on their unfinished state —
     // which is what happened the first time the core improved itself.
+    // A suite another platform cannot attempt is left uncollected rather than collected
+    // and reported as a skip, which reads as a test somebody disabled. What it is and why
+    // it did not run is stated by globalSetup instead, so leaving it out stays visible.
+    // Both sides read tests/platformCoverage.ts, so neither can drift from the other.
     exclude: [
       '**/node_modules/**', '**/dist/**', 'orchestration/worktrees/**',
-      // Launching a Windows process tree and observing its consoles is not something
-      // another platform can attempt. Leaving the file uncollected keeps a Linux run
-      // reporting only tests that apply to it; collecting it and reporting a skip reads
-      // as a test somebody disabled, which is the question it kept prompting.
-      ...(process.platform === 'win32' ? [] : ['tests/windows-console.test.ts']),
+      ...uncollectedSuites(),
     ],
+    globalSetup: ['tests/globalSetup.ts'],
     // Fork IPC times out while the git-heavy suites run on Windows under Node 24;
     // worker threads use the same isolation without that process-channel failure.
     pool: process.platform === 'win32' ? 'threads' : 'forks',


### PR DESCRIPTION
## Features
- None

## Bug Fixes
- None

## Project Operations
- [Test suite] The Windows hidden-console test moves to its own file, which is collected on Windows alone rather than guarded by `it.runIf`. A guard left every Linux run reporting a skip, and a skip in a summary reads as a test somebody disabled rather than one no other platform can attempt.
- [Test suite] A run now states which platform-specific suites it collected and which it did not, naming the platform each needs and why. Leaving a file uncollected alone would have removed the skip and the information with it: a file quietly absent produces the same summary as a file that does not exist.
- [Test suite] POSIX gains the real-process test it never had. Every other test of that adapter injects its runtime, which proves the decisions the adapter makes but not that `process.kill(-pid)` reaches a whole process group or that `/proc/<pid>/stat` reports what the adapter reads from it. Windows had such a test and POSIX did not, so terminating a daemon's whole group rather than the daemon alone was never exercised for real on the platform that does it.

## Security
- None

## Risks
- `vitest.config.ts` decides what to collect and `tests/globalSetup.ts` decides what to report, both from `tests/platformCoverage.ts`, so a suite added to one cannot be missing from the other. A suite added straight to the config without an entry there would be excluded silently, which is the failure this arrangement exists to prevent; `tests/platform-coverage.test.ts` pins the report and the one-suite-per-platform balance.
- The POSIX test asserts on the forked grandchild rather than the leader. The leader is a child of the test process, so between its death and being reaped its PID still answers `kill(pid, 0)` as a zombie — which is why `groupHasRunningMember` excludes state `Z` and why the grandchild is the assertion that discriminates group-wide delivery from a signal that reached only the leader.
- Verified on both platforms: Windows and the Linux container each report 60 files, 958 tests, nothing skipped.