### PR TITLE
feat: autonomous scan loop — 13 fixes

### DIFF
--- a/.claude/skills/.orchestration-core-sync.json
+++ b/.claude/skills/.orchestration-core-sync.json
@@ -7,7 +7,7 @@
     "git-review": "c71b70fc4064c1bd626b43b40b94530daadcaf8cd3af5ecd65fbb1739f423b61",
     "loop-delegate": "9f32215042f497eb3c0def1d841a109d190bda8d1614925686ec9ef185fec285",
     "loop-setup": "7492bfad12e4532d63e9d94180be0330918d95250724c9d1738520fdcc214123",
-    "loop-start": "73d9abfe5ec82e0cf6ef4694d477ed38c3f337cadc7623af658ccf9f5a57e8f8",
+    "loop-start": "daf62d3c54124c45ce2e54de9b0b78371daccaee5d872c36021ee177bc318d52",
     "loop-stop": "c59772c406edc59dd065e4a4a9573a2a9765f52028cf829c0219ac8902bb6251",
     "skill-create": "6657e1650e63fc255cb3b2b286b1f2a5161d4dfe126a170504b6df1d8b4fc09e"
   }

--- a/.claude/skills/loop-start/SKILL.md
+++ b/.claude/skills/loop-start/SKILL.md
@@ -72,7 +72,7 @@ Settings:
 | `CI_GATE_ENABLED` | false | Whether the gate waits for CI — a draft PR has no checks, so waiting would hang |
 | `MAX_CONSECUTIVE_MERGE_FAILURES` | 3 | Merges failing in a row before it stops — the task finished, its verification did not |
 | `SCAN_ENABLED` | true | Set false to work the existing queue without scanning |
-| `SCAN_PARALLEL` | 2 | Scans per cycle, splitting the checklist between them (1 = single full scan, up to 4) |
+| `SCAN_PARALLEL` | 2 | Requested scans per cycle, splitting the checklist between them (1 = single full scan; requests above the numbered section count are reduced at launch) |
 | `SCAN_EFFORT` | medium | Codex reasoning effort for scan tasks |
 | `TASK_EFFORT` | medium | Codex reasoning effort for queued tasks (`delegate --effort` overrides per task) |
 | `REVIEW_EFFORT` | medium | Codex reasoning effort for automatic review tasks |

--- a/README.md
+++ b/README.md
@@ -277,6 +277,10 @@ subtree installation). The command requires exactly one positive PR number, opti
 prefixed with `#`, or one absolute HTTP(S) URL. It refuses to run while the loop is active,
 performs no forge operation, records the completion in `logs/loop.log`, and emits the exact
 standalone `LOOP_DONE: <pr-number-or-url>` marker to `logs/loop-markers.log`.
+An active loop that observes the PR already ready or merged records its normal ending
+itself, so `shipped` is only needed when that ending is absent. If the PR is closed rather
+than ready or merged, the loop warns once and retries; observing the same closed state on
+the next poll logs an error, writes the stop file, and stops without emitting `LOOP_DONE`.
 
 Automatic pulls are enabled by default. To pull later improvements manually, or when
 `CORE_AUTO_UPDATE=false` pins the consumed version, use:

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ project files, and a deliberately different hooks setting are reported and never
 For `SCAN_PARALLEL` greater than one, keep the scan checklist as uniquely numbered
 Markdown headings outside fenced code blocks; without numbered headings the loop warns
 and runs one full scan, while ambiguous numbering stops the loop before the cycle starts.
+Requests above the number of numbered sections are reduced to that count and reported.
 
 Use the repository's `loop-setup` skill to collect the project-specific decisions, fill
 the generated adapter, and run `verify-setup`. The verifier reports the TypeScript gate,
@@ -316,7 +317,7 @@ settings update at their next use.
 |----------|---------|--------|
 | `MAX_SCAN_CYCLES` | 3 | Scan-and-fix rounds before the pull request is promoted |
 | `MAX_PARALLEL` | 3 | Ordinary task agent processes at once; scan agents use `SCAN_PARALLEL` independently |
-| `SCAN_PARALLEL` | 2 | Scan agent processes started together per scan cycle; values must be at least 1 and values above 4 are clamped to 4, independently of `MAX_PARALLEL` |
+| `SCAN_PARALLEL` | 2 | Requested scan agent processes per cycle; values must be at least 1 and are reduced to the template's numbered section count at launch, independently of `MAX_PARALLEL` |
 | `TASK_GATE` | full | `light` uses project-adapter-selected reduced checks for each merge, followed by the adapter's cycle suite once per cycle; `runAtEveryTaskGate` lets individual suite steps opt into every mode |
 | `AUTO_REVIEW` | false | Enable agent review of cycle diffs and queue the findings as fixes |
 | `REVIEW_EVERY_N_CYCLES` | 1 | With `AUTO_REVIEW=true`, review every Nth cycle and always review the final cycle |

--- a/SPEC.md
+++ b/SPEC.md
@@ -119,6 +119,7 @@ are not parsed by `loadConfig` and are not operator-file settings.
 | `AUTO_MERGE` | `true` | Merge completed local task worktrees automatically. `false` leaves them completed and eligible for an explicit or later merge. |
 | `AUTO_PR` | `true` | Push the run branch, create or update its draft pull request at cycle gates, and promote it with `LOOP_DONE` when the run finishes. `false` performs none of those PR operations. |
 | `SCAN_ENABLED` | `true` | Start another scan cycle after the current backlog and gate are clear. `false` drains existing local and shared work, performs any enabled final PR promotion, and exits without starting a scan. |
+| `SCAN_PARALLEL` | `2` | Requested scan processes per cycle. It must be at least 1 and is reduced at launch when the scan template has fewer numbered sections. |
 | `REVIEW_ENABLED` | `true` | Retain the review boundary in the cycle gate. Without `AUTO_REVIEW`, that boundary records resumable state and continues on the next poll; `false` skips it. If `AUTO_PR` is also `false`, disabling this setting bypasses the cycle gate entirely. |
 | `REVIEW_EFFORT` | `medium` | Reasoning effort for automatic review tasks. Accepted values are `minimal`, `low`, `medium`, and `high`. |
 | `RUNNER` | `codex` | Select the bundled `codex` or `claude` runner adapter, or an external adapter module. |
@@ -286,7 +287,8 @@ are not parsed by `loadConfig` and are not operator-file settings.
 ## Scans and cycles
 
 12. Scans start on idle (nothing queued or running), with `SCAN_PARALLEL` scans at a
-    time; the value must be at least 1, and values above 4 are clamped to 4. Scans run
+    time; the value must be at least 1. A request above the number of numbered scan
+    sections is reduced to that section count and reported in the event log. Scans run
     over disjoint groups of the checklist's sections. A cycle counts as empty only when
     every scan in it found nothing; `MAX_EMPTY_SCANS` consecutive empty cycles end the
     run early. The expected scan count (`queue/scan-expected-<n>`) and scan yield

--- a/SPEC.md
+++ b/SPEC.md
@@ -142,9 +142,11 @@ are not parsed by `loadConfig` and are not operator-file settings.
    investigation proves the requested change is already unnecessary. A missing task
    status file means no status, but an existing file must be valid JSON with string
    `task_id`, `started_at`, `updated_at`, `worktree`, and `branch` fields and a recognized
-   task state; `merged` additionally requires string `merge_commit` and `run_branch`
-   fields. Malformed JSON or a schema mismatch is not treated as absent: the read fails,
-   stopping the poll that encountered it, and the file is retained for operator repair.
+   task state. Current writes of `merged` additionally require string `merge_commit` and
+   `run_branch` fields; reads remain compatible with legacy `merged` records that predate
+   those fields. Malformed JSON or any other schema mismatch is not treated as absent:
+   the read fails, stopping the poll that encountered it, and the file is retained for
+   operator repair.
 2. Task ids are `YYYYMMDD_HHMMSS_nnn_<slug>` with `nnn` a per-day sequence; slugs end in
    `scan` for scans, are `review-c<n>` for automatic reviews of cycle `<n>`, and start
    with `ci-fix`, `auto-`, `fix-`, or `user-` for CI fixes, scan findings, review-origin

--- a/SPEC.md
+++ b/SPEC.md
@@ -430,7 +430,15 @@ are not parsed by `loadConfig` and are not operator-file settings.
     for a person instead of promoting a branch its own review keeps rejecting.
     Review tasks commit nothing and are exempt from the merge commit check.
 18. After the final cycle passes the same gate, the PR is promoted from draft,
-    the event log names the host environment where the run verification executed and
+    unless it is already open and ready. A PR found merged before promotion, or merged
+    while the ready operation is being confirmed, is also a successful terminal state;
+    both paths emit the normal completion records without another ready operation.
+    A PR found closed before or during promotion is not success: the first observation
+    warns and leaves the final gate resumable, while the same closed-state failure on the
+    next poll logs `ERROR`, writes the stop file, and ends the retry. Promotion errors,
+    status-query errors, and a PR that remains draft use the same two-attempt bound, and
+    no `LOOP_DONE` marker is emitted until an open ready or merged state is confirmed.
+    The event log names the host environment where the run verification executed and
     states that the branch was not run elsewhere. Repository adapters may also declare
     manual cross-environment checks; the log names each check and its command while
     explicitly recording that the loop did not run it for the branch.
@@ -442,7 +450,9 @@ are not parsed by `loadConfig` and are not operator-file settings.
      promoted by hand. It requires exactly one positive PR number (with an optional `#`)
      or absolute HTTP(S) URL
      and refuses to run while the loop is active, because an active loop records its own
-     ending. It performs no forge operation: it appends a cycle-aware `Completed Loop`
+     ending after observing the already-ready or merged PR itself. Use `shipped` only
+     when that automatic ending was not recorded. It performs no forge operation: it
+     appends a cycle-aware `Completed Loop`
      event to `logs/loop.log`, appends the exact standalone marker
      `LOOP_DONE: <pr-number-or-url>` to `logs/loop-markers.log`, and confirms the record
      on stdout.

--- a/skills/loop-start/SKILL.md
+++ b/skills/loop-start/SKILL.md
@@ -72,7 +72,7 @@ Settings:
 | `CI_GATE_ENABLED` | false | Whether the gate waits for CI — a draft PR has no checks, so waiting would hang |
 | `MAX_CONSECUTIVE_MERGE_FAILURES` | 3 | Merges failing in a row before it stops — the task finished, its verification did not |
 | `SCAN_ENABLED` | true | Set false to work the existing queue without scanning |
-| `SCAN_PARALLEL` | 2 | Scans per cycle, splitting the checklist between them (1 = single full scan, up to 4) |
+| `SCAN_PARALLEL` | 2 | Requested scans per cycle, splitting the checklist between them (1 = single full scan; requests above the numbered section count are reduced at launch) |
 | `SCAN_EFFORT` | medium | Codex reasoning effort for scan tasks |
 | `TASK_EFFORT` | medium | Codex reasoning effort for queued tasks (`delegate --effort` overrides per task) |
 | `REVIEW_EFFORT` | medium | Codex reasoning effort for automatic review tasks |

--- a/src/adapters/forge-github.ts
+++ b/src/adapters/forge-github.ts
@@ -8,7 +8,7 @@ import type {
   CheckConclusion, CreateIssueInRepositoryOptions, CreateIssueOptions, CreatePrOptions, Forge,
   ForgeAuthor, ForgeIssue, ForgeIssueComment, PrReference, PrStatus, WorkflowRun,
 } from './forge.ts'
-import { ForgeRateLimitError } from './forge.ts'
+import { ForgeIssueNotFoundError, ForgeRateLimitError } from './forge.ts'
 
 const execFileAsync = promisify(execFile)
 
@@ -210,6 +210,10 @@ function isMissingPrFailure(error: unknown): boolean {
   const text = commandErrorText(error)
   return /\bno (?:open )?pull requests found for branch\b/i.test(text)
     || /\bCould not resolve to a PullRequest with the number of \d+\b/i.test(text)
+}
+
+function isMissingIssueFailure(error: unknown): boolean {
+  return /\bCould not resolve to an Issue with the number of \d+\b/i.test(commandErrorText(error))
 }
 
 function githubPrBody(body: string): string {
@@ -539,7 +543,15 @@ export function createGithubForge(
       const args = ['issue', 'view', String(issueNumber),
         '--repo', repository,
         '--json', 'number,state,title,body,author,labels,assignees,updatedAt']
-      const stdout = await checkedGh(repoRoot, args)
+      let stdout: string
+      try {
+        stdout = await checkedGh(repoRoot, args)
+      } catch (error) {
+        if (isMissingIssueFailure(error)) {
+          throw new ForgeIssueNotFoundError(issueNumber, { cause: error })
+        }
+        throw error
+      }
       return normalizeIssue(parseGhJson(args, stdout, githubIssueSchema))
     },
 

--- a/src/adapters/forge.ts
+++ b/src/adapters/forge.ts
@@ -105,6 +105,17 @@ export class ForgeRateLimitError extends Error {
   }
 }
 
+/** A forge lookup that positively confirmed the requested issue does not exist. */
+export class ForgeIssueNotFoundError extends Error {
+  readonly issueNumber: number
+
+  constructor(issueNumber: number, options?: ErrorOptions) {
+    super(`Forge issue #${issueNumber} does not exist`, options)
+    this.name = 'ForgeIssueNotFoundError'
+    this.issueNumber = issueNumber
+  }
+}
+
 export interface Forge {
   /** Resolve forge-specific repository shorthand into a Git remote or URL. */
   resolveGitRemote(remote: string): string

--- a/src/branchTopology.ts
+++ b/src/branchTopology.ts
@@ -123,6 +123,9 @@ export function prepareBranchTopology(
       `Integration worktree ${worktree} is on ${checkedOutBranch}, expected ${integrationBranch}.`,
     )
   }
+  if (git(worktree, ['status', '--porcelain']).trim() !== '') {
+    throw new Error(`Integration worktree ${worktree} has uncommitted changes.`)
+  }
   if (!resuming) {
     try {
       git(paths.repoRoot, ['merge-base', '--is-ancestor', daemonHead, integrationBranch])

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1295,6 +1295,17 @@ async function runLoopDaemon(
     )
     const topology = prepareBranchTopology(paths, config.integrationBranch)
     const loopPaths = topology.paths
+    // A dependency-changing merge may have landed in the integration worktree before a
+    // surviving task process forced the previous daemon to stop. Its package-scoped
+    // pending marker must be retried here; synchronizing the frozen daemon checkout above
+    // cannot satisfy or clear that worktree's state.
+    syncOrchestrationDepsAtStartup(
+      loopPaths,
+      (name, subject) => log(name === 'Installed'
+        ? formatEventLine(name, 'orchestration deps', subject)
+        : formatEventLine(name, subject)),
+      orchestrationDepsRuntimeForPackage(topology.packageRoot),
+    )
     const forge = await loadForge(
       config.forge,
       loopPaths.repoRoot,

--- a/src/config.ts
+++ b/src/config.ts
@@ -179,8 +179,7 @@ function resolveConfig(env: NodeJS.ProcessEnv): LoopConfig {
   if (taskGate !== 'full' && taskGate !== 'light') {
     throw new Error(`TASK_GATE must be 'full' or 'light', got '${taskGate}'`)
   }
-  // SCAN_PARALLEL: the loop supports up to four concurrent scans, so higher values clamp.
-  const scanParallel = Math.min(num(env, 'SCAN_PARALLEL', 2), 4)
+  const scanParallel = num(env, 'SCAN_PARALLEL', 2)
   if (scanParallel < 1) {
     throw new Error('SCAN_PARALLEL must be at least 1')
   }

--- a/src/issueQueue.ts
+++ b/src/issueQueue.ts
@@ -4,6 +4,7 @@ import {
 } from 'node:fs'
 import { dirname, join } from 'node:path'
 import type { Forge, ForgeIssue } from './adapters/forge.ts'
+import { ForgeIssueNotFoundError } from './adapters/forge.ts'
 import {
   descSlug, existingTaskIdForDesc, forgetTaskId, newTaskId, recordTaskIdForDesc, taskIdForDesc,
 } from './ids.ts'
@@ -627,8 +628,9 @@ async function findExistingFinding(
     let recordedIssue: ForgeIssue | undefined
     try {
       recordedIssue = await forge.getIssue(recorded.issueNumber)
-    } catch {
-      // A missing issue cannot validate even a durable advisory ledger entry.
+    } catch (error) {
+      if (!(error instanceof ForgeIssueNotFoundError)) throw error
+      writeFingerprintLedger(paths, ledger.filter((entry) => entry !== recorded))
     }
     const durableClosedAdvisory = recordedIssue?.state === 'closed'
       && isAdvisoryFingerprint(fingerprint)
@@ -650,7 +652,9 @@ async function findExistingFinding(
       recordFingerprint(paths, fingerprint, survivor)
       return survivor
     }
-    writeFingerprintLedger(paths, ledger.filter((entry) => entry !== recorded))
+    if (recordedIssue !== undefined) {
+      writeFingerprintLedger(paths, ledger.filter((entry) => entry !== recorded))
+    }
   }
   const matching = (await forge.listOpenIssues(LABEL_FINDING))
     .filter((issue) => isTrustedFingerprintOwner(issue)

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1555,6 +1555,15 @@ export function createLoop(deps: LoopDeps) {
       return true
     }
 
+    // The PR can be completed or closed by a person between the final gate and
+    // promotion. Let postLoopPr interpret that terminal state instead of trying to
+    // create another PR for the same branch on every poll.
+    if (mode === 'final' && (status.state === 'merged' || status.state === 'closed')) {
+      if (status.url !== '') writeFileSync(prUrlFile, `${status.url}\n`)
+      previousGateFailures.delete('draft-pr')
+      return true
+    }
+
     try {
       const ahead = gitIn(paths.repoRoot, ['rev-list', '--count', `${baseRef}..HEAD`]).trim()
       if (ahead === '0') {
@@ -1659,7 +1668,17 @@ export function createLoop(deps: LoopDeps) {
       }
       return false
     }
-    if (status.isDraft) {
+    if (status.state === 'merged') {
+      previousGateFailures.delete('pr-promotion-state')
+    } else if (status.state === 'closed') {
+      reportGateFailure(
+        'could not promote PR because it is closed',
+        true,
+        'pr-promotion-state',
+      )
+      return false
+    }
+    if (status.state === 'open' && status.isDraft) {
       try {
         await forge.markPrReady(branch)
         previousGateFailures.delete('pr-promotion')
@@ -1687,7 +1706,24 @@ export function createLoop(deps: LoopDeps) {
         return false
       }
     }
-    if (status.state !== 'open' || status.isDraft) return false
+    if (status.state === 'closed') {
+      reportGateFailure(
+        'could not promote PR because it is closed',
+        true,
+        'pr-promotion-state',
+      )
+      return false
+    }
+    if (status.state === 'open' && status.isDraft) {
+      reportGateFailure(
+        'could not confirm PR promotion; PR is still draft',
+        true,
+        'pr-promotion-state',
+      )
+      return false
+    }
+    if (status.state !== 'open' && status.state !== 'merged') return false
+    previousGateFailures.delete('pr-promotion-state')
     const gateEnvironment = os.verificationEnvironmentLabel()
     event(
       'Status', 'Environments',
@@ -1710,6 +1746,7 @@ export function createLoop(deps: LoopDeps) {
     previousGateFailures.delete('pr-status-before-promotion')
     previousGateFailures.delete('pr-promotion')
     previousGateFailures.delete('pr-status-after-promotion')
+    previousGateFailures.delete('pr-promotion-state')
     return true
   }
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2036,7 +2036,7 @@ export function createLoop(deps: LoopDeps) {
       }
       prepareIntegration()
     }
-    const requestedScans = [1, 2, 3, 4].includes(config.scanParallel) ? config.scanParallel : 2
+    const requestedScans = config.scanParallel
     let nScans = requestedScans
     let sectionGroups: number[][] = []
     if (nScans > 1) {
@@ -2052,6 +2052,10 @@ export function createLoop(deps: LoopDeps) {
         event('WARN', `scan-template.md has no numbered sections; requested ${requestedScans} parallel scans, running one full scan`)
         nScans = 1
       } else {
+        if (requestedScans > sections.length) {
+          nScans = sections.length
+          event('WARN', `requested ${requestedScans} parallel scans but scan-template.md has ${sections.length} numbered sections; running ${nScans} scans`)
+        }
         sectionGroups = partitionScanSections(sections, nScans)
       }
     }

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -144,6 +144,12 @@ function orchestrationLockHashFile(root: string): string {
   return join(root, 'node_modules', '.orchestration-lock.sha256')
 }
 
+/** Durable retry state, scoped to the exact package checkout whose tree must be replaced. */
+export function pendingOrchestrationDepsFile(paths: OrchPaths, root: string): string {
+  const packageKey = createHash('sha256').update(resolve(root)).digest('hex').slice(0, 16)
+  return join(paths.queueDir, `orchestration-deps-pending-${packageKey}.json`)
+}
+
 function installFailureSummary(error: unknown): string {
   const failure = error as { stderr?: string | Buffer }
   const stderr = Buffer.isBuffer(failure.stderr)
@@ -157,12 +163,25 @@ function installOrchestrationDeps(
   subject: string,
   event: OrchestrationDepsEvent,
   runtime: OrchestrationDepsRuntime,
+  pendingFile: string,
   beforeInstall?: (() => boolean) | undefined,
 ): void {
   const root = runtime.packageRoot ?? PACKAGE_ROOT
+  try {
+    mkdirSync(dirname(pendingFile), { recursive: true })
+    writeFileSync(pendingFile, `${JSON.stringify({ packageRoot: resolve(root), subject })}\n`)
+  } catch (error) {
+    throw new OrchestrationDepsInstallError(
+      `Could not persist pending orchestration dependency installation ${subject}: `
+      + installFailureSummary(error),
+    )
+  }
   if (beforeInstall?.() === false) {
     event('Skipped', `${subject}; a live task process tree survived`)
-    return
+    throw new OrchestrationDepsInstallError(
+      `Orchestration dependency installation ${subject} remains pending in ${root} because `
+      + 'a live task process tree survived. Restart the loop after the process is stopped.',
+    )
   }
   try {
     runtime.install(root)
@@ -172,6 +191,7 @@ function installOrchestrationDeps(
       mkdirSync(join(root, 'node_modules'), { recursive: true })
       writeFileSync(hashFile, `${lockHash}\n`)
     }
+    rmSync(pendingFile, { force: true })
     event('Installed', subject)
   } catch (error) {
     throw new OrchestrationDepsInstallError(
@@ -200,7 +220,11 @@ function syncOrchestrationDepsAfterMerge(
   ]).split(/\r?\n/).filter((path) => path !== '')
   const manifests = orchestrationManifests(runtime.packageRoot ?? PACKAGE_ROOT)
   if (!changed.some((path) => manifests.has(resolve(paths.repoRoot, path)))) return
-  installOrchestrationDeps(`after ${shortTaskId(taskId)}`, event, runtime, beforeInstall)
+  const root = runtime.packageRoot ?? PACKAGE_ROOT
+  installOrchestrationDeps(
+    `after ${shortTaskId(taskId)}`, event, runtime,
+    pendingOrchestrationDepsFile(paths, root), beforeInstall,
+  )
 }
 
 function orchestrationDepsMissing(root: string): boolean {
@@ -250,8 +274,9 @@ export function syncOrchestrationDepsAtStartup(
   // at its own package: that is why the daemon starts in the repository it was given
   // rather than in the package directory (see `cmdLoop`).
   if (!isInside(paths.repoRoot, root)) return
-  if (!orchestrationDepsMissing(root)) return
-  installOrchestrationDeps('at startup', event, runtime)
+  const pendingFile = pendingOrchestrationDepsFile(paths, root)
+  if (!existsSync(pendingFile) && !orchestrationDepsMissing(root)) return
+  installOrchestrationDeps('at startup', event, runtime, pendingFile)
 }
 
 interface MergeIo {

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -727,6 +727,25 @@ function reclaimMalformedMergeGuard(dir: string): boolean {
   return mergeGuardRemovalWasVerified(dir)
 }
 
+function reclaimRetiredMergeGuard(dir: string): boolean {
+  try {
+    rmSync(join(dir, 'owner.json'))
+  } catch {
+    // A concurrent waiter may already have removed the owner.
+  }
+  try {
+    rmSync(join(dir, 'retired'))
+  } catch {
+    // A concurrent waiter may already have removed the retirement marker.
+  }
+  try {
+    rmdirSync(dir)
+  } catch {
+    // A concurrent waiter reclaimed it, or an unexpected marker keeps it non-empty.
+  }
+  return mergeGuardRemovalWasVerified(dir)
+}
+
 type MergeGuardAcquisition = { acquired: true; file: string; owner: MergeGuardOwner } | {
   acquired: false
   reason: 'active' | 'succeeded'
@@ -747,6 +766,18 @@ function acquireMergeGuard(
       return { acquired: true, file: dir, owner }
     }
     if (existsSync(join(dir, 'succeeded'))) return { acquired: false, reason: 'succeeded' }
+    if (existsSync(join(dir, 'retired'))) {
+      reclaimDeadline ??= Date.now() + MERGE_GUARD_RECLAIM_TIMEOUT_MS
+      if (reclaimRetiredMergeGuard(dir)) {
+        reclaimDeadline = undefined
+        continue
+      }
+      if (Date.now() >= reclaimDeadline) {
+        throw new MergeError(`Could not remove stale merge guard: ${taskId}`)
+      }
+      return new Promise((resolve) => setTimeout(resolve, MERGE_GUARD_RECLAIM_RETRY_MS))
+        .then(() => acquireMergeGuard(paths, taskId, reclaimDeadline))
+    }
     const recorded = activeMergeGuardOwner(dir)
     if (recorded === undefined) {
       // Atomic publication means a fresh ownerless or malformed directory may belong to
@@ -801,9 +832,20 @@ function finishMergeGuard(
   }
   if (!ownsGuard) return
   const retiredGuard = `${guard.file}.retired-${randomUUID()}`
-  // Renaming the whole guard is the release operation. Once it succeeds, a failed
-  // cleanup cannot leave this daemon's live PID at the well-known path or block a retry.
-  renameSync(guard.file, retiredGuard)
+  // Publish retirement before the preferred atomic rename. If Windows refuses the
+  // directory rename, a waiter can still distinguish this guard from a live operation.
+  try {
+    writeFileSync(join(guard.file, 'retired'), '', { flag: 'wx' })
+  } catch {
+    // The rename can still retire the guard without the fallback marker.
+  }
+  try {
+    renameSync(guard.file, retiredGuard)
+  } catch {
+    // Retirement must not replace the merge result. A published marker lets the next
+    // attempt reclaim this daemon's otherwise-live owner without waiting for restart.
+    return
+  }
   try {
     rmSync(retiredGuard, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
   } catch {

--- a/src/processRegistry.ts
+++ b/src/processRegistry.ts
@@ -117,8 +117,9 @@ function registeredTaskProcessPid(
   try {
     recorded = readFileSync(file, 'utf8')
     writtenAt = statSync(file).mtimeMs
-  } catch {
-    return undefined
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
   }
   try {
     entry = JSON.parse(recorded) as ProcessRegistryEntry

--- a/src/status.ts
+++ b/src/status.ts
@@ -127,6 +127,7 @@ function sleep(ms: number): Promise<void> {
 
 const STATUS_LOCK_WAIT_MS = 10_000
 const STATUS_LOCK_RETRY_MS = 10
+const releasedStatusLockTokens = new Set<string>()
 
 function lockIsAged(dir: string): boolean {
   try {
@@ -149,7 +150,9 @@ async function acquireStatusLock(paths: OrchPaths, taskId: string): Promise<stri
   const dir = lockDir(paths, taskId)
   const pidFile = join(dir, 'pid')
   const identityFile = join(dir, 'start-identity')
-  const owner = JSON.stringify(currentProcessStartIdentity())
+  const tokenFile = join(dir, 'owner-token')
+  const startIdentity = JSON.stringify(currentProcessStartIdentity())
+  const token = randomUUID()
   const deadline = Date.now() + STATUS_LOCK_WAIT_MS
   for (;;) {
     if (Date.now() >= deadline) {
@@ -183,8 +186,31 @@ async function acquireStatusLock(paths: OrchPaths, taskId: string): Promise<stri
       } catch {
         // Legacy owner or identity not published yet.
       }
+      let recordedToken = ''
+      try {
+        recordedToken = readFileSync(tokenFile, 'utf8').trim()
+      } catch {
+        // Legacy owner or token not published yet.
+      }
+      if (recordedToken !== '' && releasedStatusLockTokens.has(recordedToken)) {
+        try {
+          rmSync(tokenFile)
+          rmSync(identityFile, { force: true })
+          rmSync(pidFile, { force: true })
+          rmdirSync(dir)
+        } catch {
+          // another waiter won the reclaim
+        }
+        if (lockRemovalWasVerified(dir)) {
+          releasedStatusLockTokens.delete(recordedToken)
+          continue
+        }
+        await sleep(STATUS_LOCK_RETRY_MS)
+        continue
+      }
       if (validOwner && !lockOwnerIsCurrent(Number(recordedOwner), startIdentity)) {
         try {
+          rmSync(tokenFile, { force: true })
           rmSync(identityFile, { force: true })
           rmSync(pidFile)
           rmdirSync(dir)
@@ -199,6 +225,8 @@ async function acquireStatusLock(paths: OrchPaths, taskId: string): Promise<stri
       }
       if (!validOwner && lockIsAged(dir)) {
         try {
+          rmSync(tokenFile, { force: true })
+          rmSync(identityFile, { force: true })
           if (recordedOwner !== '') rmSync(pidFile)
           rmdirSync(dir)
         } catch {
@@ -215,8 +243,9 @@ async function acquireStatusLock(paths: OrchPaths, taskId: string): Promise<stri
     try {
       // Keep the PID file readable by older cores and publish identity separately.
       writeFileSync(pidFile, `${process.pid}\n`)
-      writeFileSync(identityFile, `${owner}\n`)
-      return owner
+      writeFileSync(identityFile, `${startIdentity}\n`)
+      writeFileSync(tokenFile, `${token}\n`)
+      return token
     } catch (error) {
       // Publishing metadata is part of acquisition, not contention. A writer that
       // cannot finish it must not leave its own PID looking like a live lock owner.
@@ -226,24 +255,33 @@ async function acquireStatusLock(paths: OrchPaths, taskId: string): Promise<stri
   }
 }
 
-function releaseStatusLock(paths: OrchPaths, taskId: string, owner: string): void {
+function releaseStatusLock(paths: OrchPaths, taskId: string, token: string): void {
   const dir = lockDir(paths, taskId)
   const pidFile = join(dir, 'pid')
-  const identityFile = join(dir, 'start-identity')
+  const tokenFile = join(dir, 'owner-token')
   let recordedPid = ''
-  let recordedOwner = ''
+  let recordedToken = ''
   try {
     recordedPid = readFileSync(pidFile, 'utf8').trim()
-    recordedOwner = readFileSync(identityFile, 'utf8').trim()
+    recordedToken = readFileSync(tokenFile, 'utf8').trim()
   } catch {
     return
   }
-  if (recordedPid !== String(process.pid) || recordedOwner !== owner) return
+  if (recordedPid !== String(process.pid) || recordedToken !== token) return
   const releasedDir = join(paths.statusDir, `.${taskId}.lock.released-${randomUUID()}`)
   // Renaming the whole lock is the release operation. Once it succeeds, failures
   // while removing the retired metadata cannot leave a live-looking owner at the
   // well-known lock path or block the next writer.
-  renameSync(dir, releasedDir)
+  try {
+    renameSync(dir, releasedDir)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    // The status mutation has already committed. Let the next acquisition reclaim
+    // this exact lock token even while this process remains alive.
+    releasedStatusLockTokens.add(token)
+    return
+  }
+  releasedStatusLockTokens.delete(token)
   try {
     rmSync(releasedDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 })
   } catch {

--- a/tests/__snapshots__/runner-codex.test.ts.snap
+++ b/tests/__snapshots__/runner-codex.test.ts.snap
@@ -398,7 +398,7 @@ Settings:
 | \`CI_GATE_ENABLED\` | false | Whether the gate waits for CI — a draft PR has no checks, so waiting would hang |
 | \`MAX_CONSECUTIVE_MERGE_FAILURES\` | 3 | Merges failing in a row before it stops — the task finished, its verification did not |
 | \`SCAN_ENABLED\` | true | Set false to work the existing queue without scanning |
-| \`SCAN_PARALLEL\` | 2 | Scans per cycle, splitting the checklist between them (1 = single full scan, up to 4) |
+| \`SCAN_PARALLEL\` | 2 | Requested scans per cycle, splitting the checklist between them (1 = single full scan; requests above the numbered section count are reduced at launch) |
 | \`SCAN_EFFORT\` | medium | Codex reasoning effort for scan tasks |
 | \`TASK_EFFORT\` | medium | Codex reasoning effort for queued tasks (\`delegate --effort\` overrides per task) |
 | \`REVIEW_EFFORT\` | medium | Codex reasoning effort for automatic review tasks |

--- a/tests/branch-topology.test.ts
+++ b/tests/branch-topology.test.ts
@@ -327,6 +327,23 @@ describe('integration branch topology', () => {
       .toThrow('The resumed run is fixed')
   })
 
+  it('refuses to reuse a dirty integration worktree on the expected branch', () => {
+    const worktree = join(paths.worktreesDir, '.integration')
+    git(repoRoot, ['worktree', 'add', '-q', worktree, '-b', 'integration/run'])
+    writeFileSync(join(worktree, 'uncommitted.txt'), 'not promoted\n')
+
+    expect(() => prepareBranchTopology(paths, 'integration/run'))
+      .toThrow(`Integration worktree ${worktree} has uncommitted changes.`)
+  })
+
+  it('refuses a dirty integration worktree when resuming', () => {
+    const topology = prepareBranchTopology(paths, 'integration/run')
+    writeFileSync(join(topology.paths.repoRoot, 'uncommitted.txt'), 'not promoted\n')
+
+    expect(() => prepareBranchTopology(paths, 'integration/run'))
+      .toThrow(`Integration worktree ${topology.paths.repoRoot} has uncommitted changes.`)
+  })
+
   it('refuses direct mode when resuming an integration run', () => {
     prepareBranchTopology(paths, 'integration/run')
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -111,8 +111,8 @@ describe('loadConfig', () => {
     )
   })
 
-  it('clamps SCAN_PARALLEL to four concurrent scans', () => {
-    expect(loadConfig({ SCAN_PARALLEL: '9' }).scanParallel).toBe(4)
+  it('accepts SCAN_PARALLEL above four', () => {
+    expect(loadConfig({ SCAN_PARALLEL: '9' }).scanParallel).toBe(9)
   })
 
   it('rejects SCAN_PARALLEL below one', () => {

--- a/tests/fakeForge.ts
+++ b/tests/fakeForge.ts
@@ -2,6 +2,7 @@ import type {
   CreateIssueInRepositoryOptions, CreateIssueOptions, CreatePrOptions, Forge, ForgeIssue,
   ForgeIssueComment, PrReference, PrStatus,
 } from '../src/adapters/forge.ts'
+import { ForgeIssueNotFoundError } from '../src/adapters/forge.ts'
 
 // An in-memory forge for tests: PR calls answer from a settable status, and the issue
 // operations behave like a real tracker — including multiple simultaneous assignees,
@@ -105,7 +106,7 @@ export function makeFakeForge(user = 'worker-a'): FakeForge {
     },
     async getIssue(issueNumber: number): Promise<ForgeIssue> {
       const issue = fake.issues.get(issueNumber)
-      if (issue === undefined) throw new Error(`no such issue: #${issueNumber}`)
+      if (issue === undefined) throw new ForgeIssueNotFoundError(issueNumber)
       return { ...issue, labels: [...issue.labels], assignees: [...issue.assignees] }
     },
     async commentIssue(issueNumber: number, comment: string): Promise<void> {

--- a/tests/forge-github.test.ts
+++ b/tests/forge-github.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   createGithubForge, workflowRunForDispatch, type GithubCommand, type GithubWorkflowRun,
 } from '../src/adapters/forge-github.ts'
-import { ForgeRateLimitError, type Forge } from '../src/adapters/forge.ts'
+import { ForgeIssueNotFoundError, ForgeRateLimitError, type Forge } from '../src/adapters/forge.ts'
 import { ensureQueueLabels, QUEUE_LABELS } from '../src/issueQueue.ts'
 
 const workflowRunFixture = {
@@ -647,6 +647,18 @@ describe('GitHub forge JSON schemas', () => {
     }).getIssue(357)).resolves.toMatchObject({
       author: { login: '(unknown)', hasWriteAccess: false },
     })
+  })
+
+  it('distinguishes a confirmed missing issue from other lookup failures', async () => {
+    const missing = Object.assign(new Error('issue lookup failed'), {
+      stderr: 'GraphQL: Could not resolve to an Issue with the number of 357. (repository.issue)',
+    })
+    const forge = createGithubForge('repo-root', async (_root, args) => {
+      if (args[0] === 'repo') return JSON.stringify({ nameWithOwner: 'example/repo' })
+      throw missing
+    })
+
+    await expect(forge.getIssue(357)).rejects.toBeInstanceOf(ForgeIssueNotFoundError)
   })
 
   it('drops and reports stale closed entries from an open issue listing', async () => {

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -339,6 +339,40 @@ describe('publishFinding', () => {
     expect(forge.issues.size).toBe(1)
   })
 
+  it('preserves the fingerprint ledger and propagates a transient issue lookup failure', async () => {
+    const finding = '[BUG] `src/a/b.ts` breaks'
+    const fingerprint = fingerprintOf(finding)
+    const issueNumber = await forge.createIssue({
+      title: finding,
+      body: buildIssueBody(finding, 'scan-1'),
+      labels: [LABEL_FINDING, LABEL_READY],
+    })
+    const ledgerFile = join(paths.queueDir, 'issue-fingerprints')
+    writeFileSync(ledgerFile, `${fingerprint} ${issueNumber}\n`)
+    forge.listOpenIssues = async () => []
+    forge.getIssue = async () => {
+      throw new Error('transient issue lookup failure')
+    }
+
+    await expect(publishFinding(forge, paths, finding, 'scan-2'))
+      .rejects.toThrow('transient issue lookup failure')
+
+    expect(readFileSync(ledgerFile, 'utf8')).toBe(`${fingerprint} ${issueNumber}\n`)
+    expect(forge.issues.size).toBe(1)
+  })
+
+  it('replaces a ledger entry after the recorded issue is confirmed absent', async () => {
+    const finding = '[BUG] `src/a/b.ts` breaks'
+    const fingerprint = fingerprintOf(finding)
+    const ledgerFile = join(paths.queueDir, 'issue-fingerprints')
+    writeFileSync(ledgerFile, `${fingerprint} 999\n`)
+
+    const result = await publishFinding(forge, paths, finding, 'scan-1')
+
+    expect(result).toEqual({ outcome: 'created', issueNumber: 1 })
+    expect(readFileSync(ledgerFile, 'utf8')).toBe(`${fingerprint} 1\n`)
+  })
+
   it.each([
     ['an outsider author', false, []],
     ['the untrusted-author label', true, [LABEL_UNTRUSTED_AUTHOR]],

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -3298,6 +3298,43 @@ describe('completion marker output', () => {
     expect(logged.some((line) => line.startsWith('Status Linux check'))).toBe(false)
   })
 
+  it('treats a PR merged while it is being promoted as complete', async () => {
+    initializeGitRepo()
+    configureRemoteDefaultBranch()
+    const loop = makeLoop()
+    fakeForge.markPrReady = async () => {
+      forgeStatus = { ...forgeStatus, state: 'merged', isDraft: false }
+    }
+
+    expect(await loop.postLoopPr()).toBe(true)
+
+    expect(logged).toContain('LOOP_DONE: https://example.test/pull/1')
+    expect(logged).toContain('Completed Loop        PR https://example.test/pull/1')
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
+  })
+
+  it('reports a PR closed while it is being promoted and stops after repetition', async () => {
+    initializeGitRepo()
+    configureRemoteDefaultBranch()
+    const loop = makeLoop()
+    const markPrReady = vi.fn(async () => {
+      forgeStatus = { ...forgeStatus, state: 'closed', isDraft: false }
+    })
+    fakeForge.markPrReady = markPrReady
+
+    expect(await loop.postLoopPr()).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
+    expect(await loop.postLoopPr()).toBe(false)
+
+    expect(markPrReady).toHaveBeenCalledOnce()
+    expect(logText()).toContain('WARN could not promote PR because it is closed')
+    expect(logText()).toContain(
+      'ERROR could not promote PR because it is closed (repeated 2 times)',
+    )
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(logged.some((line) => line.startsWith('LOOP_DONE:'))).toBe(false)
+  })
+
   it('reports repeated pre-promotion status errors and stops the loop', async () => {
     initializeGitRepo()
     const remote = join(repoRoot, 'remote.git')
@@ -3356,7 +3393,7 @@ describe('completion marker output', () => {
     expect(logged.some((line) => line.startsWith('Status Environments'))).toBe(false)
   })
 
-  it('does not emit LOOP_DONE until the forge confirms the PR is ready', async () => {
+  it('reports a persistently draft PR and stops without emitting LOOP_DONE', async () => {
     initializeGitRepo()
     const remote = join(repoRoot, 'remote.git')
     execFileSync('git', ['init', '--bare', remote], { windowsHide: true })
@@ -3366,8 +3403,15 @@ describe('completion marker output', () => {
     const loop = makeLoop()
 
     expect(await loop.postLoopPr()).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
+    expect(await loop.postLoopPr()).toBe(false)
 
-    expect(prStatusCalls).toBe(3)
+    expect(prStatusCalls).toBe(6)
+    expect(logText()).toContain('WARN could not confirm PR promotion; PR is still draft')
+    expect(logText()).toContain(
+      'ERROR could not confirm PR promotion; PR is still draft (repeated 2 times)',
+    )
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
     expect(logged.some((line) => line.startsWith('LOOP_DONE:'))).toBe(false)
     expect(logged).not.toContain('Completed Loop        PR https://example.test/pull/1')
     expect(logged.some((line) => line.startsWith('Status Environments'))).toBe(false)

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -19,7 +19,8 @@ import {
 import { existingTaskIdForDesc, recordTaskIdForDesc } from '../src/ids.ts'
 import { createLoop, formatEventLine, type Loop, type LoopDeps } from '../src/loop.ts'
 import {
-  syncOrchestrationDepsAtStartup, type OrchestrationDepsRuntime,
+  pendingOrchestrationDepsFile, syncOrchestrationDepsAtStartup,
+  type OrchestrationDepsRuntime,
 } from '../src/merge.ts'
 import {
   branchName, finalMessageFile, orchPaths, PACKAGE_ROOT, statusFile, worktreeDir,
@@ -329,6 +330,20 @@ describe('daemon startup', () => {
     })
 
     expect(install).toHaveBeenCalledOnce()
+  })
+
+  it('retries a durable pending sync even when the recorded lockfile is current', () => {
+    writeOrchestrationManifests('{"lockfileVersion":3}\n')
+    const install = vi.fn(successfulInstall)
+    const packageRoot = fixturePackageRoot()
+    syncOrchestrationDepsAtStartup(paths, vi.fn(), { install, packageRoot })
+    const pendingFile = pendingOrchestrationDepsFile(paths, packageRoot)
+    writeFileSync(pendingFile, '{}\n')
+
+    syncOrchestrationDepsAtStartup(paths, vi.fn(), { install, packageRoot })
+
+    expect(install).toHaveBeenCalledTimes(2)
+    expect(existsSync(pendingFile)).toBe(false)
   })
 
   it('stops startup with recovery instructions after a lockfile upgrade fails', () => {
@@ -3468,7 +3483,7 @@ describe('completed task merge recovery', () => {
     return worktree
   }
 
-  it('skips dependency installation when a task process tree survives', async () => {
+  it('persists pending dependency installation and stops when a task process tree survives', async () => {
     const taskId = '20260820_181834_032_auto-dependency-installation'
     makeDependencyChangingTask(taskId)
     const oldDependency = join(repoRoot, 'node_modules', 'old-dependency', 'package.json')
@@ -3492,7 +3507,9 @@ describe('completed task merge recovery', () => {
     )
     loop.initializeSessionStateForBranch()
 
-    expect(await loop.poll()).toBe('continue')
+    await expect(loop.poll()).rejects.toThrow(
+      /dependency installation after 032_auto remains pending.*live task process tree survived/,
+    )
 
     expect(install).not.toHaveBeenCalled()
     expect(readFileSync(oldDependency, 'utf8')).toBe('{}\n')
@@ -3503,6 +3520,16 @@ describe('completed task merge recovery', () => {
       'Skipped orchestration deps  after 032_auto; a live task process tree survived',
     )
     expect(readStatus(paths, taskId)?.status).toBe('merged')
+    const pendingFile = pendingOrchestrationDepsFile(paths, repoRoot)
+    expect(existsSync(pendingFile)).toBe(true)
+
+    const retryInstall = vi.fn()
+    syncOrchestrationDepsAtStartup(paths, vi.fn(), {
+      install: retryInstall, packageRoot: repoRoot,
+    })
+
+    expect(retryInstall).toHaveBeenCalledOnce()
+    expect(existsSync(pendingFile)).toBe(false)
   })
 
   it('installs dependencies after every task process tree stops cleanly', async () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1601,6 +1601,23 @@ describe('cycle gate', () => {
     expect(Math.max(...assignmentSizes) - Math.min(...assignmentSizes)).toBeLessThanOrEqual(1)
   })
 
+  it('clamps parallel scans to the numbered section count and reports the request', async () => {
+    initializeGitRepo()
+    mkdirSync(join(paths.root, 'templates'), { recursive: true })
+    writeFileSync(
+      join(paths.root, 'templates', 'scan-template.md'),
+      '# {{SCAN_ID}}\n\n{{SCAN_SCOPE}}\n\n### 1. First check\n\n### 2. Second check\n',
+    )
+    const loop = makeLoop({ scanParallel: 5, autoPr: false, reviewEnabled: false })
+
+    expect(await loop.triggerScanIfIdle()).toBe('continue')
+    expect(runnerStarts).toHaveLength(2)
+    expect(readFileSync(join(paths.queueDir, 'scan-expected-1'), 'utf8')).toBe('2\n')
+    expect(logText()).toContain(
+      'WARN requested 5 parallel scans but scan-template.md has 2 numbered sections; running 2 scans',
+    )
+  })
+
   it('falls back to one full scan with a warning when the template has no numbered sections', async () => {
     initializeGitRepo()
     mkdirSync(join(paths.root, 'templates'), { recursive: true })

--- a/tests/merge-guard.test.ts
+++ b/tests/merge-guard.test.ts
@@ -4,11 +4,11 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({ rmSync: vi.fn() }))
+const mocks = vi.hoisted(() => ({ renameSync: vi.fn(), rmSync: vi.fn() }))
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
-  return { ...actual, rmSync: mocks.rmSync }
+  return { ...actual, renameSync: mocks.renameSync, rmSync: mocks.rmSync }
 })
 
 import { mergeTask, MergeError } from '../src/merge.ts'
@@ -52,6 +52,8 @@ beforeEach(() => {
   git(repoRoot, ['commit', '-qm', 'chore: initial commit'])
   mocks.rmSync.mockReset().mockImplementation((...args: unknown[]) =>
     Reflect.apply(actualFs.rmSync, actualFs, args))
+  mocks.renameSync.mockReset().mockImplementation((...args: unknown[]) =>
+    Reflect.apply(actualFs.renameSync, actualFs, args))
 })
 
 afterEach(() => {
@@ -60,6 +62,43 @@ afterEach(() => {
 })
 
 describe('merge guard retirement', () => {
+  it('reclaims a failed merge after guard retirement rename fails', async () => {
+    const taskId = '20260822_093823_001_auto-failed-guard-rename'
+    await makeCompletedTask(taskId, { dirty: true })
+    const guard = join(paths.queueDir, 'merge-guards', taskId)
+    mocks.renameSync.mockImplementation((...args: unknown[]) => {
+      if (args[0] === guard) throw new Error('guard retirement rename failed')
+      return Reflect.apply(actualFs.renameSync, actualFs, args)
+    })
+
+    await expect(mergeTask(paths, taskId, {
+      taskGate: 'light', project: stubProject,
+    })).rejects.toBeInstanceOf(MergeError)
+    expect(actualFs.existsSync(join(guard, 'retired'))).toBe(true)
+
+    const onMergeStart = vi.fn()
+    await expect(mergeTask(paths, taskId, {
+      taskGate: 'light', project: stubProject, onMergeStart,
+    })).rejects.toBeInstanceOf(MergeError)
+    expect(onMergeStart).toHaveBeenCalledOnce()
+  })
+
+  it('does not turn a successful merge into failure when guard retirement rename fails', async () => {
+    const taskId = '20260822_093823_002_auto-successful-guard-rename'
+    await makeCompletedTask(taskId, { commit: true })
+    const guard = join(paths.queueDir, 'merge-guards', taskId)
+    mocks.renameSync.mockImplementation((...args: unknown[]) => {
+      if (args[0] === guard) throw new Error('guard retirement rename failed')
+      return Reflect.apply(actualFs.renameSync, actualFs, args)
+    })
+
+    await expect(mergeTask(paths, taskId, {
+      taskGate: 'light', project: stubProject,
+    })).resolves.toMatchObject({ outcome: 'merged' })
+    expect(readStatus(paths, taskId)?.status).toBe('merged')
+    expect(actualFs.existsSync(join(guard, 'retired'))).toBe(true)
+  })
+
   it('releases a failed merge before non-fatal retired guard cleanup', async () => {
     const taskId = '20260820_205825_001_auto-failed-guard-cleanup'
     await makeCompletedTask(taskId, { dirty: true })

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -24,11 +24,19 @@ import {
   removeWorktreeWithFallback, type WorktreeRemovalRuntime,
 } from '../src/worktree.ts'
 import { stubProject } from './stubProject.ts'
-import { TestProcessRegistry } from './testProcess.ts'
+import { PROCESS_TEST_TIMEOUT_MS, TestProcessRegistry } from './testProcess.ts'
 
 let repoRoot: string
 let paths: OrchPaths
 const testProcesses = new TestProcessRegistry()
+
+async function waitForFile(file: string, message: string): Promise<void> {
+  const deadline = Date.now() + PROCESS_TEST_TIMEOUT_MS
+  while (!existsSync(file)) {
+    if (Date.now() >= deadline) throw new Error(message)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
 
 const installProject: ProjectAdapter = {
   ...stubProject,
@@ -474,7 +482,12 @@ describe('mergeTask', () => {
   it('stops and verifies a completed runner with a live PID before merging', async () => {
     const taskId = '20260808_000000_017_user-runner-finishes-output-first'
     const worktree = await makeCompletedTask(taskId, { commit: true })
-    const runner = testProcesses.spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    const runnerReady = join(repoRoot, 'runner-ready')
+    const runner = testProcesses.spawn(process.execPath, [
+      '--input-type=module', '--eval',
+      "const { writeFileSync } = await import('node:fs'); writeFileSync(process.argv[1], ''); setInterval(() => {}, 1000)",
+      runnerReady,
+    ], {
       detached: true,
       stdio: 'ignore',
       windowsHide: true,
@@ -483,6 +496,7 @@ describe('mergeTask', () => {
     if (runnerPid === undefined) throw new Error('Runner did not publish a PID.')
     runner.unref()
     await writeStatus(paths, taskId, 'completed', runnerPid)
+    await waitForFile(runnerReady, 'Runner fixture did not become ready.')
 
     await mergeTask(paths, taskId, { taskGate: 'light', project: stubProject })
 

--- a/tests/platform-coverage.test.ts
+++ b/tests/platform-coverage.test.ts
@@ -6,7 +6,10 @@ import {
 describe('platform coverage', () => {
   it('leaves a suite uncollected only on the platforms that cannot attempt it', () => {
     expect(uncollectedSuites('win32')).toEqual(['tests/posix-process-group.test.ts'])
-    expect(uncollectedSuites('linux')).toEqual(['tests/windows-console.test.ts'])
+    expect(uncollectedSuites('linux')).toEqual([
+      'tests/windows-console.test.ts',
+      'tests/windows-run-tests-cancellation.test.ts',
+    ])
   })
 
   it('names an uncollected suite, the platform it needs, and why', () => {
@@ -31,14 +34,11 @@ describe('platform coverage', () => {
     }
   })
 
-  it('covers each platform with the same number of real-process suites', () => {
-    // The asymmetry this pins is the one that prompted the suite: Windows had a test
-    // that drove real processes and POSIX had none, so a signal reaching a whole
-    // process group was only ever asserted through an injected runtime.
+  it('counts every registered real-process suite by platform', () => {
     const perPlatform = new Map<NodeJS.Platform, number>()
     for (const suite of PLATFORM_SUITES) {
       perPlatform.set(suite.platform, (perPlatform.get(suite.platform) ?? 0) + 1)
     }
-    expect([...perPlatform.entries()].sort()).toEqual([['linux', 1], ['win32', 1]])
+    expect([...perPlatform.entries()].sort()).toEqual([['linux', 1], ['win32', 2]])
   })
 })

--- a/tests/platform-coverage.test.ts
+++ b/tests/platform-coverage.test.ts
@@ -33,12 +33,4 @@ describe('platform coverage', () => {
       for (const suite of PLATFORM_SUITES) expect(report).toContain(suite.file)
     }
   })
-
-  it('counts every registered real-process suite by platform', () => {
-    const perPlatform = new Map<NodeJS.Platform, number>()
-    for (const suite of PLATFORM_SUITES) {
-      perPlatform.set(suite.platform, (perPlatform.get(suite.platform) ?? 0) + 1)
-    }
-    expect([...perPlatform.entries()].sort()).toEqual([['linux', 1], ['win32', 2]])
-  })
 })

--- a/tests/platformCoverage.ts
+++ b/tests/platformCoverage.ts
@@ -19,6 +19,11 @@ export const PLATFORM_SUITES: PlatformSuite[] = [
     reason: 'launches a Windows process tree and observes the consoles it attaches',
   },
   {
+    file: 'tests/windows-run-tests-cancellation.test.ts',
+    platform: 'win32',
+    reason: 'launches PowerShell and verifies Windows process-tree cancellation',
+  },
+  {
     file: 'tests/posix-process-group.test.ts',
     platform: 'linux',
     reason: 'signals a real detached process group and reads /proc to see who survived',

--- a/tests/process-registry.test.ts
+++ b/tests/process-registry.test.ts
@@ -3,7 +3,28 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsFailures = vi.hoisted(() => ({
+  read: undefined as NodeJS.ErrnoException | undefined,
+  stat: undefined as NodeJS.ErrnoException | undefined,
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    readFileSync: ((...args: Parameters<typeof actual.readFileSync>) => {
+      if (fsFailures.read !== undefined) throw fsFailures.read
+      return Reflect.apply(actual.readFileSync, actual, args)
+    }) as typeof actual.readFileSync,
+    statSync: ((...args: Parameters<typeof actual.statSync>) => {
+      if (fsFailures.stat !== undefined) throw fsFailures.stat
+      return Reflect.apply(actual.statSync, actual, args)
+    }) as typeof actual.statSync,
+  }
+})
+
 import { orchPaths, type OrchPaths } from '../src/paths.ts'
 import {
   bootedAt, forgetTaskProcess, recordTaskProcess, taskProcessPid, terminableTaskProcessPid,
@@ -15,6 +36,8 @@ describe('task process registry', () => {
   const taskId = '20260813_120000_001_auto-registry'
 
   beforeEach(() => {
+    fsFailures.read = undefined
+    fsFailures.stat = undefined
     repoRoot = mkdtempSync(join(tmpdir(), 'orch process-registry-'))
     paths = orchPaths(repoRoot)
   })
@@ -35,6 +58,18 @@ describe('task process registry', () => {
   it('answers with nothing for a task it never recorded', () => {
     expect(taskProcessPid(paths, taskId)).toBeUndefined()
   })
+
+  it.each(['read', 'stat'] as const)(
+    'propagates a non-ENOENT registry %s failure',
+    (operation) => {
+      recordTaskProcess(paths, taskId, 4321, identity)
+      const error = Object.assign(new Error(`${operation} denied`), { code: 'EACCES' })
+      fsFailures[operation] = error
+
+      expect(() => taskProcessPid(paths, taskId, undefined, identity)).toThrow(error)
+      expect(existsSync(registryFile())).toBe(true)
+    },
+  )
 
   it('releases the process on stop', () => {
     recordTaskProcess(paths, taskId, 4321, identity)

--- a/tests/run-tests.test.ts
+++ b/tests/run-tests.test.ts
@@ -8,30 +8,12 @@ import { performance } from 'node:perf_hooks'
 import { afterEach, describe, expect, it } from 'vitest'
 
 const fixtures: string[] = []
-const processRoots: number[] = []
 
 async function waitForPath(path: string): Promise<void> {
   const deadline = Date.now() + 5_000
   while (!existsSync(path)) {
     if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${path}`)
     await new Promise((resolve) => setTimeout(resolve, 20))
-  }
-}
-
-async function waitUntil(predicate: () => boolean, message: string): Promise<void> {
-  const deadline = Date.now() + 10_000
-  while (!predicate()) {
-    if (Date.now() >= deadline) throw new Error(message)
-    await new Promise((resolve) => setTimeout(resolve, 20))
-  }
-}
-
-function processIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch {
-    return false
   }
 }
 
@@ -57,93 +39,10 @@ function run(command: string, args: readonly string[], cwd: string, env: NodeJS.
 }
 
 afterEach(() => {
-  for (const pid of processRoots.splice(0)) {
-    if (!processIsAlive(pid)) continue
-    try {
-      execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
-        stdio: 'ignore',
-        windowsHide: true,
-      })
-    } catch {
-      if (processIsAlive(pid)) throw new Error(`Could not stop test process tree ${pid}`)
-    }
-  }
   for (const fixture of fixtures.splice(0)) rmSync(fixture, { recursive: true, force: true })
 })
 
 describe('test suite wrapper', () => {
-  it.runIf(process.platform === 'win32')(
-    'terminates Vitest and releases its lock when the invoking PowerShell exits',
-    async () => {
-      const fixture = mkdtempSync(join(tmpdir(), 'orch-run-tests-cancel-'))
-      fixtures.push(fixture)
-      const scripts = join(fixture, 'scripts')
-      const vitest = join(fixture, 'node_modules', 'vitest')
-      const startedFile = join(fixture, 'started')
-      const completedFile = join(fixture, 'completed')
-      const pidFile = join(fixture, 'vitest-pid')
-      mkdirSync(scripts, { recursive: true })
-      mkdirSync(vitest, { recursive: true })
-      writeFileSync(
-        join(scripts, 'run-tests.mjs'),
-        readFileSync(join(import.meta.dirname, '..', 'scripts', 'run-tests.mjs')),
-      )
-      writeFileSync(join(vitest, 'package.json'), '{"name":"vitest","version":"0.0.0"}\n')
-      writeFileSync(join(vitest, 'vitest.mjs'), [
-        "import { writeFileSync } from 'node:fs'",
-        'if (process.env.ORCHESTRATION_TEST_STARTED_FILE) {',
-        '  writeFileSync(process.env.ORCHESTRATION_TEST_PID_FILE, String(process.pid))',
-        "  writeFileSync(process.env.ORCHESTRATION_TEST_STARTED_FILE, '')",
-        '}',
-        'await new Promise((resolve) => setTimeout(resolve, Number(process.env.ORCHESTRATION_TEST_DELAY_MS ?? 0)))',
-        'if (process.env.ORCHESTRATION_TEST_COMPLETED_FILE) {',
-        "  writeFileSync(process.env.ORCHESTRATION_TEST_COMPLETED_FILE, '')",
-        '}',
-        '',
-      ].join('\n'))
-
-      const invoker = spawn('powershell.exe', [
-        '-NoLogo', '-NoProfile', '-NonInteractive', '-Command',
-        '& $env:ORCHESTRATION_TEST_NODE $env:ORCHESTRATION_TEST_WRAPPER',
-      ], {
-        cwd: fixture,
-        env: {
-          ...process.env,
-          ORCHESTRATION_TEST_COMPLETED_FILE: completedFile,
-          ORCHESTRATION_TEST_DELAY_MS: '2000',
-          ORCHESTRATION_TEST_NODE: process.execPath,
-          ORCHESTRATION_TEST_PID_FILE: pidFile,
-          ORCHESTRATION_TEST_STARTED_FILE: startedFile,
-          ORCHESTRATION_TEST_WRAPPER: join(scripts, 'run-tests.mjs'),
-        },
-        stdio: 'ignore',
-        windowsHide: true,
-      })
-      if (invoker.pid !== undefined) processRoots.push(invoker.pid)
-      await waitForPath(startedFile)
-      const vitestPid = Number(readFileSync(pidFile, 'utf8'))
-      processRoots.push(vitestPid)
-      expect(processIsAlive(vitestPid)).toBe(true)
-
-      invoker.kill('SIGKILL')
-      await waitUntil(
-        () => !processIsAlive(vitestPid),
-        `Vitest process ${vitestPid} survived its invoking PowerShell process`,
-      )
-      await new Promise((resolve) => setTimeout(resolve, 2_100))
-      expect(existsSync(completedFile)).toBe(false)
-
-      const contender = await run(
-        process.execPath,
-        [join(scripts, 'run-tests.mjs')],
-        fixture,
-        process.env,
-      )
-      expect(contender.status).toBe(0)
-      expect(contender.stderr).toBe('')
-    },
-  )
-
   it('serializes linked-worktree invocations and forwards each gate flag once', async () => {
     const fixture = mkdtempSync(join(tmpdir(), 'orch-run-tests-'))
     fixtures.push(fixture)

--- a/tests/status-lock.test.ts
+++ b/tests/status-lock.test.ts
@@ -3,11 +3,18 @@ import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({ rmSync: vi.fn(), writeFileSync: vi.fn() }))
+const mocks = vi.hoisted(() => ({
+  renameSync: vi.fn(), rmSync: vi.fn(), writeFileSync: vi.fn(),
+}))
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
-  return { ...actual, rmSync: mocks.rmSync, writeFileSync: mocks.writeFileSync }
+  return {
+    ...actual,
+    renameSync: mocks.renameSync,
+    rmSync: mocks.rmSync,
+    writeFileSync: mocks.writeFileSync,
+  }
 })
 
 import { orchPaths, type OrchPaths } from '../src/paths.ts'
@@ -20,6 +27,8 @@ let paths: OrchPaths
 beforeEach(() => {
   repoRoot = mkdtempSync(join(tmpdir(), 'orch-status-lock-'))
   paths = orchPaths(repoRoot)
+  mocks.renameSync.mockReset().mockImplementation((...args: unknown[]) =>
+    Reflect.apply(actualFs.renameSync, actualFs, args))
   mocks.rmSync.mockReset().mockImplementation((...args: unknown[]) =>
     Reflect.apply(actualFs.rmSync, actualFs, args))
   mocks.writeFileSync.mockReset().mockImplementation((...args: unknown[]) =>
@@ -32,6 +41,29 @@ afterEach(() => {
 })
 
 describe('status lock publication', () => {
+  it('preserves a successful write and recovers when lock release rename fails', async () => {
+    const taskId = 'release-rename-failure'
+    const lockDirectory = join(paths.statusDir, `.${taskId}.lock`)
+    const failure = Object.assign(new Error('lock release failed'), { code: 'EPERM' })
+    let releaseFailed = false
+    mocks.renameSync.mockImplementation((...args: unknown[]) => {
+      if (!releaseFailed && args[0] === lockDirectory) {
+        releaseFailed = true
+        throw failure
+      }
+      return Reflect.apply(actualFs.renameSync, actualFs, args)
+    })
+
+    await expect(writeStatus(paths, taskId, 'running', process.pid)).resolves.toBeUndefined()
+    expect(releaseFailed).toBe(true)
+    expect(readStatus(paths, taskId)?.status).toBe('running')
+    expect(actualFs.existsSync(lockDirectory)).toBe(true)
+
+    await expect(writeStatus(paths, taskId, 'completed')).resolves.toBeUndefined()
+    expect(readStatus(paths, taskId)?.status).toBe('completed')
+    expect(actualFs.existsSync(lockDirectory)).toBe(false)
+  })
+
   it('keeps the lock released when retired metadata removal fails', async () => {
     const taskId = 'partial-release-failure'
     const lockDir = join(paths.statusDir, `.${taskId}.lock`)

--- a/tests/windows-run-tests-cancellation.test.ts
+++ b/tests/windows-run-tests-cancellation.test.ts
@@ -1,0 +1,140 @@
+import { execFileSync, spawn } from 'node:child_process'
+import {
+  existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it } from 'vitest'
+
+// This assertion launches PowerShell and depends on Windows process-tree semantics.
+// vitest.config.ts leaves the file uncollected off Windows; see platformCoverage.ts.
+
+const fixtures: string[] = []
+const processRoots: number[] = []
+
+async function waitForPath(path: string): Promise<void> {
+  const deadline = Date.now() + 5_000
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${path}`)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+async function waitUntil(predicate: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 10_000
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function run(command: string, args: readonly string[], cwd: string, env: NodeJS.ProcessEnv): Promise<{
+  status: number | null
+  stderr: string
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [...args], {
+      cwd,
+      env,
+      stdio: ['ignore', 'ignore', 'pipe'] as const,
+      windowsHide: true,
+    })
+    let stderr = ''
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString() })
+    child.once('error', reject)
+    child.once('close', (status) => resolve({ status, stderr }))
+  })
+}
+
+afterEach(() => {
+  for (const pid of processRoots.splice(0)) {
+    if (!processIsAlive(pid)) continue
+    try {
+      execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      })
+    } catch {
+      if (processIsAlive(pid)) throw new Error(`Could not stop test process tree ${pid}`)
+    }
+  }
+  for (const fixture of fixtures.splice(0)) rmSync(fixture, { recursive: true, force: true })
+})
+
+it('terminates Vitest and releases its lock when the invoking PowerShell exits', async () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'orch-run-tests-cancel-'))
+  fixtures.push(fixture)
+  const scripts = join(fixture, 'scripts')
+  const vitest = join(fixture, 'node_modules', 'vitest')
+  const startedFile = join(fixture, 'started')
+  const completedFile = join(fixture, 'completed')
+  const pidFile = join(fixture, 'vitest-pid')
+  mkdirSync(scripts, { recursive: true })
+  mkdirSync(vitest, { recursive: true })
+  writeFileSync(
+    join(scripts, 'run-tests.mjs'),
+    readFileSync(join(import.meta.dirname, '..', 'scripts', 'run-tests.mjs')),
+  )
+  writeFileSync(join(vitest, 'package.json'), '{"name":"vitest","version":"0.0.0"}\n')
+  writeFileSync(join(vitest, 'vitest.mjs'), [
+    "import { writeFileSync } from 'node:fs'",
+    'if (process.env.ORCHESTRATION_TEST_STARTED_FILE) {',
+    '  writeFileSync(process.env.ORCHESTRATION_TEST_PID_FILE, String(process.pid))',
+    "  writeFileSync(process.env.ORCHESTRATION_TEST_STARTED_FILE, '')",
+    '}',
+    'await new Promise((resolve) => setTimeout(resolve, Number(process.env.ORCHESTRATION_TEST_DELAY_MS ?? 0)))',
+    'if (process.env.ORCHESTRATION_TEST_COMPLETED_FILE) {',
+    "  writeFileSync(process.env.ORCHESTRATION_TEST_COMPLETED_FILE, '')",
+    '}',
+    '',
+  ].join('\n'))
+
+  const invoker = spawn('powershell.exe', [
+    '-NoLogo', '-NoProfile', '-NonInteractive', '-Command',
+    '& $env:ORCHESTRATION_TEST_NODE $env:ORCHESTRATION_TEST_WRAPPER',
+  ], {
+    cwd: fixture,
+    env: {
+      ...process.env,
+      ORCHESTRATION_TEST_COMPLETED_FILE: completedFile,
+      ORCHESTRATION_TEST_DELAY_MS: '2000',
+      ORCHESTRATION_TEST_NODE: process.execPath,
+      ORCHESTRATION_TEST_PID_FILE: pidFile,
+      ORCHESTRATION_TEST_STARTED_FILE: startedFile,
+      ORCHESTRATION_TEST_WRAPPER: join(scripts, 'run-tests.mjs'),
+    },
+    stdio: 'ignore',
+    windowsHide: true,
+  })
+  if (invoker.pid !== undefined) processRoots.push(invoker.pid)
+  await waitForPath(startedFile)
+  const vitestPid = Number(readFileSync(pidFile, 'utf8'))
+  processRoots.push(vitestPid)
+  expect(processIsAlive(vitestPid)).toBe(true)
+
+  invoker.kill('SIGKILL')
+  await waitUntil(
+    () => !processIsAlive(vitestPid),
+    `Vitest process ${vitestPid} survived its invoking PowerShell process`,
+  )
+  await new Promise((resolve) => setTimeout(resolve, 2_100))
+  expect(existsSync(completedFile)).toBe(false)
+
+  const contender = await run(
+    process.execPath,
+    [join(scripts, 'run-tests.mjs')],
+    fixture,
+    process.env,
+  )
+  expect(contender.status).toBe(0)
+  expect(contender.stderr).toBe('')
+})


### PR DESCRIPTION
## Features
- None

## Bug Fixes
- [Promotion] Terminal pull-request promotion retries are bounded and their states documented, so a promotion that keeps failing parks with a report instead of retrying forever.
- [Merge] A retired merge guard is reclaimable after a crash, a failed status-lock release recovers on the next poll, and reusing an integration worktree left dirty is rejected rather than built upon.
- [State] A fingerprint ledger survives a forge lookup failure instead of being emptied, process-registry I/O errors propagate rather than reading as an empty registry, and a pending orchestration dependency sync persists across a daemon restart.

## Security
- None

## Project Operations
- [Configuration] The scan-parallel ceiling now derives from the template's actual section count instead of a fixed cap of four (#319): `SCAN_PARALLEL` validates as a positive integer, a request above the section count clamps to it and reports both numbers, and the documentation drops the up-to-four wording.
- [Tests] The Windows cancellation suite is collected by platform through the platform-coverage arrangement (no `it.runIf` skips), the redundant per-platform suite count assertion is removed, and the merge-runner fixture awaits readiness instead of racing.
- [Documentation] Legacy merged-status reads and terminal promotion states are documented where the settings live.

## Risks
- The scan-parallel change removes a documented ceiling: a consumer that sets a large `SCAN_PARALLEL` now gets as many scans as its template has sections, with the clamp reported rather than silent. The default of 2 is unchanged.
- Verified for this branch: CI passes on ubuntu-latest and windows-latest; `npm run test:linux` passes in the container with 1005 tests and nothing skipped, and the platform-coverage report names the two Windows-only suites it could not run.
