### PR TITLE
feat: autonomous scan loop — 19 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ settings update at their next use.
 |----------|---------|--------|
 | `MAX_SCAN_CYCLES` | 3 | Scan-and-fix rounds before the pull request is promoted |
 | `MAX_PARALLEL` | 3 | Ordinary task agent processes at once; scan agents use `SCAN_PARALLEL` independently |
-| `SCAN_PARALLEL` | 2 | Scan agent processes started together per scan cycle (1-4), independent of `MAX_PARALLEL` |
+| `SCAN_PARALLEL` | 2 | Scan agent processes started together per scan cycle; values must be at least 1 and values above 4 are clamped to 4, independently of `MAX_PARALLEL` |
 | `TASK_GATE` | full | `light` uses project-adapter-selected reduced checks for each merge, followed by the adapter's cycle suite once per cycle; `runAtEveryTaskGate` lets individual suite steps opt into every mode |
 | `AUTO_REVIEW` | false | Enable agent review of cycle diffs and queue the findings as fixes |
 | `REVIEW_EVERY_N_CYCLES` | 1 | With `AUTO_REVIEW=true`, review every Nth cycle and always review the final cycle |

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ specific failure; the comments in the source name the incident rather than the p
 
 - Node 23.6 or later — the TypeScript sources are executed natively, with no build step
 - git
-- Bash on Windows (for example, Git Bash), with `bash` available on `PATH` — the bundled
-  runners use it to launch npm command shims safely
-- An agent CLI (the bundled runner adapters drive
-  [Codex](https://openai.com/codex/) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code))
-- A forge CLI (the bundled forge adapter drives GitHub through `gh`)
+- The bundled adapters additionally require:
+  - Bash on Windows (for example, Git Bash), with `bash` available on `PATH` — the
+    bundled runners use it to launch npm command shims safely
+  - The agent CLI selected by the bundled runner adapter:
+    [Codex](https://openai.com/codex/) or
+    [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+  - The GitHub CLI, `gh`, when using the bundled `forge-github` adapter
 
 ## How a run works
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -233,15 +233,18 @@ are not parsed by `loadConfig` and are not operator-file settings.
    documented; the gate stops the loop rather than promote a failing tip.
    A missing-toolchain repair that fails also stops the gate and reports the adapter's
    remediation message without running the subsequent suite step.
-9a. A merge check that passes counts only where its directory satisfies its own declared
-    dependencies. A worktree sits inside the checkout it was cut from, so Node resolves
-    anything the worktree lacks from the parent's `node_modules`: an install that stopped
-    partway produces a pass against a dependency tree nobody assembled, and that verdict
-    describes neither tree. Declared dependencies with no `node_modules`, an npm-owned
-    directory with no completed-install record, or any declared dependency absent from
-    `node_modules` turns the pass into a failure that names what was borrowed. The
-    verification follows the check rather than preceding it, because a check may install
-    as its own first step.
+9a. Dependency-isolation verification is opt-in per project adapter. When
+    `verifyDependencyIsolation` is `true`, a merge check that passes counts only where its
+    directory satisfies its own declared Node dependencies. A worktree sits inside the
+    checkout it was cut from, so Node resolves anything the worktree lacks from the
+    parent's `node_modules`: an install that stopped partway produces a pass against a
+    dependency tree nobody assembled, and that verdict describes neither tree. Declared
+    dependencies with no `node_modules`, an npm-owned directory with no completed-install
+    record, or any declared dependency absent from `node_modules` turns the pass into a
+    failure that names what was borrowed. The verification follows the check rather than
+    preceding it, because a check may install as its own first step. When the option is
+    omitted or false, merge-check results are not subjected to this Node/npm-specific
+    verification, allowing adapters with other dependency models to opt out.
 9b. The core project's merge and cycle gates build `node_modules` with `npm ci` in a
     staging directory, then activate the complete tree. The working dependency tree is
     never npm's cleanup target: a failed install leaves it untouched, a failed activation

--- a/SPEC.md
+++ b/SPEC.md
@@ -224,11 +224,13 @@ are not parsed by `loadConfig` and are not operator-file settings.
    task worktree and run branch clean. The task is abandoned after that first counted
    merge failure: its worktree and branch are removed, and linked issues return to ready
    before another poll can select it again. Pre-merge tests are chosen from the paths the
-   rebased worktree touched. `TASK_GATE=full`
-   asks the project adapter for its full merge checks; `TASK_GATE=light` asks it for
-   reduced merge checks, then runs the adapter's cycle suite once at each cycle-gate
-   entry. Light-gate attribution cost (a suite break at the gate names no task) is
-   accepted and documented; the gate stops the loop rather than promote a failing tip.
+   rebased worktree touched. `TASK_GATE=full` asks the project adapter for its full merge
+   checks; `TASK_GATE=light` asks it for reduced merge checks. At each cycle-gate entry,
+   light mode runs every step in the adapter's cycle suite, while full mode runs only
+   cycle-suite steps that opt in with `SuiteStep.runAtEveryTaskGate`. A successful suite
+   verdict is retained across gate retries only while the branch tip is unchanged.
+   Light-gate attribution cost (a suite break at the gate names no task) is accepted and
+   documented; the gate stops the loop rather than promote a failing tip.
    A missing-toolchain repair that fails also stops the gate and reports the adapter's
    remediation message without running the subsequent suite step.
 9a. A merge check that passes counts only where its directory satisfies its own declared

--- a/SPEC.md
+++ b/SPEC.md
@@ -604,7 +604,7 @@ it; scan and review prompts apply that rule to the text they inspect or quote. A
 author has write access; idle detection additionally retains the merge-SHA ancestry check,
 so authorship and verified ancestry must both hold.
 
-32. With `ISSUE_QUEUE_ENABLED=true`, scan and review findings become forge issues
+33. With `ISSUE_QUEUE_ENABLED=true`, scan and review findings become forge issues
     (labels `loop:finding` + `loop:ready`) instead of local queue entries, under the
     same growth bounds. A finding is filed in the repository the loop is running
     against, never anywhere else. An issue is filed once per fingerprint: the advisory
@@ -621,7 +621,7 @@ so authorship and verified ancestry must both hold.
     merges because the same advisory recurs with different prose. Pre-granularity open
     issue bodies are interpreted from their requirement text, and their coarse local
     ledger entry is replaced when encountered, avoiding a one-time duplicate round.
-33. Before claiming, worker daemons group ready findings whose titles name the same first
+34. Before claiming, worker daemons group ready findings whose titles name the same first
     path, using the same primary-path convention as fingerprinting. A group contains at
     most four issues; another batch remains ready for the next claim. Titles without a
     path stay singleton tasks. Every grouped requirement appears separately in the task
@@ -650,7 +650,7 @@ so authorship and verified ancestry must both hold.
     issue without heartbeats for `ISSUE_LEASE_HOURS` (default 3) is reaped back to
     ready, unassigned, so lease expiry identifies a worker that is no longer polling
     rather than a long-running task.
-34. The merge commit of an issue-born task carries `closes #N` for every linked issue, so
+35. The merge commit of an issue-born task carries `closes #N` for every linked issue, so
     the forge closes all of them when the promotion PR lands the commit on the default
     branch. Immediately after merging, the worker comments on every linked issue with the
     merge commit and run branch and states that closure happens on promotion; this refreshes
@@ -678,7 +678,7 @@ so authorship and verified ancestry must both hold.
     once creation may have happened, the issue is reconciled or the command aborts.
     The marker includes the daemon PID, is removed with the PID lock on every graceful
     exit, and is ignored when its owning process is no longer alive.
-35. `WORKER_MODE=true` defaults off and requires `ISSUE_QUEUE_ENABLED=true`. A worker-mode
+36. `WORKER_MODE=true` defaults off and requires `ISSUE_QUEUE_ENABLED=true`. A worker-mode
     daemon is execution-only: it never scans, enters a cycle gate, creates or updates a
     pull request, runs a review, or merges. It claims and heartbeats ready issues through
     the standard path and starts their local tasks. A completed task with commits pushes
@@ -690,7 +690,7 @@ so authorship and verified ancestry must both hold.
     `Running    Status      Task=<n>  Queue=<n>` event while work is active and appends
     `Waiting=open finding` when idle; because workers never scan, their loop-log prefix
     carries cycle zero rather than a worker-specific replacement for the cycle.
-36. Exactly one normal, non-worker daemon owns the run tree and is the merger. After
+37. Exactly one normal, non-worker daemon owns the run tree and is the merger. After
     processing local completions, each stop-file-free poll adopts `loop:merge-ready`
     issues from that poll's shared finding snapshot: it reads the reported branch and head, fetches that branch
     from the configured push remote, verifies the head and that it adds commits to the

--- a/SPEC.md
+++ b/SPEC.md
@@ -271,7 +271,8 @@ are not parsed by `loadConfig` and are not operator-file settings.
 
 ## Scans and cycles
 
-12. Scans start on idle (nothing queued or running), `SCAN_PARALLEL` (1-4) at a time
+12. Scans start on idle (nothing queued or running), with `SCAN_PARALLEL` scans at a
+    time; the value must be at least 1, and values above 4 are clamped to 4. Scans run
     over disjoint groups of the checklist's sections. A cycle counts as empty only when
     every scan in it found nothing; `MAX_EMPTY_SCANS` consecutive empty cycles end the
     run early. The expected scan count (`queue/scan-expected-<n>`) and scan yield

--- a/SPEC.md
+++ b/SPEC.md
@@ -138,7 +138,12 @@ are not parsed by `loadConfig` and are not operator-file settings.
    process is alive and becomes `failed` when the process is gone. Markers in the
    transcript log are ignored — only the final-message file is authoritative. An ordinary
    completed task may additionally report `NO_CHANGE_WARRANTED` on its own line when its
-   investigation proves the requested change is already unnecessary.
+   investigation proves the requested change is already unnecessary. A missing task
+   status file means no status, but an existing file must be valid JSON with string
+   `task_id`, `started_at`, `updated_at`, `worktree`, and `branch` fields and a recognized
+   task state; `merged` additionally requires string `merge_commit` and `run_branch`
+   fields. Malformed JSON or a schema mismatch is not treated as absent: the read fails,
+   stopping the poll that encountered it, and the file is retained for operator repair.
 2. Task ids are `YYYYMMDD_HHMMSS_nnn_<slug>` with `nnn` a per-day sequence; slugs end in
    `scan` for scans, are `review-c<n>` for automatic reviews of cycle `<n>`, and start
    with `ci-fix`, `auto-`, `fix-`, or `user-` for CI fixes, scan findings, review-origin
@@ -187,7 +192,11 @@ are not parsed by `loadConfig` and are not operator-file settings.
    cleanup leaves a durable release intent and retains the task mapping until the daemon
    retries the release successfully. Reconciliation runs on each poll before stale-lease
    reaping; three consecutive failed polls stop the loop, while a successful poll clears
-   the failure streak.
+   the failure streak. Persisted issue mappings, release preparations, and release intents
+   are either empty or contain one positive safe integer per line. Any malformed entry
+   rejects the whole list instead of being skipped; reconciliation does not perform a
+   partial release or discard the file, so the complete state remains available for
+   operator repair.
 
 ## Growth and decisions
 
@@ -295,7 +304,11 @@ are not parsed by `loadConfig` and are not operator-file settings.
     the cycle's scans all came back empty and one more empty cycle reaches
     `MAX_EMPTY_SCANS`. The current cycle number lives in `queue/scan-count.txt` and is
     re-read every poll (this is also the documented lever for forcing an early final
-    cycle on a running loop).
+    cycle on a running loop). A missing persisted counter reads as zero; an existing
+    counter must contain base-10 digits representing a non-negative safe integer.
+    Invalid contents, including an empty file, log the affected repository-relative
+    state path, write the stop file, and stop the loop without resetting or overwriting
+    the counter, retaining it for operator repair.
 14. Effort defaults: scans, queued tasks, and automatic reviews all run the runner at
     medium reasoning effort. Fixes spawned by an automatic review are the exception: they
     always run at high effort because they repair findings that escaped the original

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,8 +1,6 @@
-import { execFileSync, spawn } from 'node:child_process'
+import { execFileSync, spawn, spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
-import {
-  mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync,
-} from 'node:fs'
+import { mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve, toNamespacedPath } from 'node:path'
 import { performance } from 'node:perf_hooks'
 
@@ -12,6 +10,7 @@ const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2
 const retryMilliseconds = 250
 const unpublishedOwnerGraceMilliseconds = 30_000
 const maximumWaitMilliseconds = 10 * 60_000
+const windowsParentPollMilliseconds = 50
 
 function commonGitDirectory() {
   try {
@@ -66,6 +65,31 @@ function processIdentity(pid) {
     return started === '' ? null : `${process.platform}:${started}`
   } catch {
     return null
+  }
+}
+
+function invokingWindowsShellPid() {
+  const command = [
+    '& { param([int]$TargetPid)',
+    '$fallback = $TargetPid',
+    'while ($TargetPid -gt 0) {',
+    '  $candidate = Get-CimInstance Win32_Process -Filter "ProcessId = $TargetPid" -ErrorAction SilentlyContinue',
+    '  if ($null -eq $candidate) { break }',
+    '  if ($candidate.Name -in @("powershell.exe", "pwsh.exe")) { $TargetPid; return }',
+    '  $TargetPid = [int]$candidate.ParentProcessId',
+    '}',
+    '$fallback',
+    '}',
+  ].join(' ')
+  try {
+    const value = execFileSync(
+      'powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', command, String(process.ppid)],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim()
+    const pid = Number(value)
+    return Number.isSafeInteger(pid) && pid > 0 ? pid : process.ppid
+  } catch {
+    return process.ppid
   }
 }
 
@@ -194,31 +218,92 @@ function vitestEntryPoint() {
   return join(dirname(require.resolve('vitest/package.json')), 'vitest.mjs')
 }
 
-await acquireLock()
-let child
-const forwardSignal = (signal) => child?.kill(signal)
-process.once('SIGINT', forwardSignal)
-process.once('SIGTERM', forwardSignal)
-try {
-  // The package script deliberately supplies no Vitest flags. npm appends gate flags to
-  // this argument list once, so the merge gate remains `npm test -- ...` compatible.
-  child = spawn(process.execPath, [vitestEntryPoint(), 'run', ...process.argv.slice(2)], {
+function terminateWindowsProcessTree(pid) {
+  spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+    stdio: 'ignore',
+    windowsHide: true,
+  })
+}
+
+async function runVitest(args, invokingPid) {
+  const child = spawn(process.execPath, [vitestEntryPoint(), 'run', ...args], {
     cwd: packageRoot,
     stdio: 'inherit',
     windowsHide: true,
   })
-  const status = await new Promise((resolveStatus, reject) => {
-    child.once('error', reject)
-    child.once('exit', (code, signal) => resolveStatus({ code, signal }))
-  })
-  if (status.signal !== null) {
+  let cancelled = false
+  const parentMonitor = invokingPid === undefined ? undefined : setInterval(() => {
+    if (processIsAlive(invokingPid)) return
+    cancelled = true
+    clearInterval(parentMonitor)
+    if (child.pid !== undefined) terminateWindowsProcessTree(child.pid)
+  }, windowsParentPollMilliseconds)
+  let status
+  try {
+    status = await new Promise((resolveStatus, reject) => {
+      child.once('error', reject)
+      child.once('exit', (code, signal) => resolveStatus({ code, signal }))
+    })
+  } finally {
+    if (parentMonitor !== undefined) clearInterval(parentMonitor)
+  }
+  if (cancelled) {
+    console.error('Vitest stopped because its invoking process exited.')
+    process.exitCode = 1
+  } else if (status.signal !== null) {
     console.error(`Vitest stopped on signal ${status.signal}.`)
     process.exitCode = 1
   } else {
     process.exitCode = status.code ?? 1
   }
-} finally {
-  process.removeListener('SIGINT', forwardSignal)
-  process.removeListener('SIGTERM', forwardSignal)
-  releaseLock()
+}
+
+if (process.argv[2] === '--windows-vitest-supervisor') {
+  const invokingPid = Number(process.argv[3])
+  if (!Number.isSafeInteger(invokingPid) || invokingPid <= 0) {
+    throw new Error('The Windows test supervisor requires an invoking process PID.')
+  }
+  await runVitest(process.argv.slice(4), invokingPid)
+} else {
+  await acquireLock()
+  let child
+  const forwardSignal = (signal) => {
+    if (child?.pid === undefined) return
+    if (process.platform === 'win32') terminateWindowsProcessTree(child.pid)
+    else child.kill(signal)
+  }
+  process.once('SIGINT', forwardSignal)
+  process.once('SIGTERM', forwardSignal)
+  try {
+    // The package script deliberately supplies no Vitest flags. npm appends gate flags to
+    // this argument list once, so the merge gate remains `npm test -- ...` compatible.
+    const args = process.argv.slice(2)
+    child = process.platform === 'win32'
+      ? spawn(process.execPath, [
+        import.meta.filename, '--windows-vitest-supervisor',
+        String(invokingWindowsShellPid()), ...args,
+      ], {
+        cwd: packageRoot,
+        stdio: 'inherit',
+        windowsHide: true,
+      })
+      : spawn(process.execPath, [vitestEntryPoint(), 'run', ...args], {
+        cwd: packageRoot,
+        stdio: 'inherit',
+      })
+    const status = await new Promise((resolveStatus, reject) => {
+      child.once('error', reject)
+      child.once('exit', (code, signal) => resolveStatus({ code, signal }))
+    })
+    if (status.signal !== null) {
+      console.error(`Vitest stopped on signal ${status.signal}.`)
+      process.exitCode = 1
+    } else {
+      process.exitCode = status.code ?? 1
+    }
+  } finally {
+    process.removeListener('SIGINT', forwardSignal)
+    process.removeListener('SIGTERM', forwardSignal)
+    releaseLock()
+  }
 }

--- a/src/adapters/project.ts
+++ b/src/adapters/project.ts
@@ -116,7 +116,10 @@ export interface ProjectAdapter {
   deployment?: { workflow: string; revisionUrl: string }
   /** Whether pull requests are expected to receive CI checks. Omit when unknown. */
   ciChecksExpected?: boolean
-  /** Verify that passing merge checks did not borrow Node modules from a parent checkout. */
+  /**
+   * Opt in to verifying that passing merge checks did not borrow Node modules from a
+   * parent checkout. Omitted or false skips this Node/npm-specific verification.
+   */
   verifyDependencyIsolation?: boolean
   /** Per-merge verification, selected from the paths the worktree touched. */
   mergeChecks(taskGate: 'full' | 'light'): MergeCheck[]

--- a/src/adapters/project.ts
+++ b/src/adapters/project.ts
@@ -531,6 +531,46 @@ async function importProject(adapterPath: string, name?: string): Promise<Projec
 
 const LOCAL_MODULE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.mjs', '.cjs', '.json']
 
+function typeOnlyModuleSpecifiers(source: string, path: string): Set<string> {
+  const typeOnly = new Set<string>()
+  const runtime = new Set<string>()
+  const sourceFile = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true)
+  const classify = (specifier: ts.Node | undefined, isTypeOnly: boolean): void => {
+    if (specifier === undefined) return
+    const literal = ts.isLiteralTypeNode(specifier) ? specifier.literal : specifier
+    if (!ts.isStringLiteralLike(literal)) return
+    const imports = isTypeOnly ? typeOnly : runtime
+    imports.add(literal.text)
+  }
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      const clause = node.importClause
+      const namedImports = clause?.namedBindings !== undefined
+        && ts.isNamedImports(clause.namedBindings) ? clause.namedBindings : undefined
+      classify(
+        node.moduleSpecifier,
+        clause?.isTypeOnly === true
+          || (namedImports !== undefined && namedImports.elements.length > 0
+            && namedImports.elements.every((element) => element.isTypeOnly)),
+      )
+    } else if (ts.isExportDeclaration(node)) {
+      const namedExports = node.exportClause !== undefined
+        && ts.isNamedExports(node.exportClause) ? node.exportClause : undefined
+      classify(
+        node.moduleSpecifier,
+        node.isTypeOnly
+          || (namedExports !== undefined && namedExports.elements.length > 0
+            && namedExports.elements.every((element) => element.isTypeOnly)),
+      )
+    } else if (ts.isImportTypeNode(node)) {
+      classify(node.argument, true)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return new Set([...typeOnly].filter((specifier) => !runtime.has(specifier)))
+}
+
 function resolveLocalModule(importer: string, specifier: string): string | undefined {
   if (!specifier.startsWith('./') && !specifier.startsWith('../')) return undefined
   const imported = resolve(dirname(importer), specifier)
@@ -555,8 +595,11 @@ function projectSources(adapterPath: string): Map<string, Buffer> {
     if (sources.has(path)) continue
     const source = readFileSync(path)
     sources.set(path, source)
-    const imports = ts.preProcessFile(source.toString('utf8'), true, true).importedFiles
+    const sourceText = source.toString('utf8')
+    const typeOnlyImports = typeOnlyModuleSpecifiers(sourceText, path)
+    const imports = ts.preProcessFile(sourceText, true, true).importedFiles
     for (const imported of imports) {
+      if (typeOnlyImports.has(imported.fileName)) continue
       const dependency = resolveLocalModule(path, imported.fileName)
       if (dependency !== undefined && !sources.has(dependency)) pending.push(dependency)
     }

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -106,8 +106,14 @@ export function cleanupTask(
   const status = readStatus(
     paths, taskId, runtime.os.processStartIdentity, runtime.os.processIsAlive,
   )
-  if (status !== undefined && status.pid !== null) {
-    stopTaskProcess(runtime, paths, taskId, status.pid)
+  // startTask records ownership before persisting status. A StartupProcessRetainedError
+  // can therefore leave a live registry-only runner, which must be stopped before its
+  // worktree can safely be removed.
+  const pid = status?.pid ?? taskProcessPid(
+    paths, taskId, undefined, runtime.os.processStartIdentity, runtime.os.processIsAlive,
+  )
+  if (pid !== undefined) {
+    stopTaskProcess(runtime, paths, taskId, pid)
   }
 
   const worktree = worktreeDir(paths, taskId)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -203,7 +203,7 @@ async function approveLoopStart(
   const rl = createInterface({ input: process.stdin, output: process.stdout })
   try {
     const answer = await rl.question('Start the loop with this configuration? [y/N] ')
-    const approved = /^(?:y|yes)$/i.test(answer.trim())
+    const approved = answer === 'y' || answer === 'yes'
     if (!approved) console.error('Refusing start: configuration was not approved.')
     return approved
   } finally {

--- a/src/issueQueue.ts
+++ b/src/issueQueue.ts
@@ -811,17 +811,32 @@ function failureCountFile(paths: OrchPaths, issueNumber: number): string {
 export function issueFailureCount(paths: OrchPaths, issueNumber: number): number {
   const file = failureCountFile(paths, issueNumber)
   if (!existsSync(file)) return 0
-  const value = Number(readFileSync(file, 'utf8').trim())
-  return Number.isSafeInteger(value) && value > 0 ? value : 0
+  const persisted = readFileSync(file, 'utf8').replace(/\r?\n$/, '')
+  const value = Number(persisted)
+  if (!/^[1-9]\d*$/.test(persisted) || !Number.isSafeInteger(value)) {
+    throw new Error(
+      `Persisted issue failure count ${file} is invalid; expected a positive safe integer`,
+    )
+  }
+  return value
 }
 
 /** Count one terminal task failure for each issue before its claim is released. */
 export function recordIssueFailure(paths: OrchPaths, taskId: string): number[] {
   const issueNumbers = issueNumbersForTask(paths, taskId)
   if (issueNumbers.length === 0) return []
-  mkdirSync(failureCountDir(paths), { recursive: true })
-  return issueNumbers.map((issueNumber) => {
+  const counts = issueNumbers.map((issueNumber) => {
     const count = issueFailureCount(paths, issueNumber) + 1
+    if (!Number.isSafeInteger(count)) {
+      throw new Error(
+        `Persisted issue failure count ${failureCountFile(paths, issueNumber)} cannot be safely incremented`,
+      )
+    }
+    return count
+  })
+  mkdirSync(failureCountDir(paths), { recursive: true })
+  issueNumbers.forEach((issueNumber, index) => {
+    const count = counts[index]!
     const file = failureCountFile(paths, issueNumber)
     const temporaryFile = `${file}.${process.pid}.tmp`
     try {
@@ -830,8 +845,8 @@ export function recordIssueFailure(paths: OrchPaths, taskId: string): number[] {
     } finally {
       rmSync(temporaryFile, { force: true })
     }
-    return count
   })
+  return counts
 }
 
 /** A completed task breaks the issue's consecutive failure streak. */
@@ -853,9 +868,22 @@ export function recordIssuesForTask(
 export function issueNumbersForTask(paths: OrchPaths, taskId: string): number[] {
   const file = issueMapFile(paths, taskId)
   if (!existsSync(file)) return []
-  return readFileSync(file, 'utf8').split(/\r?\n/)
-    .filter((line) => /^\d+$/.test(line))
-    .map(Number)
+  return readPersistedIssueNumbers(file)
+}
+
+function readPersistedIssueNumbers(file: string): number[] {
+  const persisted = readFileSync(file, 'utf8')
+  if (/^(?:\r?\n)?$/.test(persisted)) return []
+  const lines = persisted.split(/\r?\n/)
+  if (lines.at(-1) === '') lines.pop()
+  const issueNumbers = lines.map((line) => Number(line))
+  if (lines.length === 0 || lines.some((line, index) =>
+    !/^[1-9]\d*$/.test(line) || !Number.isSafeInteger(issueNumbers[index]))) {
+    throw new Error(
+      `Persisted issue list ${file} is invalid; expected one positive safe integer per line`,
+    )
+  }
+  return issueNumbers
 }
 
 function writeIssueNumbers(file: string, issueNumbers: readonly number[]): void {
@@ -898,17 +926,13 @@ export function completeIssueReleaseIntent(paths: OrchPaths, taskId: string): vo
 export function issueReleaseIntentForTask(paths: OrchPaths, taskId: string): number[] {
   const file = releaseIntentFile(paths, taskId)
   if (!existsSync(file)) return []
-  return readFileSync(file, 'utf8').split(/\r?\n/)
-    .filter((line) => /^\d+$/.test(line))
-    .map(Number)
+  return readPersistedIssueNumbers(file)
 }
 
 export function issueReleasePreparationForTask(paths: OrchPaths, taskId: string): number[] {
   const file = releasePreparationFile(paths, taskId)
   if (!existsSync(file)) return []
-  return readFileSync(file, 'utf8').split(/\r?\n/)
-    .filter((line) => /^\d+$/.test(line))
-    .map(Number)
+  return readPersistedIssueNumbers(file)
 }
 
 /** Cancel a release preparation that did not reach completed local cleanup. */

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -102,6 +102,8 @@ interface FindingDispatch {
 const IDLE_LOG_MAX_INTERVAL_MS = 5 * 60 * 1000
 const MAX_CONSECUTIVE_ISSUE_RELEASE_FAILURES = 3
 
+class InvalidPersistedCounterError extends Error {}
+
 function formatIdleDuration(milliseconds: number): string {
   const totalSeconds = Math.floor(milliseconds / 1000)
   if (totalSeconds < 60) return `${totalSeconds}s`
@@ -369,9 +371,23 @@ export function createLoop(deps: LoopDeps) {
   }
 
   function readCount(file: string): number {
-    if (!existsSync(file)) return 0
-    const raw = readFileSync(file, 'utf8').replace(/[\s\r\n]/g, '')
-    return /^\d+$/.test(raw) ? Number(raw) : 0
+    let raw: string
+    try {
+      raw = readFileSync(file, 'utf8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0
+      throw error
+    }
+    const value = raw.trim()
+    const count = Number(value)
+    if (!/^\d+$/.test(value) || !Number.isSafeInteger(count)) {
+      const stateFile = relative(paths.root, file).replaceAll('\\', '/')
+      const message = `persisted counter ${stateFile} is invalid; expected a non-negative integer; stopping the loop`
+      event('ERROR', message)
+      writeFileSync(stopFile, '')
+      throw new InvalidPersistedCounterError(message)
+    }
+    return count
   }
 
   function git(args: string[], quietSuccess = ''): string {
@@ -2664,6 +2680,7 @@ export function createLoop(deps: LoopDeps) {
       // Even a reset far beyond the ordinary poll window is an external wait, not a
       // branch failure. The proxy suppresses all further forge calls until it expires.
       if (error instanceof ForgeRateLimitError) return 'continue'
+      if (error instanceof InvalidPersistedCounterError) return 'stopped'
       throw error
     }
   }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -46,14 +46,6 @@ export function packagePathPrefix(repoRoot: string, packageRoot = PACKAGE_ROOT):
   return packageDirectory === '' ? '' : `${packageDirectory}/`
 }
 
-export function packageScriptCommand(
-  repoRoot: string,
-  script: string,
-  packageRoot = PACKAGE_ROOT,
-): string {
-  return `${packageCommandPrefix(repoRoot, packageRoot)} ${script}`
-}
-
 function shellPathArgument(path: string): string {
   return `'${path.replaceAll('\\', '/').replaceAll("'", "'\\''")}'`
 }

--- a/src/processRegistry.ts
+++ b/src/processRegistry.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, statSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readdirSync, rmSync, statSync, readFileSync, writeFileSync } from 'node:fs'
 import { uptime } from 'node:os'
 import { join } from 'node:path'
 import { operatingSystem } from './adapters/os.ts'
@@ -41,6 +41,19 @@ function registryDir(paths: OrchPaths): string {
 
 function registryFile(paths: OrchPaths, taskId: string): string {
   return join(registryDir(paths), taskId)
+}
+
+/** Task ids with a process-registry entry, including entries not backed by status. */
+export function registeredTaskIds(paths: OrchPaths): string[] {
+  try {
+    return readdirSync(registryDir(paths), { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .sort()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
 }
 
 /** When the running system started, in epoch milliseconds. */

--- a/src/status.ts
+++ b/src/status.ts
@@ -53,7 +53,23 @@ const durableTaskStatusSchema = z.object({
   branch: z.string(),
   merge_commit: z.string().optional(),
   run_branch: z.string().optional(),
-}).passthrough()
+}).passthrough().superRefine((record, context) => {
+  if (record.status !== 'merged') return
+  if (record.merge_commit === undefined) {
+    context.addIssue({
+      code: 'custom',
+      path: ['merge_commit'],
+      message: 'Required for merged status',
+    })
+  }
+  if (record.run_branch === undefined) {
+    context.addIssue({
+      code: 'custom',
+      path: ['run_branch'],
+      message: 'Required for merged status',
+    })
+  }
+})
 
 function schemaPath(path: PropertyKey[]): string {
   if (path.length === 0) return '(root)'
@@ -271,7 +287,12 @@ function writeStatusUnlocked(
   if (pid === undefined || !Number.isInteger(pid)) forgetTaskProcess(paths, taskId)
 }
 
-export async function writeStatus(paths: OrchPaths, taskId: string, status: TaskState, pid?: number): Promise<void> {
+export async function writeStatus(
+  paths: OrchPaths,
+  taskId: string,
+  status: Exclude<TaskState, 'merged'>,
+  pid?: number,
+): Promise<void> {
   const owner = await acquireStatusLock(paths, taskId)
   try {
     writeStatusUnlocked(paths, taskId, status, pid)
@@ -303,7 +324,7 @@ export async function transitionStatus(
   paths: OrchPaths,
   taskId: string,
   expected: TaskState,
-  next: TaskState,
+  next: Exclude<TaskState, 'merged'>,
   pid?: number,
 ): Promise<boolean> {
   const owner = await acquireStatusLock(paths, taskId)

--- a/src/status.ts
+++ b/src/status.ts
@@ -3,6 +3,7 @@ import {
   mkdirSync, readFileSync, renameSync, rmdirSync, rmSync, statSync, writeFileSync,
 } from 'node:fs'
 import { join } from 'node:path'
+import { z } from 'zod'
 import { operatingSystem } from './adapters/os.ts'
 import { branchName, statusFile, worktreeDir, type OrchPaths } from './paths.ts'
 import { currentProcessStartIdentity, lockOwnerIsCurrent } from './processOwner.ts'
@@ -19,7 +20,9 @@ import {
 // lock and compare-and-swap transitions refuse to overwrite a state another writer
 // already changed.
 
-export type TaskState = 'running' | 'completed' | 'failed' | 'merged' | 'no-change' | string
+const taskStateSchema = z.enum(['running', 'completed', 'failed', 'merged', 'no-change'])
+
+export type TaskState = z.infer<typeof taskStateSchema>
 
 export interface TaskStatus {
   task_id: string
@@ -41,19 +44,48 @@ interface StatusMetadata {
 
 type DurableTaskStatus = Omit<TaskStatus, 'pid'>
 
+const durableTaskStatusSchema = z.object({
+  task_id: z.string(),
+  status: taskStateSchema,
+  started_at: z.string(),
+  updated_at: z.string(),
+  worktree: z.string(),
+  branch: z.string(),
+  merge_commit: z.string().optional(),
+  run_branch: z.string().optional(),
+}).passthrough()
+
+function schemaPath(path: PropertyKey[]): string {
+  if (path.length === 0) return '(root)'
+  return path.map((segment, index) => {
+    if (typeof segment === 'number') return `[${segment}]`
+    return `${index === 0 ? '' : '.'}${String(segment)}`
+  }).join('')
+}
+
 export function readStatus(
   paths: OrchPaths,
   taskId: string,
   processStartIdentity: ProcessStartIdentity = operatingSystem.processStartIdentity,
   processIsAlive: ProcessIsAlive = operatingSystem.processIsAlive,
 ): TaskStatus | undefined {
-  let record: DurableTaskStatus
+  let parsed: unknown
   try {
-    record = JSON.parse(readFileSync(statusFile(paths, taskId), 'utf8')) as DurableTaskStatus
+    parsed = JSON.parse(readFileSync(statusFile(paths, taskId), 'utf8')) as unknown
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
     throw error
   }
+  const result = durableTaskStatusSchema.safeParse(parsed)
+  if (!result.success) {
+    const mismatches = result.error.issues
+      .map((issue) => `${schemaPath(issue.path)}: ${issue.message}`)
+      .join('; ')
+    throw new Error(`Status file for ${taskId} failed schema validation at ${mismatches}`, {
+      cause: result.error,
+    })
+  }
+  const record: DurableTaskStatus = result.data
   // The record is durable; the process it named is not. The registry answers for the
   // process, so a number left in an old record is not read back as a live task.
   return {

--- a/src/status.ts
+++ b/src/status.ts
@@ -44,7 +44,10 @@ interface StatusMetadata {
 
 type DurableTaskStatus = Omit<TaskStatus, 'pid'>
 
-const durableTaskStatusSchema = z.object({
+// Older cores wrote merged records before durable merge metadata was introduced.
+// Reads accept that historical shape, while every record written by this core is
+// checked against the current schema below.
+const readableDurableTaskStatusSchema = z.object({
   task_id: z.string(),
   status: taskStateSchema,
   started_at: z.string(),
@@ -53,23 +56,27 @@ const durableTaskStatusSchema = z.object({
   branch: z.string(),
   merge_commit: z.string().optional(),
   run_branch: z.string().optional(),
-}).passthrough().superRefine((record, context) => {
-  if (record.status !== 'merged') return
-  if (record.merge_commit === undefined) {
-    context.addIssue({
-      code: 'custom',
-      path: ['merge_commit'],
-      message: 'Required for merged status',
-    })
-  }
-  if (record.run_branch === undefined) {
-    context.addIssue({
-      code: 'custom',
-      path: ['run_branch'],
-      message: 'Required for merged status',
-    })
-  }
-})
+}).passthrough()
+
+const writableDurableTaskStatusSchema = readableDurableTaskStatusSchema.superRefine(
+  (record, context) => {
+    if (record.status !== 'merged') return
+    if (record.merge_commit === undefined) {
+      context.addIssue({
+        code: 'custom',
+        path: ['merge_commit'],
+        message: 'Required for merged status',
+      })
+    }
+    if (record.run_branch === undefined) {
+      context.addIssue({
+        code: 'custom',
+        path: ['run_branch'],
+        message: 'Required for merged status',
+      })
+    }
+  },
+)
 
 function schemaPath(path: PropertyKey[]): string {
   if (path.length === 0) return '(root)'
@@ -92,7 +99,7 @@ export function readStatus(
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
     throw error
   }
-  const result = durableTaskStatusSchema.safeParse(parsed)
+  const result = readableDurableTaskStatusSchema.safeParse(parsed)
   if (!result.success) {
     const mismatches = result.error.issues
       .map((issue) => `${schemaPath(issue.path)}: ${issue.message}`)
@@ -276,6 +283,7 @@ function writeStatusUnlocked(
       run_branch: metadata.runBranch,
     }),
   }
+  writableDurableTaskStatusSchema.parse(record)
   try {
     // Publishing with a same-directory rename prevents readers from observing a
     // truncated JSON document if this process exits while writing the new record.

--- a/src/taskProcesses.ts
+++ b/src/taskProcesses.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { operatingSystem, type OperatingSystem } from './adapters/os.ts'
 import { type OrchPaths } from './paths.ts'
 import {
-  bootedAt, forgetTaskProcess, taskProcessPid, terminableTaskProcessPid,
+  bootedAt, forgetTaskProcess, registeredTaskIds, taskProcessPid, terminableTaskProcessPid,
 } from './processRegistry.ts'
 import { listTaskIds } from './refresh.ts'
 
@@ -22,7 +22,11 @@ export function liveTaskProcesses(
   os: OperatingSystem = operatingSystem,
 ): TaskProcess[] {
   const live: TaskProcess[] = []
-  for (const taskId of listTaskIds(paths)) {
+  // A runner is registered before its status is persisted. If status persistence and
+  // startup termination both fail, the registry is the only surviving ownership
+  // record and must still make the task visible to stop and daemon-start checks.
+  const taskIds = new Set([...listTaskIds(paths), ...registeredTaskIds(paths)])
+  for (const taskId of [...taskIds].sort()) {
     const pid = taskProcessPid(
       paths, taskId, bootedAt, os.processStartIdentity, os.processIsAlive,
     )

--- a/tests/cleanup-command.test.ts
+++ b/tests/cleanup-command.test.ts
@@ -13,13 +13,26 @@ import {
   LABEL_MERGE_FAILED, LABEL_MERGE_READY, LABEL_READY, prepareIssueReleaseIntent,
   reapStaleLeases, reconcileIssueReleaseIntents, recordIssueReleaseIntent, recordIssuesForTask,
 } from '../src/issueQueue.ts'
-import { finalMessageFile, orchPaths, statusFile, type OrchPaths } from '../src/paths.ts'
+import {
+  branchName, finalMessageFile, orchPaths, statusFile, worktreeDir, type OrchPaths,
+} from '../src/paths.ts'
 import { specFile } from '../src/tasks.ts'
 import { makeFakeForge } from './fakeForge.ts'
 
 let repoRoot: string
 let paths: OrchPaths
 const taskId = '20260813_184040_037_auto-cleanup-claim'
+
+function writeTaskStatus(): void {
+  writeFileSync(statusFile(paths, taskId), JSON.stringify({
+    task_id: taskId,
+    status: 'completed',
+    started_at: '2026-08-13T09:40:40Z',
+    updated_at: '2026-08-13T09:40:40Z',
+    worktree: worktreeDir(paths, taskId),
+    branch: branchName(taskId),
+  }))
+}
 
 function runtime(
   overrides: Partial<CleanupCommandRuntime> = {},
@@ -89,7 +102,7 @@ describe('cleanup command', () => {
       assignees: [forge.user],
     })
     recordIssuesForTask(paths, taskId, [issueNumber])
-    writeFileSync(statusFile(paths, taskId), JSON.stringify({ task_id: taskId, pid: null }))
+    writeTaskStatus()
     prepareIssueReleaseIntent(paths, taskId, [issueNumber])
 
     await expect(reconcileIssueReleaseIntents(forge, paths)).resolves.toEqual([])
@@ -185,7 +198,7 @@ describe('cleanup command', () => {
 
   it('keeps successful local cleanup when the forge cannot release the issue', async () => {
     execFileSync('git', ['init'], { cwd: repoRoot, windowsHide: true })
-    writeFileSync(statusFile(paths, taskId), JSON.stringify({ task_id: taskId, pid: null }))
+    writeTaskStatus()
     writeFileSync(finalMessageFile(paths, taskId), 'TASK_COMPLETE\n')
     writeFileSync(specFile(paths, taskId), '# claimed task\n')
     recordIssuesForTask(paths, taskId, [51, 52])

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -140,6 +140,23 @@ afterEach(() => {
 })
 
 describe('cleanupTask', () => {
+  it('retains a registry-only startup-failure task when termination cannot be verified', () => {
+    mkdirSync(worktree, { recursive: true })
+    recordTaskProcess(paths, taskId, 12345, () => 'started:12345')
+    let now = 0
+    const runtime = makeRuntime({ os: windowsOperatingSystem({
+      probeProcess: () => {},
+      now: () => now,
+      sleep: (milliseconds) => { now += milliseconds },
+    }) })
+
+    expect(() => cleanupTask(paths, taskId, runtime))
+      .toThrow('Could not stop process 12345; task state was retained.')
+
+    expect(existsSync(statusFile(paths, taskId))).toBe(false)
+    expect(existsSync(worktree)).toBe(true)
+  })
+
   it('retains task state when taskkill does not stop the process', () => {
     seedTask(12345)
     let now = 0

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -12,7 +12,9 @@ import {
   type WindowsOperatingSystemRuntime,
 } from '../src/adapters/os-windows.ts'
 import { cleanupTask, type CleanupRuntime } from '../src/cleanup.ts'
-import { finalMessageFile, orchPaths, statusFile, worktreeDir, type OrchPaths } from '../src/paths.ts'
+import {
+  branchName, finalMessageFile, orchPaths, statusFile, worktreeDir, type OrchPaths,
+} from '../src/paths.ts'
 import { recordTaskProcess } from '../src/processRegistry.ts'
 
 let repoRoot: string
@@ -24,7 +26,15 @@ function seedTask(pid: number | null): void {
   worktree = worktreeDir(paths, taskId)
   mkdirSync(worktree, { recursive: true })
   mkdirSync(join(paths.queueDir, 'scanned'), { recursive: true })
-  writeFileSync(statusFile(paths, taskId), JSON.stringify({ task_id: taskId, pid }))
+  writeFileSync(statusFile(paths, taskId), JSON.stringify({
+    task_id: taskId,
+    status: 'running',
+    started_at: '2026-08-08T03:00:00Z',
+    updated_at: '2026-08-08T03:00:00Z',
+    worktree,
+    branch: branchName(taskId),
+    pid,
+  }))
   // A task's process lives in the registry, not in the record.
   if (pid !== null) recordTaskProcess(paths, taskId, pid, () => `started:${pid}`)
   writeFileSync(finalMessageFile(paths, taskId), 'TASK_COMPLETE\n')

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1077,6 +1077,10 @@ describe('loop daemon ownership', () => {
     writeFileSync(statusFile(paths, taskId), JSON.stringify({
       task_id: taskId,
       status: 'running',
+      started_at: '2026-08-12T01:02:03Z',
+      updated_at: '2026-08-12T01:02:03Z',
+      worktree: worktreeDir(paths, taskId),
+      branch: branchName(taskId),
       pid: process.pid,
     }))
     // A task's process lives in the registry, not in the record.

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -767,6 +767,61 @@ describe('loop daemon ownership', () => {
     expect(existsSync(join(repoRoot, 'orchestration', 'worktrees'))).toBe(false)
   })
 
+  it.each(['Y', 'YES', ' y', 'yes '])('refuses the non-exact TTY approval answer %j', async (answer) => {
+    const close = vi.fn()
+    const question = vi.fn(async () => answer)
+    vi.doMock('node:readline/promises', () => ({
+      createInterface: () => ({ close, question }),
+    }))
+    vi.doMock('../src/adapters/runner.ts', async (importOriginal) => ({
+      ...await importOriginal<typeof import('../src/adapters/runner.ts')>(),
+      loadRunner: async () => ({ sharedSkills: fakeRunnerSharedSkills, start: vi.fn() }),
+    }))
+    vi.doMock('node:child_process', async (importOriginal) => {
+      const childProcess = await importOriginal<typeof import('node:child_process')>()
+      return {
+        ...childProcess,
+        execFileSync: (...args: Parameters<typeof execFileSync>) => {
+          const [file, fileArgs] = args
+          if (file === 'git' && fileArgs?.join(' ') === 'rev-parse --show-toplevel') {
+            return repoRoot
+          }
+          return childProcess.execFileSync(...args)
+        },
+      }
+    })
+    vi.resetModules()
+
+    const previousArgv = process.argv
+    const previousExitCode = process.exitCode
+    const previousEnv = { ...process.env }
+    const stdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
+    try {
+      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true })
+      for (const name of Object.keys(process.env)) delete process.env[name]
+      Object.assign(process.env, CORE_ENV, { ISSUE_QUEUE_ENABLED: 'false' })
+      process.argv = [process.execPath, CLI, 'loop']
+
+      await import('../src/cli.ts')
+
+      expect(process.exitCode).toBe(1)
+      expect(question).toHaveBeenCalledWith('Start the loop with this configuration? [y/N] ')
+      expect(close).toHaveBeenCalledOnce()
+      expect(existsSync(join(repoRoot, 'orchestration', 'queue'))).toBe(false)
+    } finally {
+      process.argv = previousArgv
+      process.exitCode = previousExitCode
+      for (const name of Object.keys(process.env)) delete process.env[name]
+      Object.assign(process.env, previousEnv)
+      if (stdinIsTTY === undefined) delete (process.stdin as { isTTY?: boolean }).isTTY
+      else Object.defineProperty(process.stdin, 'isTTY', stdinIsTTY)
+      vi.doUnmock('node:readline/promises')
+      vi.doUnmock('../src/adapters/runner.ts')
+      vi.doUnmock('node:child_process')
+      vi.resetModules()
+    }
+  })
+
   it('accepts a non-interactive start when the approved mode agrees', () => {
     const result = spawnSync(
       process.execPath,

--- a/tests/core-update.test.ts
+++ b/tests/core-update.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Forge } from '../src/adapters/forge.ts'
 import type { Runner } from '../src/adapters/runner.ts'
+import { loadMonitoredProject } from '../src/adapters/project.ts'
 import { loadConfig } from '../src/config.ts'
 import {
   updateCoreBeforeCycle, type CoreUpdateEvent, type CoreUpdateRuntime,
@@ -76,6 +77,7 @@ function makeLoop(
   runtime: CoreUpdateRuntime = { packageRoot, git },
   forge: Forge = makeFakeForge(),
   runnerOverride?: Runner,
+  projectAdapterChanged?: () => boolean,
 ) {
   mkdirSync(join(paths.root, 'templates'), { recursive: true })
   writeFileSync(join(paths.root, 'templates', 'scan-template.md'), '{{SCAN_SCOPE}}\n')
@@ -92,6 +94,7 @@ function makeLoop(
     forge,
     runner,
     project: stubProject,
+    projectAdapterChanged,
     log: (line) => events.push(line),
     now: () => new Date(2026, 7, 12, 0, 0, 0),
     updateCoreBeforeCycle: (cycle) =>
@@ -111,6 +114,11 @@ beforeEach(() => {
   mkdirSync(upstreamRoot)
   configureRepository(upstreamRoot)
   writeFileSync(join(upstreamRoot, 'core.txt'), 'version one\n')
+  mkdirSync(join(upstreamRoot, 'src', 'adapters'), { recursive: true })
+  writeFileSync(
+    join(upstreamRoot, 'src', 'adapters', 'project.ts'),
+    'export interface ProjectAdapter { name: string }\n',
+  )
   mkdirSync(join(upstreamRoot, 'skills'), { recursive: true })
   writeFileSync(join(upstreamRoot, 'skills', 'manifest.json'), JSON.stringify({
     commandPrefixPlaceholder: '{{ORCHESTRATION_COMMAND_PREFIX}}',
@@ -220,6 +228,49 @@ describe('pre-cycle core update', () => {
       .toBe('version two\n')
     expect(events).toContain(`Updated core ${oldCore.slice(0, 8)}..${newCore.slice(0, 8)}`)
     expect(events.some((line) => line.startsWith('Restarting core'))).toBe(false)
+  })
+
+  it('continues an integration poll when a core update changes an adapter type import', async () => {
+    const adapterDirectory = join(paths.root, 'project')
+    mkdirSync(adapterDirectory, { recursive: true })
+    writeFileSync(join(adapterDirectory, 'project-consumer.ts'), `
+import type { ProjectAdapter } from '../ts/src/adapters/project.ts'
+
+export const consumerProject: ProjectAdapter & Record<string, unknown> = {
+  name: 'consumer',
+  pullRequest: {
+    categories: [{ label: 'Changes' }],
+    titleFallback: 'no changes',
+    classifyCommit: () => ({ category: 'Changes' }),
+    detectRisks: () => [],
+  },
+  preCommitChecks: [],
+  mergeChecks: () => [],
+  cycleSuite: () => [],
+}
+`)
+    commit(repoRoot, 'test: add consumer adapter fixture')
+    const monitored = await loadMonitoredProject(paths.root, { PROJECT: 'consumer' })
+    const oldCore = git(upstreamRoot, ['rev-parse', 'HEAD'])
+    writeFileSync(
+      join(upstreamRoot, 'src', 'adapters', 'project.ts'),
+      'export interface ProjectAdapter { name: string; updated?: true }\n',
+    )
+    const newCore = commit(upstreamRoot, 'feat: update project adapter types')
+    const loop = makeLoop(
+      config({ INTEGRATION_BRANCH: 'integration/run' }),
+      { packageRoot, git },
+      makeFakeForge(),
+      undefined,
+      monitored.sourceChanged,
+    )
+
+    expect(await loop.poll(), events.join('\n')).toBe('continue')
+
+    expect(monitored.sourceChanged()).toBe(false)
+    expect(runnerStarts).toHaveLength(1)
+    expect(events).toContain(`Updated core ${oldCore.slice(0, 8)}..${newCore.slice(0, 8)}`)
+    expect(events.some((line) => line.startsWith('Restarting adapter'))).toBe(false)
   })
 
   it('lets the forge adapter resolve repository shorthand for Git', async () => {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -120,6 +120,33 @@ describe('deploy', () => {
     )).rejects.toThrow('Deployment verification request failed with HTTP 404.')
   })
 
+  it('rejects a completed failed workflow before fetching the deployed revision', async () => {
+    const forge = makeFakeForge()
+    forge.findWorkflowRun = async () => ({
+      id: 77,
+      createdAt: '2026-08-08T15:00:00Z',
+      headSha: 'failed-sha',
+      status: 'completed',
+      conclusion: 'failure',
+    })
+    const fetcher = vi.fn(async () => response('failed-sha'))
+
+    await expect(deploy(
+      {
+        workflow: 'deploy.yml',
+        revisionUrl: 'https://shiora.jp/.well-known/shiora-revision',
+      },
+      'main',
+      forge,
+      {
+        clock: clock(),
+        fetcher,
+        createDispatchToken: () => 'failed-dispatch',
+      },
+    )).rejects.toThrow("Deployment workflow run 77 finished with conclusion 'failure'.")
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
   it('times out when the dispatched workflow never appears', async () => {
     const forge = makeFakeForge()
     forge.findWorkflowRun = vi.fn(async () => undefined)

--- a/tests/forge-github.test.ts
+++ b/tests/forge-github.test.ts
@@ -154,6 +154,54 @@ describe('GitHub pull request bodies', () => {
   })
 })
 
+describe('GitHub pull request promotion and workflow dispatch', () => {
+  it.each([
+    {
+      name: 'marks a pull request ready',
+      invoke: (forge: Forge) => forge.markPrReady('task/branch'),
+      expectedArgs: ['pr', 'ready', 'task/branch'],
+    },
+    {
+      name: 'dispatches a workflow with its correlation token',
+      invoke: (forge: Forge) => forge.dispatchWorkflow(
+        'deploy.yml', 'release/production', 'dispatch-token-123',
+      ),
+      expectedArgs: [
+        'workflow', 'run', 'deploy.yml', '--ref', 'release/production',
+        '--field', 'dispatch_token=dispatch-token-123',
+      ],
+    },
+  ])('$name with the exact gh arguments', async ({ invoke, expectedArgs }) => {
+    const calls: string[][] = []
+    const command: GithubCommand = async (_root, args) => {
+      calls.push(args)
+      return ''
+    }
+
+    await invoke(createGithubForge('repo-root', command))
+
+    expect(calls).toEqual([expectedArgs])
+  })
+
+  it.each([
+    {
+      name: 'markPrReady',
+      invoke: (forge: Forge) => forge.markPrReady('task/branch'),
+    },
+    {
+      name: 'dispatchWorkflow',
+      invoke: (forge: Forge) => forge.dispatchWorkflow(
+        'deploy.yml', 'release/production', 'dispatch-token-123',
+      ),
+    },
+  ])('propagates command failures from $name', async ({ invoke }) => {
+    const failure = new Error('gh command failed')
+    const command: GithubCommand = async () => { throw failure }
+
+    await expect(invoke(createGithubForge('repo-root', command))).rejects.toBe(failure)
+  })
+})
+
 describe('GitHub workflow dispatch correlation', () => {
   it('ignores newer concurrent and same-second runs with another token or ref', () => {
     const wanted = run({ databaseId: 71 })

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -45,6 +45,7 @@ function durableStatus(taskId: string, status: string, extra: Record<string, unk
     updated_at: '2026-08-08T03:00:00Z',
     worktree: worktreeDir(paths, taskId),
     branch: branchName(taskId),
+    ...(status === 'merged' ? { merge_commit: 'merge-commit', run_branch: 'main' } : {}),
     ...extra,
   })
 }

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -11,11 +11,13 @@ import {
   buildIssueBody, claimIssueGroup, closeIssueAndRemoveLifecycleLabels,
   commentOnIssueMerge, fingerprintOf, groupReadyFindings, heartbeatIssueForTask,
   issueCompletionForIssue, issueNumberForTask, issueNumbersForTask, issuePromotionForIssue,
-  issueFailureCount, IssueReleaseReconciliationError,
+  issueFailureCount, issueReleaseIntentForTask, issueReleasePreparationForTask,
+  IssueReleaseReconciliationError,
   missingRequirementCompletionMarkers, parseIssueBody,
   publishDelegatedTask, publishFinding, reapStaleLeases,
   reconcileClosedIssueLifecycleLabels, reconcileFindingFingerprints,
-  clearIssueFailureCounts, reconcileIssueReleaseIntent, recordIssueCompletions,
+  clearIssueFailureCounts, prepareIssueReleaseIntent, reconcileIssueReleaseIntent,
+  recordIssueCompletions,
   recordIssueFailure, recordIssueReleaseIntent, recordIssuesForTask,
   recordIssuePromotions,
   releaseIssueClaim,
@@ -1504,6 +1506,74 @@ describe('claimIssueGroup', () => {
 })
 
 describe('issue claim release', () => {
+  it('rejects malformed failure counts without overwriting any issue streak', () => {
+    recordIssuesForTask(paths, 'failed-task', [41, 42])
+    const countDirectory = join(paths.queueDir, 'issue-failure-count')
+    mkdirSync(countDirectory, { recursive: true })
+    writeFileSync(join(countDirectory, '41'), '2\n')
+    writeFileSync(join(countDirectory, '42'), 'malformed\n')
+
+    expect(() => recordIssueFailure(paths, 'failed-task')).toThrow(
+      /expected a positive safe integer/,
+    )
+    expect(readFileSync(join(countDirectory, '41'), 'utf8')).toBe('2\n')
+    expect(readFileSync(join(countDirectory, '42'), 'utf8')).toBe('malformed\n')
+  })
+
+  it('rejects a failure count whose next increment would be unsafe', () => {
+    recordIssuesForTask(paths, 'failed-task', [41])
+    const countDirectory = join(paths.queueDir, 'issue-failure-count')
+    mkdirSync(countDirectory, { recursive: true })
+    writeFileSync(join(countDirectory, '41'), `${Number.MAX_SAFE_INTEGER}\n`)
+
+    expect(() => recordIssueFailure(paths, 'failed-task')).toThrow(/cannot be safely incremented/)
+    expect(issueFailureCount(paths, 41)).toBe(Number.MAX_SAFE_INTEGER)
+  })
+
+  it('rejects every malformed persisted issue-list entry', () => {
+    const taskId = 'malformed-lists'
+    recordIssuesForTask(paths, taskId, [41, 42])
+    recordIssueReleaseIntent(paths, taskId, [41, 42])
+    prepareIssueReleaseIntent(paths, taskId, [41, 42])
+    const files = [
+      join(paths.queueDir, 'issue-map', taskId),
+      join(paths.queueDir, 'issue-release-intent', taskId),
+      join(paths.queueDir, 'issue-release-preparation', taskId),
+    ]
+    for (const file of files) writeFileSync(file, '41\nmalformed\n42\n')
+
+    expect(() => issueNumbersForTask(paths, taskId)).toThrow(/one positive safe integer per line/)
+    expect(() => issueReleaseIntentForTask(paths, taskId)).toThrow(
+      /one positive safe integer per line/,
+    )
+    expect(() => issueReleasePreparationForTask(paths, taskId)).toThrow(
+      /one positive safe integer per line/,
+    )
+  })
+
+  it('accepts empty persisted issue lists produced by the writers', () => {
+    const taskId = 'empty-lists'
+    recordIssuesForTask(paths, taskId, [])
+    recordIssueReleaseIntent(paths, taskId, [])
+    prepareIssueReleaseIntent(paths, taskId, [])
+
+    expect(issueNumbersForTask(paths, taskId)).toEqual([])
+    expect(issueReleaseIntentForTask(paths, taskId)).toEqual([])
+    expect(issueReleasePreparationForTask(paths, taskId)).toEqual([])
+  })
+
+  it('keeps malformed release reconciliation state for operator repair', async () => {
+    const taskId = 'malformed-release'
+    const intent = join(paths.queueDir, 'issue-release-intent', taskId)
+    recordIssueReleaseIntent(paths, taskId, [41, 42])
+    writeFileSync(intent, '41\n9007199254740992\n')
+
+    await expect(reconcileIssueReleaseIntent(forge, paths, taskId)).rejects.toThrow(
+      /one positive safe integer per line/,
+    )
+    expect(readFileSync(intent, 'utf8')).toBe('41\n9007199254740992\n')
+  })
+
   it('parks an issue when consecutive failed-task releases reach the retry bound', async () => {
     const issueNumber = await forge.createIssue({
       title: 'persistently failing issue', body: '',

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -25,7 +25,7 @@ import {
   type ClaimedRequirement,
 } from '../src/issueQueue.ts'
 import { existingTaskIdForDesc } from '../src/ids.ts'
-import { orchPaths, type OrchPaths } from '../src/paths.ts'
+import { branchName, orchPaths, worktreeDir, type OrchPaths } from '../src/paths.ts'
 import { recordTaskProcess } from '../src/processRegistry.ts'
 import { specFile } from '../src/tasks.ts'
 import { frameVerifiedRequirement } from '../src/templates.ts'
@@ -36,6 +36,18 @@ import { stubProject } from './stubProject.ts'
 let repoRoot: string
 let paths: OrchPaths
 let forge: FakeForge
+
+function durableStatus(taskId: string, status: string, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    task_id: taskId,
+    status,
+    started_at: '2026-08-08T03:00:00Z',
+    updated_at: '2026-08-08T03:00:00Z',
+    worktree: worktreeDir(paths, taskId),
+    branch: branchName(taskId),
+    ...extra,
+  })
+}
 
 beforeEach(() => {
   repoRoot = mkdtempSync(join(tmpdir(), 'orch-issues-'))
@@ -1014,7 +1026,7 @@ describe('claimIssueGroup', () => {
     )
     if (first.outcome !== 'claimed') throw new Error(`expected a claim, got ${first.outcome}`)
     writeFileSync(join(paths.statusDir, `${first.taskId}.json`),
-      JSON.stringify({ task_id: first.taskId, status: 'merged' }))
+      durableStatus(first.taskId, 'merged'))
     writeFileSync(join(paths.queueDir, 'backlog.txt'), '')
     recordIssuePromotions(paths, first.taskId, 'a'.repeat(40), 'chore/run-branch')
 
@@ -1040,7 +1052,7 @@ describe('claimIssueGroup', () => {
       )
       if (first.outcome !== 'claimed') throw new Error(`expected a claim, got ${first.outcome}`)
       writeFileSync(join(paths.statusDir, `${first.taskId}.json`),
-        JSON.stringify({ task_id: first.taskId, status }))
+        durableStatus(first.taskId, status))
       writeFileSync(join(paths.queueDir, 'backlog.txt'), '')
 
       const duplicate = await forge.createIssue({
@@ -2062,7 +2074,7 @@ describe('reapStaleLeases', () => {
     })
     recordIssuesForTask(paths, 'task-completed', [issueNumber])
     writeFileSync(join(paths.statusDir, 'task-completed.json'),
-      JSON.stringify({ task_id: 'task-completed', status: 'completed' }))
+      durableStatus('task-completed', 'completed'))
 
     const reaped = await reapStaleLeases(
       forge, paths, 3, new Date('2026-08-08T12:00:00Z'),
@@ -2211,7 +2223,7 @@ describe('loop integration in issue mode', () => {
     writeFileSync(finalMessageFile(paths, '20260808_000000_001_scan'),
       'NEXT_TASK: [BUG] `src/a/b.ts` breaks on empty input\nTASK_COMPLETE\n')
     writeFileSync(join(paths.statusDir, '20260808_000000_001_scan.json'),
-      JSON.stringify({ task_id: '20260808_000000_001_scan', status: 'completed', pid: null }))
+      durableStatus('20260808_000000_001_scan', 'completed'))
 
     // One poll carries the finding all the way: published as an issue by the
     // completion scan, then claimed and started by the same poll's fill step.
@@ -2251,7 +2263,7 @@ describe('loop integration in issue mode', () => {
     await forge.assignIssue(unlinked, 'worker-gone')
     recordIssuesForTask(paths, 'task-running', [linked])
     writeFileSync(join(paths.statusDir, 'task-running.json'),
-      JSON.stringify({ task_id: 'task-running', status: 'running', pid: process.pid }))
+      durableStatus('task-running', 'running', { pid: process.pid }))
     recordTaskProcess(paths, 'task-running', process.pid)
     forge.clock = () => new Date('2026-08-08T12:00:00Z')
 
@@ -2289,7 +2301,7 @@ describe('loop integration in issue mode', () => {
     })
     recordIssuesForTask(paths, 'task-running', [issueNumber])
     writeFileSync(join(paths.statusDir, 'task-running.json'),
-      JSON.stringify({ task_id: 'task-running', status: 'running', pid: process.pid }))
+      durableStatus('task-running', 'running', { pid: process.pid }))
     recordTaskProcess(paths, 'task-running', process.pid)
     forge.clock = () => new Date('2026-08-08T12:00:00Z')
     forge.commentIssue = async () => { throw new Error('forge unavailable') }

--- a/tests/lib.test.ts
+++ b/tests/lib.test.ts
@@ -14,7 +14,7 @@ import {
   absolutePackageScriptCommand, orchPaths, statusFile, type OrchPaths,
 } from '../src/paths.ts'
 import { taskProcessPid } from '../src/processRegistry.ts'
-import { readStatus, transitionStatus, writeStatus } from '../src/status.ts'
+import { readStatus, transitionStatus, writeMergedStatus, writeStatus } from '../src/status.ts'
 import { lockContentionProbeScript, TestProcessRegistry } from './testProcess.ts'
 
 let repoRoot: string
@@ -89,7 +89,8 @@ describe('status files', () => {
     writeFileSync(join(lockDir, 'pid'), `${process.pid}\n`)
 
     let finished = false
-    const writer = writeStatus(paths, 'task-locked', 'merged').then(() => { finished = true })
+    const writer = writeMergedStatus(paths, 'task-locked', 'merge-commit', 'main')
+      .then(() => { finished = true })
     await new Promise((resolve) => setTimeout(resolve, 100))
     expect(finished).toBe(false)
     expect(readStatus(paths, 'task-locked')?.status).toBe('running')
@@ -169,7 +170,7 @@ describe('status files', () => {
   })
 
   it('refuses a transition whose expected state is stale', async () => {
-    await writeStatus(paths, 'task-cas', 'merged')
+    await writeMergedStatus(paths, 'task-cas', 'merge-commit', 'main')
     expect(await transitionStatus(paths, 'task-cas', 'running', 'completed')).toBe(false)
     expect(readStatus(paths, 'task-cas')?.status).toBe('merged')
   })

--- a/tests/lib.test.ts
+++ b/tests/lib.test.ts
@@ -11,7 +11,7 @@ import { descSlug, newTaskId, shortTaskId, taskIdForDesc } from '../src/ids.ts'
 import {
   branchName, finalMessageFile, isInspectionTaskId, isReviewTaskId,
   isScanTaskId,
-  absolutePackageScriptCommand, orchPaths, packageScriptCommand, statusFile, type OrchPaths,
+  absolutePackageScriptCommand, orchPaths, statusFile, type OrchPaths,
 } from '../src/paths.ts'
 import { taskProcessPid } from '../src/processRegistry.ts'
 import { readStatus, transitionStatus, writeStatus } from '../src/status.ts'
@@ -262,33 +262,6 @@ describe('package script commands', () => {
 
     expect(absolutePackageScriptCommand(repoRoot, 'loop-status', packageRoot))
       .toBe(`npm run -C '${expectedPackageRoot}' loop-status -- --repo '${expectedRepoRoot}'`)
-  })
-
-  it('runs scripts directly when the package is the repository root', () => {
-    expect(packageScriptCommand(repoRoot, 'loop-status', repoRoot))
-      .toBe('npm run loop-status')
-  })
-
-  it('selects the package directory when it is installed as a subtree', () => {
-    expect(packageScriptCommand(repoRoot, 'stop', join(repoRoot, 'orchestration', 'ts')))
-      .toBe("npm run -C 'orchestration/ts' stop")
-  })
-
-  it('shell-quotes a subtree package directory containing spaces', () => {
-    expect(packageScriptCommand(repoRoot, 'stop', join(repoRoot, 'orchestration', 'core package')))
-      .toBe("npm run -C 'orchestration/core package' stop")
-  })
-
-  it.each([
-    ['core;false', "'orchestration/core;false'"],
-    ['core&false', "'orchestration/core&false'"],
-    ['core$(false)', "'orchestration/core$(false)'"],
-    ['core`false`', "'orchestration/core`false`'"],
-    ['core!false', "'orchestration/core!false'"],
-    ["core'package", "'orchestration/core'\\''package'"],
-  ])('shell-quotes Bash and Windows Git Bash metacharacters in %s', (directory, quoted) => {
-    expect(packageScriptCommand(repoRoot, 'stop', join(repoRoot, 'orchestration', directory)))
-      .toBe(`npm run -C ${quoted} stop`)
   })
 })
 

--- a/tests/lib.test.ts
+++ b/tests/lib.test.ts
@@ -183,6 +183,54 @@ describe('status files', () => {
     expect(() => readStatus(paths, 'task-malformed')).toThrow(SyntaxError)
   })
 
+  it.each([
+    ['task_id', { status: 'running', started_at: '', updated_at: '', worktree: '', branch: '' }],
+    ['status', { task_id: 'task-invalid', started_at: '', updated_at: '', worktree: '', branch: '' }],
+    ['started_at', { task_id: 'task-invalid', status: 'running', updated_at: '', worktree: '', branch: '' }],
+    ['updated_at', { task_id: 'task-invalid', status: 'running', started_at: '', worktree: '', branch: '' }],
+    ['worktree', { task_id: 'task-invalid', status: 'running', started_at: '', updated_at: '', branch: '' }],
+    ['branch', { task_id: 'task-invalid', status: 'running', started_at: '', updated_at: '', worktree: '' }],
+  ])('rejects a status record missing required field %s', (field, record) => {
+    writeFileSync(statusFile(paths, 'task-invalid'), JSON.stringify(record))
+
+    expect(() => readStatus(paths, 'task-invalid'))
+      .toThrow(`Status file for task-invalid failed schema validation at ${field}`)
+  })
+
+  it.each([
+    ['task_id', 1], ['status', 1], ['started_at', 1], ['updated_at', 1],
+    ['worktree', 1], ['branch', 1], ['merge_commit', 1], ['run_branch', 1],
+  ])('rejects a status record whose %s has the wrong type', (field, value) => {
+    const record = {
+      task_id: 'task-invalid',
+      status: 'running',
+      started_at: '2026-08-21T12:00:00Z',
+      updated_at: '2026-08-21T12:00:00Z',
+      worktree: 'worktree',
+      branch: 'task/task-invalid',
+      [field]: value,
+    }
+    writeFileSync(statusFile(paths, 'task-invalid'), JSON.stringify(record))
+
+    expect(() => readStatus(paths, 'task-invalid'))
+      .toThrow(`Status file for task-invalid failed schema validation at ${field}`)
+  })
+
+  it('rejects an unknown task state', () => {
+    const record = {
+      task_id: 'task-invalid',
+      status: 'unknown',
+      started_at: '2026-08-21T12:00:00Z',
+      updated_at: '2026-08-21T12:00:00Z',
+      worktree: 'worktree',
+      branch: 'task/task-invalid',
+    }
+    writeFileSync(statusFile(paths, 'task-invalid'), JSON.stringify(record))
+
+    expect(() => readStatus(paths, 'task-invalid'))
+      .toThrow('Status file for task-invalid failed schema validation at status')
+  })
+
   it('publishes status through a temporary file without leaving it behind', async () => {
     await writeStatus(paths, 'task-atomic', 'running', 12345)
     expect(existsSync(join(paths.statusDir, `.task-atomic.${process.pid}.tmp`))).toBe(false)

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -117,7 +117,15 @@ function writeFinal(taskId: string, content: string): void {
 
 function writeRawStatus(taskId: string, status: string, pid: number | null = null): void {
   writeFileSync(statusFile(paths, taskId),
-    JSON.stringify({ task_id: taskId, status, pid }))
+    JSON.stringify({
+      task_id: taskId,
+      status,
+      pid,
+      started_at: '2026-08-08T03:00:00Z',
+      updated_at: '2026-08-08T03:00:00Z',
+      worktree: worktreeDir(paths, taskId),
+      branch: branchName(taskId),
+    }))
   // A running task's process lives in the registry, not in the record.
   if (pid === null) forgetTaskProcess(paths, taskId)
   else recordTaskProcess(paths, taskId, pid)
@@ -430,6 +438,17 @@ describe('status file safety', () => {
 
     const loop = makeLoop({ scanEnabled: false, autoMerge: false })
     await expect(loop.poll()).rejects.toThrow(SyntaxError)
+  })
+
+  it('stops the poll when an existing task status is structurally invalid', async () => {
+    const taskId = '20260811_000000_001_user-existing'
+    writeFileSync(join(paths.tasksDir, `${taskId}.md`), '# Existing task\n')
+    writeFileSync(statusFile(paths, taskId), '{}')
+
+    const loop = makeLoop({ scanEnabled: false, autoMerge: false })
+    await expect(loop.poll()).rejects.toThrow(
+      `Status file for ${taskId} failed schema validation`,
+    )
   })
 })
 

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -452,30 +452,6 @@ describe('status file safety', () => {
     )
   })
 
-  it.each(['merge_commit', 'run_branch'])(
-    'stops the poll when a merged task status is missing %s',
-    async (missingField) => {
-      const taskId = `20260811_000000_001_merged-missing-${missingField}`
-      writeFileSync(join(paths.tasksDir, `${taskId}.md`), '# Existing task\n')
-      const record: Record<string, string> = {
-        task_id: taskId,
-        status: 'merged',
-        started_at: '2026-08-21T12:00:00Z',
-        updated_at: '2026-08-21T12:00:00Z',
-        worktree: join(paths.worktreesDir, taskId),
-        branch: `task/${taskId}`,
-        merge_commit: 'merge-commit',
-        run_branch: 'main',
-      }
-      delete record[missingField]
-      writeFileSync(statusFile(paths, taskId), JSON.stringify(record))
-
-      const loop = makeLoop({ scanEnabled: false, autoMerge: false })
-      await expect(loop.poll()).rejects.toThrow(
-        `Status file for ${taskId} failed schema validation at ${missingField}`,
-      )
-    },
-  )
 })
 
 describe('persisted counter safety', () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -125,6 +125,7 @@ function writeRawStatus(taskId: string, status: string, pid: number | null = nul
       updated_at: '2026-08-08T03:00:00Z',
       worktree: worktreeDir(paths, taskId),
       branch: branchName(taskId),
+      ...(status === 'merged' ? { merge_commit: 'merge-commit', run_branch: 'main' } : {}),
     }))
   // A running task's process lives in the registry, not in the record.
   if (pid === null) forgetTaskProcess(paths, taskId)
@@ -450,6 +451,31 @@ describe('status file safety', () => {
       `Status file for ${taskId} failed schema validation`,
     )
   })
+
+  it.each(['merge_commit', 'run_branch'])(
+    'stops the poll when a merged task status is missing %s',
+    async (missingField) => {
+      const taskId = `20260811_000000_001_merged-missing-${missingField}`
+      writeFileSync(join(paths.tasksDir, `${taskId}.md`), '# Existing task\n')
+      const record: Record<string, string> = {
+        task_id: taskId,
+        status: 'merged',
+        started_at: '2026-08-21T12:00:00Z',
+        updated_at: '2026-08-21T12:00:00Z',
+        worktree: join(paths.worktreesDir, taskId),
+        branch: `task/${taskId}`,
+        merge_commit: 'merge-commit',
+        run_branch: 'main',
+      }
+      delete record[missingField]
+      writeFileSync(statusFile(paths, taskId), JSON.stringify(record))
+
+      const loop = makeLoop({ scanEnabled: false, autoMerge: false })
+      await expect(loop.poll()).rejects.toThrow(
+        `Status file for ${taskId} failed schema validation at ${missingField}`,
+      )
+    },
+  )
 })
 
 describe('persisted counter safety', () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -433,6 +433,48 @@ describe('status file safety', () => {
   })
 })
 
+describe('persisted counter safety', () => {
+  it.each(['', 'not-a-count', '1 2', '-1', '9007199254740992'])(
+    'stops with a diagnostic instead of resetting a malformed scan count %j',
+    async (value) => {
+      initializeGitRepo()
+      const loop = makeLoop({ scanEnabled: false, autoMerge: false })
+      loop.initializeSessionStateForBranch()
+      writeFileSync(join(paths.queueDir, 'scan-count.txt'), value)
+
+      expect(await loop.poll()).toBe('stopped')
+
+      expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+      expect(logged).toContain(
+        'ERROR persisted counter queue/scan-count.txt is invalid; expected a non-negative integer; stopping the loop',
+      )
+    },
+  )
+
+  it('rejects a malformed task-growth count without overwriting it', () => {
+    const countFile = join(paths.queueDir, 'total-task-count.txt')
+    writeFileSync(countFile, 'unknown\n')
+    const loop = makeLoop()
+
+    expect(() => loop.countAllTasks()).toThrow('persisted counter queue/total-task-count.txt is invalid')
+
+    expect(readFileSync(countFile, 'utf8')).toBe('unknown\n')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+  })
+
+  it('rejects a malformed merge-failure count without incrementing it', () => {
+    const countFile = join(paths.queueDir, 'merge-failure-count.txt')
+    writeFileSync(countFile, 'NaN\n')
+    const loop = makeLoop()
+
+    expect(() => loop.noteMergeFailure(join(paths.logsDir, 'missing.merge.log')))
+      .toThrow('persisted counter queue/merge-failure-count.txt is invalid')
+
+    expect(readFileSync(countFile, 'utf8')).toBe('NaN\n')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+  })
+})
+
 describe('forge poll budget', () => {
   it('claims ready findings for the same titled file as one task', async () => {
     initializeGitRepo()
@@ -1979,6 +2021,25 @@ describe('cycle gate', () => {
     expect(existsSync(completeFlag)).toBe(true)
     expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
     expect(logText()).toContain('WARN could not enqueue CI fix: queue unavailable')
+  })
+
+  it('stops instead of resetting a malformed CI fix attempt count', async () => {
+    const enqueue = vi.fn<typeof enqueueTask>()
+    const loop = makeLoop({
+      autoPr: false,
+      reviewEnabled: true,
+      ciGateEnabled: true,
+      maxCiFixAttempts: 2,
+    }, stubProject, undefined, undefined, undefined, enqueue)
+    const { attemptFile } = prepareFailedCiGate()
+    writeFileSync(attemptFile, 'corrupt\n')
+
+    await expect(loop.triggerScanIfIdle())
+      .rejects.toThrow('persisted counter queue/ci-fix-emitted-1 is invalid')
+
+    expect(enqueue).not.toHaveBeenCalled()
+    expect(readFileSync(attemptFile, 'utf8')).toBe('corrupt\n')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
   })
 
   it('stops only after successfully enqueued CI fix attempts reach the cap', async () => {

--- a/tests/project-loader.test.ts
+++ b/tests/project-loader.test.ts
@@ -186,6 +186,28 @@ describe('project adapter loading', () => {
     expect(monitored.sourceChanged()).toBe(true)
   })
 
+  it('does not monitor dependencies imported only for adapter types', async () => {
+    const repository = createFixtureRepository()
+    const orchestrationRoot = join(repository, 'orchestration')
+    const projectDirectory = join(orchestrationRoot, 'project')
+    const adapterPath = join(projectDirectory, 'project-fixture.ts')
+    const typesPath = join(orchestrationRoot, 'ts', 'src', 'adapters', 'project.ts')
+    mkdirSync(dirname(typesPath), { recursive: true })
+    writeFileSync(typesPath, 'export interface ProjectAdapter { name: string }\n')
+    writeFixtureAdapter(adapterPath, 'fixture.yml')
+    const adapterSource = readFileSync(adapterPath, 'utf8')
+    writeFileSync(adapterPath, [
+      "import type { ProjectAdapter } from '../ts/src/adapters/project.ts'",
+      adapterSource.replace('export const fixtureProject = {',
+        'export const fixtureProject: ProjectAdapter & Record<string, unknown> = {'),
+    ].join('\n'))
+    const monitored = await loadMonitoredProject(orchestrationRoot, {})
+
+    writeFileSync(typesPath, 'export interface ProjectAdapter { name: string; updated: true }\n')
+
+    expect(monitored.sourceChanged()).toBe(false)
+  })
+
   it('names the resolved path when the adapter is absent', async () => {
     const missingPath = resolve(import.meta.dirname, 'fixtures', 'project-missing.ts')
 

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -3,7 +3,9 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { operatingSystem } from '../src/adapters/os.ts'
-import { finalMessageFile, orchPaths, statusFile, type OrchPaths } from '../src/paths.ts'
+import {
+  branchName, finalMessageFile, orchPaths, statusFile, worktreeDir, type OrchPaths,
+} from '../src/paths.ts'
 import { recordTaskProcess, terminableTaskProcessPid } from '../src/processRegistry.ts'
 import {
   completionMarkerPresent, noChangeMarkerPresent, refreshAll, refreshTask,
@@ -24,7 +26,16 @@ afterEach(() => {
 
 function writeRawStatus(taskId: string, content: string): string {
   const file = statusFile(paths, taskId)
-  writeFileSync(file, content)
+  const partial = JSON.parse(content) as Record<string, unknown>
+  const record = {
+    task_id: taskId,
+    started_at: '2026-08-08T03:00:00Z',
+    updated_at: '2026-08-08T03:00:00Z',
+    worktree: worktreeDir(paths, taskId),
+    branch: branchName(taskId),
+    ...partial,
+  }
+  writeFileSync(file, `${JSON.stringify(record)}\n`)
   // A running task's process lives in the registry, not in the record. A fixture that
   // names one has to put it where the reader looks.
   const pid = (JSON.parse(content) as { pid?: number | null }).pid
@@ -38,8 +49,8 @@ function ageFile(file: string): void {
 }
 
 describe('refreshAll', () => {
-  // Terminal files deliberately contain only enough JSON to classify them. A refresh
-  // must not inspect other fields, and must leave their content exactly as found.
+  // Terminal files carry sentinel fields not owned by refresh. A refresh must leave
+  // their content exactly as found.
   it('leaves terminal files byte-for-byte untouched', async () => {
     const merged = writeRawStatus('merged-task', '{"status":"merged","sentinel":"keep merged"}\n')
     const noChange = writeRawStatus('no-change-task',

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -52,7 +52,9 @@ describe('refreshAll', () => {
   // Terminal files carry sentinel fields not owned by refresh. A refresh must leave
   // their content exactly as found.
   it('leaves terminal files byte-for-byte untouched', async () => {
-    const merged = writeRawStatus('merged-task', '{"status":"merged","sentinel":"keep merged"}\n')
+    const merged = writeRawStatus('merged-task',
+      '{"status":"merged","merge_commit":"merge-commit","run_branch":"main",'
+      + '"sentinel":"keep merged"}\n')
     const noChange = writeRawStatus('no-change-task',
       '{"status":"no-change","sentinel":"keep no change"}\n')
     const failed = writeRawStatus('failed-task', '{"status":"failed","sentinel":"keep failed"}\n')

--- a/tests/run-tests.test.ts
+++ b/tests/run-tests.test.ts
@@ -8,12 +8,30 @@ import { performance } from 'node:perf_hooks'
 import { afterEach, describe, expect, it } from 'vitest'
 
 const fixtures: string[] = []
+const processRoots: number[] = []
 
 async function waitForPath(path: string): Promise<void> {
   const deadline = Date.now() + 5_000
   while (!existsSync(path)) {
     if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${path}`)
     await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+async function waitUntil(predicate: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 10_000
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
   }
 }
 
@@ -39,10 +57,93 @@ function run(command: string, args: readonly string[], cwd: string, env: NodeJS.
 }
 
 afterEach(() => {
+  for (const pid of processRoots.splice(0)) {
+    if (!processIsAlive(pid)) continue
+    try {
+      execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      })
+    } catch {
+      if (processIsAlive(pid)) throw new Error(`Could not stop test process tree ${pid}`)
+    }
+  }
   for (const fixture of fixtures.splice(0)) rmSync(fixture, { recursive: true, force: true })
 })
 
 describe('test suite wrapper', () => {
+  it.runIf(process.platform === 'win32')(
+    'terminates Vitest and releases its lock when the invoking PowerShell exits',
+    async () => {
+      const fixture = mkdtempSync(join(tmpdir(), 'orch-run-tests-cancel-'))
+      fixtures.push(fixture)
+      const scripts = join(fixture, 'scripts')
+      const vitest = join(fixture, 'node_modules', 'vitest')
+      const startedFile = join(fixture, 'started')
+      const completedFile = join(fixture, 'completed')
+      const pidFile = join(fixture, 'vitest-pid')
+      mkdirSync(scripts, { recursive: true })
+      mkdirSync(vitest, { recursive: true })
+      writeFileSync(
+        join(scripts, 'run-tests.mjs'),
+        readFileSync(join(import.meta.dirname, '..', 'scripts', 'run-tests.mjs')),
+      )
+      writeFileSync(join(vitest, 'package.json'), '{"name":"vitest","version":"0.0.0"}\n')
+      writeFileSync(join(vitest, 'vitest.mjs'), [
+        "import { writeFileSync } from 'node:fs'",
+        'if (process.env.ORCHESTRATION_TEST_STARTED_FILE) {',
+        "  writeFileSync(process.env.ORCHESTRATION_TEST_STARTED_FILE, '')",
+        '  writeFileSync(process.env.ORCHESTRATION_TEST_PID_FILE, String(process.pid))',
+        '}',
+        'await new Promise((resolve) => setTimeout(resolve, Number(process.env.ORCHESTRATION_TEST_DELAY_MS ?? 0)))',
+        'if (process.env.ORCHESTRATION_TEST_COMPLETED_FILE) {',
+        "  writeFileSync(process.env.ORCHESTRATION_TEST_COMPLETED_FILE, '')",
+        '}',
+        '',
+      ].join('\n'))
+
+      const invoker = spawn('powershell.exe', [
+        '-NoLogo', '-NoProfile', '-NonInteractive', '-Command',
+        '& $env:ORCHESTRATION_TEST_NODE $env:ORCHESTRATION_TEST_WRAPPER',
+      ], {
+        cwd: fixture,
+        env: {
+          ...process.env,
+          ORCHESTRATION_TEST_COMPLETED_FILE: completedFile,
+          ORCHESTRATION_TEST_DELAY_MS: '2000',
+          ORCHESTRATION_TEST_NODE: process.execPath,
+          ORCHESTRATION_TEST_PID_FILE: pidFile,
+          ORCHESTRATION_TEST_STARTED_FILE: startedFile,
+          ORCHESTRATION_TEST_WRAPPER: join(scripts, 'run-tests.mjs'),
+        },
+        stdio: 'ignore',
+        windowsHide: true,
+      })
+      if (invoker.pid !== undefined) processRoots.push(invoker.pid)
+      await waitForPath(startedFile)
+      const vitestPid = Number(readFileSync(pidFile, 'utf8'))
+      processRoots.push(vitestPid)
+      expect(processIsAlive(vitestPid)).toBe(true)
+
+      invoker.kill('SIGKILL')
+      await waitUntil(
+        () => !processIsAlive(vitestPid),
+        `Vitest process ${vitestPid} survived its invoking PowerShell process`,
+      )
+      await new Promise((resolve) => setTimeout(resolve, 2_100))
+      expect(existsSync(completedFile)).toBe(false)
+
+      const contender = await run(
+        process.execPath,
+        [join(scripts, 'run-tests.mjs')],
+        fixture,
+        process.env,
+      )
+      expect(contender.status).toBe(0)
+      expect(contender.stderr).toBe('')
+    },
+  )
+
   it('serializes linked-worktree invocations and forwards each gate flag once', async () => {
     const fixture = mkdtempSync(join(tmpdir(), 'orch-run-tests-'))
     fixtures.push(fixture)

--- a/tests/run-tests.test.ts
+++ b/tests/run-tests.test.ts
@@ -92,8 +92,8 @@ describe('test suite wrapper', () => {
       writeFileSync(join(vitest, 'vitest.mjs'), [
         "import { writeFileSync } from 'node:fs'",
         'if (process.env.ORCHESTRATION_TEST_STARTED_FILE) {',
-        "  writeFileSync(process.env.ORCHESTRATION_TEST_STARTED_FILE, '')",
         '  writeFileSync(process.env.ORCHESTRATION_TEST_PID_FILE, String(process.pid))',
+        "  writeFileSync(process.env.ORCHESTRATION_TEST_STARTED_FILE, '')",
         '}',
         'await new Promise((resolve) => setTimeout(resolve, Number(process.env.ORCHESTRATION_TEST_DELAY_MS ?? 0)))',
         'if (process.env.ORCHESTRATION_TEST_COMPLETED_FILE) {',

--- a/tests/start.test.ts
+++ b/tests/start.test.ts
@@ -30,6 +30,18 @@ vi.mock('../src/status.ts', async (importOriginal) => {
 let repoRoot: string
 let paths: OrchPaths
 
+function runningStatus(taskId: string, pid: number | null): string {
+  return JSON.stringify({
+    task_id: taskId,
+    status: 'running',
+    started_at: '2026-08-09T00:00:00Z',
+    updated_at: '2026-08-09T00:00:00Z',
+    worktree: worktreeDir(paths, taskId),
+    branch: branchName(taskId),
+    pid,
+  })
+}
+
 function git(args: string[]): string {
   return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8', windowsHide: true })
 }
@@ -71,9 +83,7 @@ describe('startTask', () => {
       cwd: worktree, windowsHide: true,
     })
     const recoveredHead = git(['rev-parse', branchName(taskId)]).trim()
-    writeFileSync(statusFile(paths, taskId), JSON.stringify({
-      task_id: taskId, status: 'running', pid: null,
-    }))
+    writeFileSync(statusFile(paths, taskId), runningStatus(taskId, null))
     const start = vi.fn(async () => process.pid)
 
     await expect(startTask(
@@ -93,9 +103,7 @@ describe('startTask', () => {
     writeFileSync(specFile(paths, taskId), '# live worktree task\n')
     mkdirSync(worktree, { recursive: true })
     writeFileSync(join(worktree, 'owned.txt'), 'still running\n')
-    writeFileSync(statusFile(paths, taskId), JSON.stringify({
-      task_id: taskId, status: 'running', pid: process.pid,
-    }))
+    writeFileSync(statusFile(paths, taskId), runningStatus(taskId, process.pid))
     // A task's process lives in the registry, not in the record.
     recordTaskProcess(paths, taskId, process.pid)
     const start = vi.fn(async () => process.pid)
@@ -115,9 +123,7 @@ describe('startTask', () => {
     const worktree = worktreeDir(paths, taskId)
     writeFileSync(specFile(paths, taskId), '# adapter verdict task\n')
     mkdirSync(worktree, { recursive: true })
-    writeFileSync(statusFile(paths, taskId), JSON.stringify({
-      task_id: taskId, status: 'running', pid: process.pid,
-    }))
+    writeFileSync(statusFile(paths, taskId), runningStatus(taskId, process.pid))
     recordTaskProcess(paths, taskId, process.pid)
     const start = vi.fn(async () => process.pid)
 

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from 'node:child_process'
+import {
+  mkdtempSync, readFileSync, rmSync, writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { orchPaths, statusFile } from '../src/paths.ts'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const CLI = join(HERE, '..', 'src', 'cli.ts')
+
+let repoRoot: string
+
+beforeEach(() => {
+  repoRoot = mkdtempSync(join(tmpdir(), 'orch-status-'))
+  expect(spawnSync('git', ['init'], { cwd: repoRoot, windowsHide: true }).status).toBe(0)
+})
+
+afterEach(() => {
+  rmSync(repoRoot, { recursive: true, force: true })
+})
+
+describe('status command', () => {
+  it('lists a legacy merged status without adding current merge metadata', () => {
+    const taskId = '20260802_170600_021_auto-legacy-merged'
+    const file = statusFile(orchPaths(repoRoot), taskId)
+    const legacyRecord = `${JSON.stringify({
+      task_id: taskId,
+      status: 'merged',
+      started_at: '2026-08-02T08:06:00Z',
+      updated_at: '2026-08-02T09:06:00Z',
+      worktree: join(repoRoot, 'orchestration', 'worktrees', taskId),
+      branch: `task/${taskId}`,
+    }, null, 2)}\n`
+    writeFileSync(file, legacyRecord)
+
+    const listing = spawnSync(process.execPath, [CLI, 'status', '--repo', repoRoot], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      windowsHide: true,
+    })
+    const loopStatus = spawnSync(process.execPath, [CLI, 'loop-status', '--repo', repoRoot], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      windowsHide: true,
+    })
+
+    expect(listing.status, listing.stderr).toBe(0)
+    expect(listing.stdout).toContain(taskId)
+    expect(listing.stdout).toContain('merged')
+    expect(loopStatus.status, loopStatus.stderr).toBe(0)
+    expect(readFileSync(file, 'utf8')).toBe(legacyRecord)
+  })
+})

--- a/tests/task-processes.test.ts
+++ b/tests/task-processes.test.ts
@@ -41,6 +41,29 @@ afterEach(() => {
 })
 
 describe('terminateLiveTaskProcesses', () => {
+  it('finds and terminates a registry-only process retained after startup failure', () => {
+    recordTaskProcess(paths, 'retained-startup', 101, () => 'started:101')
+    const alive = new Set([101])
+    const terminateProcessTree = vi.fn((pid: number) => {
+      alive.delete(pid)
+      return true
+    })
+    const os = {
+      processStartIdentity: (pid: number) => alive.has(pid) ? `started:${pid}` : undefined,
+      processIsAlive: (pid: number) => alive.has(pid),
+      terminateProcessTree,
+    } as unknown as OperatingSystem
+
+    const result = terminateLiveTaskProcesses(paths, os)
+
+    expect(terminateProcessTree).toHaveBeenCalledWith(101)
+    expect(result).toEqual({
+      terminated: [{ taskId: 'retained-startup', pid: 101 }],
+      failures: [],
+    })
+    expect(taskProcessPid(paths, 'retained-startup')).toBeUndefined()
+  })
+
   it('attempts every live task tree even when one cannot be terminated', () => {
     writeRunningTask('first-task', 101)
     writeRunningTask('second-task', 102)

--- a/tests/tasks.test.ts
+++ b/tests/tasks.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { operatingSystem } from '../src/adapters/os.ts'
-import { orchPaths, type OrchPaths } from '../src/paths.ts'
+import { branchName, orchPaths, worktreeDir, type OrchPaths } from '../src/paths.ts'
 import { processMarker, processMarkerText } from '../src/processMarker.ts'
 import {
   buildIssueBody, issueNumberForTask, parseIssueBody,
@@ -29,7 +29,14 @@ function createSpec(taskId: string): void {
 }
 
 function writeTestStatus(taskId: string, status: string): void {
-  writeFileSync(join(paths.statusDir, `${taskId}.json`), JSON.stringify({ task_id: taskId, status }))
+  writeFileSync(join(paths.statusDir, `${taskId}.json`), JSON.stringify({
+    task_id: taskId,
+    status,
+    started_at: '2026-08-08T03:00:00Z',
+    updated_at: '2026-08-08T03:00:00Z',
+    worktree: worktreeDir(paths, taskId),
+    branch: branchName(taskId),
+  }))
 }
 
 beforeEach(() => {

--- a/tests/tasks.test.ts
+++ b/tests/tasks.test.ts
@@ -36,6 +36,7 @@ function writeTestStatus(taskId: string, status: string): void {
     updated_at: '2026-08-08T03:00:00Z',
     worktree: worktreeDir(paths, taskId),
     branch: branchName(taskId),
+    ...(status === 'merged' ? { merge_commit: 'merge-commit', run_branch: 'main' } : {}),
   }))
 }
 


### PR DESCRIPTION
## Features
- None

## Bug Fixes
- [Status] A merged-status file written by an older core, which lacks the `merge_commit` and `run_branch` fields the current schema requires, is read as the older shape and listed with what is known, instead of failing the whole listing. Running `loop-status --repo` against a consuming repository whose status directory held early-August records reproduced the failure. Files the current core writes are still validated strictly, and merged statuses it writes must carry the metadata.
- [Persisted state] Malformed persisted state fails closed instead of being taken at face value: issue-queue state, persisted counters, and task status records are each validated on read, and a file that does not parse or does not conform stops the command with a report naming the file rather than resolving to a default or an empty result.
- [Startup approval] The interactive approval prompt accepts only the exact answers it printed, so a mistyped reply refuses the start instead of counting as agreement.
- [Cleanup] Task-process cleanup no longer drops processes that exist only in the registry, and cancelling the Windows test tree terminates the whole tree rather than orphaning it.
- [Adapters] Type-only imports in a project adapter no longer count as runtime dependencies when deciding what the adapter needs installed.

## Security
- None

## Project Operations
- [Documentation] The dependency-isolation opt-in, the full-gate cycle suite opt-in, the scan-parallel clamping behaviour, the fail-closed persisted-state rule, and the bundled adapter requirements are each documented where their settings are described, and the issue-queue contract items are renumbered after the additions.
- [Tests] GitHub PR promotion, workflow dispatch, and a failed deployment workflow gain coverage; the Vitest fixture publishes its PID before signalling start so the cancellation tests observe the real process.

## Risks
- Fail-closed validation of persisted state is a behaviour change with the same shape as the config-file rule that preceded it: a repository whose state directory holds a corrupt file will see commands stop and name the file, where before they continued on a default. Continuing was the failure mode — a forge error read as "no findings" is how a gate loses the set it depends on — but an operator meeting the refusal for the first time should expect to delete or repair the named file.
- The legacy status-file acceptance is deliberately narrow: only a merged-status record missing the two fields added later is read as the older shape. Anything else malformed still fails closed.
- Verified for this branch: CI passes on ubuntu-latest and windows-latest, and `npm run test:linux` passes in the container with 986 tests. The container run reports 2 skipped: this branch predates the platform-coverage arrangement that landed in #297, and two Windows-gated tests it adds use the old `it.runIf` form. Folding them into the coverage mechanism is follow-up work on `main` after this merges.
