### PR TITLE
feat: autonomous scan loop — 30 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ to select `project-<name>.ts`. You can instead give `PROJECT_ADAPTER` an explici
 it overrides the conventional path selected by `PROJECT`.
 
 An external `FORGE` or `RUNNER` selector may be a package specifier, file URL, absolute
-path, or path relative to the consumer repository root. A forge module exports a `Forge`
+path, or path relative to the consumer repository root. A repository-relative selector
+must begin with `./` or `../`; for example, use `./custom/runner.mjs`, because
+`custom/runner.mjs` is treated as a package specifier. A forge module exports a `Forge`
 as its default or `forge` export, or exports `createForge(repoRoot, report)`. A runner
 module likewise exports a `Runner` as its default or `runner` export, or exports
 `createRunner(options)`. Factories may be asynchronous.

--- a/SPEC.md
+++ b/SPEC.md
@@ -526,7 +526,9 @@ are not parsed by `loadConfig` and are not operator-file settings.
 
 29. All forge access goes through `adapters/forge.ts` (`FORGE=github` selects
     `forge-github.ts`; any other selector loads an external package, file URL, absolute
-    path, or consumer-repository-relative module). External modules export a `Forge`
+    path, or consumer-repository-relative module). A consumer-repository-relative
+    selector must begin with `./` or `../`; an unprefixed value such as
+    `custom/forge.mjs` remains a package specifier. External modules export a `Forge`
     as default or `forge`, or a `createForge(repoRoot, report)` factory, so gitea/gitlab
     implementations can be added without touching the core. The interface returns
     normalized values only: PR state plus check records with
@@ -545,8 +547,9 @@ are not parsed by `loadConfig` and are not operator-file settings.
     arbitration, and stale-lease reaping live in `src/issueQueue.ts` on those primitives.
 30. The runner is invoked only through `adapters/runner.ts` (`RUNNER=codex` selects
     `runner-codex.ts`; `RUNNER=claude` selects `runner-claude.ts`; any other selector
-    resolves like an external forge module). External modules export a `Runner` as default
-    or `runner`, or a `createRunner(options)` factory. The runner contract is
+    resolves like an external forge module, including the required `./` or `../` prefix
+    for a consumer-repository-relative module). External modules export a `Runner` as
+    default or `runner`, or a `createRunner(options)` factory. The runner contract is
     the output markers — `TASK_COMPLETE`,
     `NO_CHANGE_WARRANTED`, `NEXT_TASK:`, `DECISION_REQUIRED:` in the final-message file — plus effort/model
     arguments mapped to CLI flags, and the runner's own repository skill destination and

--- a/SPEC.md
+++ b/SPEC.md
@@ -405,7 +405,12 @@ are not parsed by `loadConfig` and are not operator-file settings.
     pending → keep polling; failure → generate a ci-fix task, up to
     `MAX_CI_FIX_ATTEMPTS`, then stop rather than poll a gate that cannot pass. A PR with
     zero checks remains unknown regardless of its age unless the project adapter
-    explicitly sets `ciChecksExpected: false`.
+    explicitly sets `ciChecksExpected: false`. Before generating a ci-fix task, the loop
+    persists its candidate task ID in a per-cycle pending-ID file. If enqueueing fails,
+    the pending ID remains while the attempt count and cycle-complete flag remain
+    unchanged; the next poll regenerates and retries the task with that same ID. A
+    successful enqueue records the attempt, clears the cycle-complete flag, and removes
+    the pending-ID file. Session cleanup also removes any remaining pending-ID file.
 17. Review: `AUTO_REVIEW=true` dispatches a review task reading the whole branch diff;
     before dispatch, the loop resolves the tracked remote's default branch and refreshes
     its remote ref. If either operation fails, the loop stops without dispatching a
@@ -428,6 +433,12 @@ are not parsed by `loadConfig` and are not operator-file settings.
     reviewed, and its rounds continue until one is clean, bounded by
     `MAX_FINAL_REVIEW_ROUNDS`; exceeding that stops the loop
     for a person instead of promoting a branch its own review keeps rejecting.
+    Before generating a review task, the loop persists its candidate task ID in a
+    per-cycle pending-ID file. If enqueueing fails, that pending ID remains and neither
+    the review round nor the dispatched review ID is recorded; the next gate pass
+    regenerates and retries the task with the same ID. A successful enqueue records the
+    round and dispatched ID, then removes the pending-ID file. Session cleanup also
+    removes any remaining pending-ID file.
     Review tasks commit nothing and are exempt from the merge commit check.
 18. After the final cycle passes the same gate, the PR is promoted from draft,
     unless it is already open and ready. A PR found merged before promotion, or merged

--- a/SPEC.md
+++ b/SPEC.md
@@ -608,11 +608,13 @@ are not parsed by `loadConfig` and are not operator-file settings.
     ref, and token. Run discovery is polled for at most five minutes; after discovery,
     only that run id is polled for at most thirty minutes. Both use five-second polling
     capped to the remaining deadline. The run must complete with conclusion `success`,
-    and the revision endpoint must return a successful response. Its trimmed body is
-    compared exactly with the run's `headSha`. The command reports the workflow success
-    and revision `PASS` or `FAIL`, and exits zero only for an exact revision match;
-    invalid usage, a missing deployment declaration, either timeout, an unsuccessful
-    workflow or revision response, and a revision mismatch exit non-zero.
+    and the revision endpoint must return a successful response. Fetching that response
+    and reading its body share a thirty-second deadline; reaching it aborts the request
+    and fails the command. The trimmed body is compared exactly with the run's `headSha`.
+    The command reports the workflow success and revision `PASS` or `FAIL`, and exits zero
+    only for an exact revision match; invalid usage, a missing deployment declaration,
+    any of the three timeouts, an unsuccessful workflow or revision response, and a
+    revision mismatch exit non-zero.
 
 ## The issue queue (new in the rewrite, opt-in)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -709,6 +709,13 @@ so authorship and verified ancestry must both hold.
     degrades a poll to local-only work. Persisted cleanup release failures are retried each
     poll and stop the loop after three consecutive failures. Labels are ensured at loop
     startup.
+    Promotion retry state is one JSON object per issue at
+    `queue/issue-promotion/<issueNumber>.json`. It requires non-empty string `taskId`,
+    numeric `issueNumber` equal to the filename's issue number, non-empty string
+    `mergeCommit`, and non-empty string `runBranch`; optional `commentConfirmed`, when
+    present, is boolean. Invalid JSON, a non-object value, or any schema violation is not
+    treated as absent state: issue reconciliation fails closed, leaves the record and issue
+    state unchanged for repair, and resumes only after the record is repaired.
     The daemon lists open `loop:finding` issues once per poll and partitions that snapshot
     locally for adoption, reconciliation, lease reaping, claiming, and cycle-gate idle
     detection. MERGED-marker comment reads are cached by issue number and `updatedAt`.
@@ -745,7 +752,9 @@ so authorship and verified ancestry must both hold.
     the project adapter's path-selected checks in a detached worktree, and merges with
     `--no-ff` and `closes #N` for every issue named by a grouped worker report. It persists
     a successful adoption for every member before updating the issues, so a later poll
-    retries failed metadata updates without merging again. A
+    retries failed metadata updates without merging again. These per-issue promotion
+    records use the schema and fail-closed repair behavior in item 35; malformed persisted
+    state stops reconciliation rather than permitting a duplicate merge or issue release. A
     successful adoption logs aligned `Merging` and `Merged` events keyed by the short
     task id, with the latter naming the first eight characters of the merge commit;
     promotion closes the issue. A failure logs the aligned `Failed` event with the short

--- a/SPEC.md
+++ b/SPEC.md
@@ -330,9 +330,13 @@ are not parsed by `loadConfig` and are not operator-file settings.
     missing, or unreadable adapter logs `Restarting adapter     for cycle <n>` and replaces
     the daemon before continuing, so every adapter consumer changes atomically at the same
     restart-safe boundary. In integration mode the monitored source is the adapter in the
-    integration worktree. The daemon then fetches the
-    configured core upstream and compares its tip with the last `git-subtree-split` for
-    this package's prefix. If it is behind, the daemon runs `git subtree pull --squash`.
+    integration worktree. The daemon then fetches the configured core upstream. It
+    recovers the imported revision by first matching the current subtree tree against
+    commit trees in the fetched upstream history, which preserves detection after a
+    squash-import commit is itself squash-merged. When no upstream tree matches, it falls
+    back to the last `git-subtree-split` whose `git-subtree-dir` matches this package's
+    prefix. It compares the recovered revision with the upstream tip and, if it is behind,
+    runs `git subtree pull --squash`.
     A package-file change logs an aligned `Updated    core        <old8>..<new8>` event.
     In direct layout only, it also logs `Restarting core        for cycle <n>`, releases
     daemon ownership, and starts the package's absolute CLI entry point from the package

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,6 +1,8 @@
 import { execFileSync, spawn, spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
-import { mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import {
+  mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync,
+} from 'node:fs'
 import { dirname, join, resolve, toNamespacedPath } from 'node:path'
 import { performance } from 'node:perf_hooks'
 
@@ -9,7 +11,7 @@ const lockName = '.orchestration-test-suite-lock'
 const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
 const retryMilliseconds = 250
 const unpublishedOwnerGraceMilliseconds = 30_000
-const maximumWaitMilliseconds = 10 * 60_000
+const maximumWaitMilliseconds = 15 * 60_000
 const windowsParentPollMilliseconds = 50
 
 function commonGitDirectory() {
@@ -26,6 +28,9 @@ function commonGitDirectory() {
 
 const lockDirectory = join(commonGitDirectory(), lockName)
 const ownerFile = join(lockDirectory, 'owner.json')
+const queueDirectory = `${lockDirectory}-queue`
+const ticketName = `${String(Date.now()).padStart(13, '0')}-${token}.json`
+const ticketFile = join(queueDirectory, ticketName)
 
 function processIsAlive(pid) {
   try {
@@ -150,6 +155,50 @@ function reclaimAbandonedLock() {
   removeDirectory(abandoned)
 }
 
+function removeQueueTicket(path) {
+  try {
+    unlinkSync(path)
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error
+  }
+}
+
+function queueTicketIsAlive(path) {
+  try {
+    const ticket = JSON.parse(readFileSync(path, 'utf8'))
+    if (
+      !Number.isSafeInteger(ticket.pid) || ticket.pid <= 0
+      || typeof ticket.processIdentity !== 'string' || ticket.processIdentity === ''
+    ) return false
+    const alive = processIsAlive(ticket.pid)
+    const currentIdentity = alive ? processIdentity(ticket.pid) : null
+    return alive && (currentIdentity === null || currentIdentity === ticket.processIdentity)
+  } catch {
+    try {
+      // A ticket is visible while its contents are being published. Only discard an
+      // unreadable record after the same grace period used for a new lock owner.
+      return Date.now() - statSync(path).mtimeMs < unpublishedOwnerGraceMilliseconds
+    } catch {
+      return false
+    }
+  }
+}
+
+function isFirstQueuedProcess() {
+  const tickets = readdirSync(queueDirectory)
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+  for (const queuedTicket of tickets) {
+    const path = join(queueDirectory, queuedTicket)
+    if (!queueTicketIsAlive(path)) {
+      removeQueueTicket(path)
+      continue
+    }
+    return queuedTicket === ticketName
+  }
+  return false
+}
+
 function waitForLockRetry(milliseconds, cancellationSignal) {
   if (cancellationSignal?.aborted) return Promise.resolve()
   if (cancellationSignal === undefined) {
@@ -177,41 +226,51 @@ async function acquireLock(cancellationSignal) {
   const waitLimit = Number.isSafeInteger(configuredMaximumWait) && configuredMaximumWait > 0
     ? Math.min(configuredMaximumWait, maximumWaitMilliseconds)
     : maximumWaitMilliseconds
-  for (;;) {
-    cancellationSignal?.throwIfAborted()
-    try {
-      mkdirSync(lockDirectory)
-      try {
-        const identity = processIdentity(process.pid)
-        if (identity === null) throw new Error('Unable to determine the test lock process identity.')
-        writeFileSync(ownerFile, `${JSON.stringify({
-          pid: process.pid,
-          token,
-          processIdentity: identity,
-          acquiredAt: new Date().toISOString(),
-          cwd: packageRoot,
-        })}\n`)
-      } catch (error) {
-        removeDirectory(lockDirectory)
-        throw error
-      }
-      return
-    } catch (error) {
-      if (error?.code !== 'EEXIST') throw error
-    }
+  const identity = processIdentity(process.pid)
+  if (identity === null) throw new Error('Unable to determine the test lock process identity.')
+  mkdirSync(queueDirectory, { recursive: true })
+  writeFileSync(ticketFile, `${JSON.stringify({ pid: process.pid, processIdentity: identity })}\n`, { flag: 'wx' })
+  try {
+    for (;;) {
+      cancellationSignal?.throwIfAborted()
+      let owner = { alive: false, diagnostic: 'lock not currently held' }
+      if (isFirstQueuedProcess()) {
+        try {
+          mkdirSync(lockDirectory)
+          try {
+            writeFileSync(ownerFile, `${JSON.stringify({
+              pid: process.pid,
+              token,
+              processIdentity: identity,
+              acquiredAt: new Date().toISOString(),
+              cwd: packageRoot,
+            })}\n`)
+          } catch (error) {
+            removeDirectory(lockDirectory)
+            throw error
+          }
+          return
+        } catch (error) {
+          if (error?.code !== 'EEXIST') throw error
+        }
 
-    const owner = readLockOwner()
-    if (!owner.alive) {
-      reclaimAbandonedLock()
-    } else if (!announced) {
-      console.log(`Another worktree is running the test suite; waiting for its repository lock (${owner.diagnostic}).`)
-      announced = true
+        owner = readLockOwner()
+        if (!owner.alive) reclaimAbandonedLock()
+      } else {
+        owner = readLockOwner()
+      }
+      if (owner.alive && !announced) {
+        console.log(`Another worktree is running the test suite; waiting for its repository lock (${owner.diagnostic}).`)
+        announced = true
+      }
+      const remainingWait = waitLimit - (performance.now() - waitStartedAt)
+      if (remainingWait <= 0) {
+        throw new Error(`Timed out after ${waitLimit}ms waiting for the repository test lock. Lock owner: ${owner.diagnostic}.`)
+      }
+      await waitForLockRetry(Math.min(retryMilliseconds, remainingWait), cancellationSignal)
     }
-    const remainingWait = waitLimit - (performance.now() - waitStartedAt)
-    if (remainingWait <= 0) {
-      throw new Error(`Timed out after ${waitLimit}ms waiting for the repository test lock. Lock owner: ${owner.diagnostic}.`)
-    }
-    await waitForLockRetry(Math.min(retryMilliseconds, remainingWait), cancellationSignal)
+  } finally {
+    removeQueueTicket(ticketFile)
   }
 }
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -150,7 +150,27 @@ function reclaimAbandonedLock() {
   removeDirectory(abandoned)
 }
 
-async function acquireLock() {
+function waitForLockRetry(milliseconds, cancellationSignal) {
+  if (cancellationSignal?.aborted) return Promise.resolve()
+  if (cancellationSignal === undefined) {
+    return new Promise((resolveWait) => setTimeout(resolveWait, milliseconds))
+  }
+  return new Promise((resolveWait) => {
+    const onCancel = () => {
+      clearTimeout(timer)
+      cancellationSignal.removeEventListener('abort', onCancel)
+      resolveWait()
+    }
+    const timer = setTimeout(() => {
+      cancellationSignal.removeEventListener('abort', onCancel)
+      resolveWait()
+    }, milliseconds)
+    cancellationSignal.addEventListener('abort', onCancel, { once: true })
+    if (cancellationSignal.aborted) onCancel()
+  })
+}
+
+async function acquireLock(cancellationSignal) {
   let announced = false
   const waitStartedAt = performance.now()
   const configuredMaximumWait = Number(process.env.ORCHESTRATION_TEST_LOCK_TIMEOUT_MS)
@@ -158,6 +178,7 @@ async function acquireLock() {
     ? Math.min(configuredMaximumWait, maximumWaitMilliseconds)
     : maximumWaitMilliseconds
   for (;;) {
+    cancellationSignal?.throwIfAborted()
     try {
       mkdirSync(lockDirectory)
       try {
@@ -190,9 +211,7 @@ async function acquireLock() {
     if (remainingWait <= 0) {
       throw new Error(`Timed out after ${waitLimit}ms waiting for the repository test lock. Lock owner: ${owner.diagnostic}.`)
     }
-    await new Promise((resolveWait) => setTimeout(
-      resolveWait, Math.min(retryMilliseconds, remainingWait),
-    ))
+    await waitForLockRetry(Math.min(retryMilliseconds, remainingWait), cancellationSignal)
   }
 }
 
@@ -258,14 +277,35 @@ async function runVitest(args, invokingPid) {
   }
 }
 
-if (process.argv[2] === '--windows-vitest-supervisor') {
-  const invokingPid = Number(process.argv[3])
-  if (!Number.isSafeInteger(invokingPid) || invokingPid <= 0) {
-    throw new Error('The Windows test supervisor requires an invoking process PID.')
+async function runTestSuite() {
+  const invokingPid = process.platform === 'win32' ? invokingWindowsShellPid() : undefined
+  const lockCancellation = invokingPid === undefined ? undefined : new AbortController()
+  const cancelIfParentExited = invokingPid === undefined ? undefined : () => {
+    if (!processIsAlive(invokingPid)) lockCancellation.abort()
   }
-  await runVitest(process.argv.slice(4), invokingPid)
-} else {
-  await acquireLock()
+  cancelIfParentExited?.()
+  const lockParentMonitor = invokingPid === undefined
+    ? undefined
+    : setInterval(cancelIfParentExited, windowsParentPollMilliseconds)
+  try {
+    await acquireLock(lockCancellation?.signal)
+    cancelIfParentExited?.()
+  } catch (error) {
+    if (!lockCancellation?.signal.aborted) throw error
+    console.error('Test suite stopped because its invoking process exited while waiting for the repository lock.')
+    process.exitCode = 1
+    return
+  } finally {
+    if (lockParentMonitor !== undefined) clearInterval(lockParentMonitor)
+  }
+
+  if (lockCancellation?.signal.aborted) {
+    releaseLock()
+    console.error('Test suite stopped because its invoking process exited while waiting for the repository lock.')
+    process.exitCode = 1
+    return
+  }
+
   let child
   const forwardSignal = (signal) => {
     if (child?.pid === undefined) return
@@ -281,7 +321,7 @@ if (process.argv[2] === '--windows-vitest-supervisor') {
     child = process.platform === 'win32'
       ? spawn(process.execPath, [
         import.meta.filename, '--windows-vitest-supervisor',
-        String(invokingWindowsShellPid()), ...args,
+        String(invokingPid), ...args,
       ], {
         cwd: packageRoot,
         stdio: 'inherit',
@@ -306,4 +346,14 @@ if (process.argv[2] === '--windows-vitest-supervisor') {
     process.removeListener('SIGTERM', forwardSignal)
     releaseLock()
   }
+}
+
+if (process.argv[2] === '--windows-vitest-supervisor') {
+  const invokingPid = Number(process.argv[3])
+  if (!Number.isSafeInteger(invokingPid) || invokingPid <= 0) {
+    throw new Error('The Windows test supervisor requires an invoking process PID.')
+  }
+  await runVitest(process.argv.slice(4), invokingPid)
+} else {
+  await runTestSuite()
 }

--- a/src/adapters/os-windows.ts
+++ b/src/adapters/os-windows.ts
@@ -134,7 +134,10 @@ function processTreePids(
     childrenByParent.set(parentPid, children)
   }
 
-  const treePids = new Set<number>()
+  // CIM can omit a process that is still alive while it builds the snapshot. Always
+  // retain the root so its direct probe, rather than its presence in the snapshot,
+  // decides whether the tree is alive and whether taskkill must be attempted.
+  const treePids = new Set<number>([rootPid])
   const visited = new Set<number>()
   const pending = [rootPid]
   while (pending.length > 0) {

--- a/src/adapters/os-windows.ts
+++ b/src/adapters/os-windows.ts
@@ -167,6 +167,11 @@ export function createOperatingSystem(
   const terminateProcessTree = (pid: number): boolean => {
     const trackedPids = processTreePids(runtime, pid)
     if (!anyProcessIsAlive(runtime, trackedPids)) return false
+    if (pid === process.pid || trackedPids?.has(process.pid)) {
+      throw new Error(
+        `Refusing to stop process tree ${pid} because it contains the current process ${process.pid}.`,
+      )
+    }
 
     try {
       runtime.spawn('taskkill', ['/PID', String(pid), '/T', '/F'])

--- a/src/adapters/windows-process.ts
+++ b/src/adapters/windows-process.ts
@@ -190,9 +190,11 @@ async function terminateLauncherTree(
   let trackedPids: ReadonlySet<number>
   try {
     trackedPids = launcherTreePids(runtime, launcher.pid)
-  } catch (error) {
-    runtime.requestLauncherTreeTermination(launcher)
-    throw error
+  } catch {
+    // Process enumeration can fail independently of taskkill. The launcher is the
+    // only PID available for a direct check in that case; do not trust taskkill's
+    // request status or discard the descriptor until that PID is confirmed gone.
+    trackedPids = new Set([launcher.pid])
   }
   if (!anyProcessIsAlive(runtime, trackedPids)) return false
 
@@ -207,6 +209,13 @@ async function terminateLauncherTree(
     throw new Error(`Could not stop Windows startup process tree ${launcher.pid}.`)
   }
   return true
+}
+
+class WindowsStartupProcessRetainedError extends Error {
+  constructor(stateDirectory: string, cause: unknown) {
+    super(`${errorSummary(cause)} Startup state was retained at ${stateDirectory}.`, { cause })
+    this.name = 'WindowsStartupProcessRetainedError'
+  }
 }
 
 const START_HIDDEN_PROCESS = [
@@ -282,6 +291,7 @@ export async function startWindowsProcess(
 
   let launcherError: Error | undefined
   let launched = false
+  let retainStartupState = false
   launcher.once('error', (error) => { launcherError = error })
   const deadline = runtime.now() + runtime.launchTimeoutMs
   try {
@@ -307,17 +317,25 @@ export async function startWindowsProcess(
       await runtime.sleep(runtime.launchPollMs)
     }
   } catch (error) {
-    const foundAlive = await terminateLauncherTree(runtime, launcher)
+    let foundAlive: boolean
+    try {
+      foundAlive = await terminateLauncherTree(runtime, launcher)
+    } catch (cleanupError) {
+      retainStartupState = true
+      throw new WindowsStartupProcessRetainedError(root, cleanupError)
+    }
     const detail = foundAlive ? 'found and terminated a live process tree' : 'found no live process tree'
     throw new Error(`${errorSummary(error)}; startup cleanup ${detail}`, { cause: error })
   } finally {
     if (!launched) launcher.kill()
-    try {
-      runtime.removeDirectory(root)
-    } catch (error) {
-      // Once the wrapper PID has been published, cleanup must not turn a live process
-      // into an unregistered launch. The OS temporary directory can be reclaimed later.
-      if (!launched) throw error
+    if (!retainStartupState) {
+      try {
+        runtime.removeDirectory(root)
+      } catch (error) {
+        // Once the wrapper PID has been published, cleanup must not turn a live process
+        // into an unregistered launch. The OS temporary directory can be reclaimed later.
+        if (!launched) throw error
+      }
     }
   }
 }

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -67,11 +67,11 @@ function stopTaskProcess(
   pid: number,
 ): void {
   const terminablePid = terminableTaskProcessPid(
-    paths, taskId, undefined, runtime.os.processStartIdentity, runtime.os.processIsAlive,
+    paths, taskId, undefined, runtime.os.processStartIdentity, runtime.os.processTreeIsAlive,
   )
   if (terminablePid === undefined) {
     const blockingPid = taskProcessPid(
-      paths, taskId, undefined, runtime.os.processStartIdentity, runtime.os.processIsAlive,
+      paths, taskId, undefined, runtime.os.processStartIdentity, runtime.os.processTreeIsAlive,
     )
     if (blockingPid !== undefined) {
       throw new Error(`Could not verify process ${blockingPid}; task state was retained.`)
@@ -82,9 +82,11 @@ function stopTaskProcess(
     throw new Error('Task process ownership changed; task state was retained.')
   }
   try {
-    if (runtime.os.terminateProcessTree(terminablePid)) {
-      console.log(`Stopping running process: pid=${terminablePid}`)
+    if (!runtime.os.terminateProcessTree(terminablePid)
+      || runtime.os.processTreeIsAlive(terminablePid)) {
+      throw new Error(`Process tree ${terminablePid} is still alive.`)
     }
+    console.log(`Stopping running process: pid=${terminablePid}`)
     forgetTaskProcess(paths, taskId)
   } catch {
     throw new Error(`Could not stop process ${terminablePid}; task state was retained.`)
@@ -104,13 +106,13 @@ export function cleanupTask(
   announce = true,
 ): void {
   const status = readStatus(
-    paths, taskId, runtime.os.processStartIdentity, runtime.os.processIsAlive,
+    paths, taskId, runtime.os.processStartIdentity, runtime.os.processTreeIsAlive,
   )
   // startTask records ownership before persisting status. A StartupProcessRetainedError
   // can therefore leave a live registry-only runner, which must be stopped before its
   // worktree can safely be removed.
   const pid = status?.pid ?? taskProcessPid(
-    paths, taskId, undefined, runtime.os.processStartIdentity, runtime.os.processIsAlive,
+    paths, taskId, undefined, runtime.os.processStartIdentity, runtime.os.processTreeIsAlive,
   )
   if (pid !== undefined) {
     stopTaskProcess(runtime, paths, taskId, pid)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1349,7 +1349,6 @@ async function runLoopDaemon(
     await loop.initializeIssueQueue()
 
     loop.initializeSessionStateForBranch()
-    loop.reportStrandedRunBranches()
     signalLoopRestartReady()
     ready()
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -302,9 +302,8 @@ export function loadConfig(
     ? undefined
     : options.filePath ?? defaultConfigFilePath()
   const report = options.onEvent ?? ((event: ConfigEvent) => console.error(event.message))
-  const environmentConfig = resolveConfig(env)
   let activeValues: ConfigFileValues = {}
-  let activeConfig = environmentConfig
+  let activeConfig!: LoopConfig
   let observedStamp: string | undefined
   let refreshError: Error | undefined
 

--- a/src/coreUpdate.ts
+++ b/src/coreUpdate.ts
@@ -10,7 +10,7 @@ import { sharedSkillManagedTargets, syncSharedSkills } from './sharedSkills.ts'
 export type CoreUpdateOutcome = 'continue' | 'restart'
 
 export type CoreUpdateEvent = (
-  name: 'Updated' | 'Restarting' | 'WARN',
+  name: 'Updated' | 'Restarting' | 'Status' | 'WARN',
   subject: string,
   detail?: string,
 ) => void
@@ -43,6 +43,23 @@ function importSplit(message: string, prefix: string): string | undefined {
   const dir = /^git-subtree-dir:\s*(.+?)\s*$/im.exec(message)?.[1]
   const split = /^git-subtree-split:\s*([0-9a-f]{7,64})\s*$/im.exec(message)?.[1]
   return dir === prefix ? split : undefined
+}
+
+function matchingUpstreamSplit(
+  repoRoot: string,
+  prefix: string,
+  upstream: string,
+  runtime: CoreUpdateRuntime,
+): string | undefined {
+  const subtreeTree = runtime.git(repoRoot, ['rev-parse', `HEAD:${prefix}`]).trim()
+  const commits = runtime.git(repoRoot, [
+    'log', '--format=%H%x09%T', upstream,
+  ]).split(/\r?\n/)
+  for (const commit of commits) {
+    const [revision, tree] = commit.split('\t')
+    if (revision !== undefined && tree === subtreeTree) return revision
+  }
+  return undefined
 }
 
 function warn(event: CoreUpdateEvent, message: string): void {
@@ -184,20 +201,6 @@ export async function updateCoreBeforeCycle(
     return finish('continue')
   }
 
-  let imported: string | undefined
-  try {
-    imported = importSplit(runtime.git(paths.repoRoot, [
-      'log', '-1', '--format=%B', `--grep=git-subtree-dir: ${prefix}`, '--fixed-strings',
-    ]), prefix)
-  } catch (error) {
-    warn(event, `core update check failed: ${summary(error)}`)
-    return finish('continue')
-  }
-  if (imported === undefined) {
-    warn(event, `core update skipped: ${prefix} has no git subtree import`)
-    return finish('continue')
-  }
-
   const remote = forge.resolveGitRemote(config.upstreamRemote.trim())
   try {
     runtime.git(paths.repoRoot, ['fetch', '--quiet', remote, config.upstreamBranch])
@@ -207,8 +210,24 @@ export async function updateCoreBeforeCycle(
   }
 
   let upstream: string
+  let imported: string | undefined
+  let recordedImport: string | undefined
   try {
     upstream = runtime.git(paths.repoRoot, ['rev-parse', 'FETCH_HEAD']).trim()
+    recordedImport = importSplit(runtime.git(paths.repoRoot, [
+      'log', '-1', '--format=%B', `--grep=git-subtree-dir: ${prefix}`, '--fixed-strings',
+    ]), prefix)
+    imported = matchingUpstreamSplit(paths.repoRoot, prefix, upstream, runtime)
+      ?? recordedImport
+  } catch (error) {
+    warn(event, `core update check failed: ${summary(error)}`)
+    return finish('continue')
+  }
+  if (imported === undefined) {
+    warn(event, `core update skipped: ${prefix} has no git subtree import`)
+    return finish('continue')
+  }
+  try {
     if (upstream !== imported) {
       runtime.git(paths.repoRoot, ['merge-base', '--is-ancestor', imported, upstream])
     }
@@ -219,20 +238,37 @@ export async function updateCoreBeforeCycle(
   }
   if (upstream === imported) return finish('continue')
 
+  const behind = (reason: string): void => {
+    event(
+      'Status',
+      'core',
+      `behind imported ${imported.slice(0, 8)} upstream ${upstream.slice(0, 8)}; ${reason}`,
+    )
+  }
+
   let dirty: boolean
   try {
     dirty = runtime.git(paths.repoRoot, ['status', '--porcelain']).trim() !== ''
   } catch (error) {
     warn(event, `core update status check failed: ${summary(error)}`)
+    behind('continuing on old code')
     return finish('continue')
   }
   if (dirty) {
     warn(event, 'core update skipped: working tree is dirty')
+    behind('continuing on old code: working tree is dirty')
     return finish('continue')
   }
 
   const oldHead = runtime.git(paths.repoRoot, ['rev-parse', 'HEAD']).trim()
+  const needsImportBridge = recordedImport !== imported
   try {
+    if (needsImportBridge) {
+      runtime.git(paths.repoRoot, [
+        'commit', '--allow-empty', '-m', 'chore: record core subtree import',
+        '-m', `git-subtree-dir: ${prefix}\ngit-subtree-split: ${imported}`,
+      ])
+    }
     runtime.git(paths.repoRoot, [
       'subtree', 'pull', `--prefix=${prefix}`, remote, config.upstreamBranch, '--squash',
     ])
@@ -245,6 +281,7 @@ export async function updateCoreBeforeCycle(
         + `pull failure: ${summary(error)}`,
       )
     }
+    if (needsImportBridge) runtime.git(paths.repoRoot, ['reset', '--soft', oldHead])
     let recoveredHead: string
     let recoveredStatus: string
     try {
@@ -264,6 +301,7 @@ export async function updateCoreBeforeCycle(
       )
     }
     warn(event, `core update pull conflicted; continuing on old code: ${summary(error)}`)
+    behind('continuing on old code: pull conflicted')
     return finish('continue')
   }
 
@@ -272,7 +310,10 @@ export async function updateCoreBeforeCycle(
   const changed = runtime.git(paths.repoRoot, [
     'diff', '--name-only', oldHead, newHead, '--', prefix,
   ]).trim()
-  if (changed === '') return 'continue'
+  if (changed === '') {
+    behind('continuing on old code: pull did not change the subtree')
+    return 'continue'
+  }
 
   event('Updated', 'core', `${imported.slice(0, 8)}..${upstream.slice(0, 8)}`)
   // The updated source belongs to the integration branch. This daemon deliberately

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -16,7 +16,10 @@ export interface DeploymentResponse {
   text(): Promise<string>
 }
 
-export type DeploymentFetcher = (url: string) => Promise<DeploymentResponse>
+export type DeploymentFetcher = (
+  url: string,
+  options?: { signal?: AbortSignal },
+) => Promise<DeploymentResponse>
 
 export interface DeploymentResult {
   run: WorkflowRun
@@ -32,6 +35,7 @@ const systemClock: DeploymentClock = {
 
 const DEFAULT_DISCOVERY_TIMEOUT_MS = 5 * 60_000
 const DEFAULT_COMPLETION_TIMEOUT_MS = 30 * 60_000
+const DEFAULT_REVISION_TIMEOUT_MS = 30_000
 
 /** Dispatch, identify, and verify one deployment by identities unique to this request. */
 export async function deploy(
@@ -44,6 +48,7 @@ export async function deploy(
     pollMilliseconds?: number
     discoveryTimeoutMilliseconds?: number
     completionTimeoutMilliseconds?: number
+    revisionTimeoutMilliseconds?: number
     now?: () => number
     createDispatchToken?: () => string
   } = {},
@@ -55,6 +60,8 @@ export async function deploy(
     ?? DEFAULT_DISCOVERY_TIMEOUT_MS
   const completionTimeoutMilliseconds = options.completionTimeoutMilliseconds
     ?? DEFAULT_COMPLETION_TIMEOUT_MS
+  const revisionTimeoutMilliseconds = options.revisionTimeoutMilliseconds
+    ?? DEFAULT_REVISION_TIMEOUT_MS
   const now = options.now ?? Date.now
   const dispatchToken = (options.createDispatchToken ?? randomUUID)()
 
@@ -90,11 +97,29 @@ export async function deploy(
     throw new Error(`Deployment workflow run ${run.id} finished with conclusion '${run.conclusion ?? 'unknown'}'.`)
   }
 
-  const response = await fetcher(deployment.revisionUrl)
-  if (!response.ok) {
-    throw new Error(`Deployment verification request failed with HTTP ${response.status}.`)
+  const controller = new AbortController()
+  let rejectTimeout: (error: Error) => void = () => {}
+  const timeout = new Promise<never>((_resolve, reject) => { rejectTimeout = reject })
+  const timeoutHandle = setTimeout(() => {
+    controller.abort()
+    rejectTimeout(new Error(
+      `Timed out after ${revisionTimeoutMilliseconds}ms fetching deployed revision from '${deployment.revisionUrl}'.`,
+    ))
+  }, revisionTimeoutMilliseconds)
+
+  let deployedRevision: string
+  try {
+    const response = await Promise.race([
+      fetcher(deployment.revisionUrl, { signal: controller.signal }),
+      timeout,
+    ])
+    if (!response.ok) {
+      throw new Error(`Deployment verification request failed with HTTP ${response.status}.`)
+    }
+    deployedRevision = (await Promise.race([response.text(), timeout])).trim()
+  } finally {
+    clearTimeout(timeoutHandle)
   }
-  const deployedRevision = (await response.text()).trim()
 
   return {
     run,

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process'
 import {
   existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync,
 } from 'node:fs'
-import { basename, dirname, join, relative, resolve } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import type { Forge } from './adapters/forge.ts'
 import { renderProjectAdapter, repairProjectAdapterSource } from './adapters/project.ts'
 import { ensureQueueLabels, QUEUE_LABELS } from './issueQueue.ts'
@@ -55,6 +55,9 @@ function currentGitConfig(git: (args: string[]) => string, key: string): string 
 
 function relativeImport(fromDirectory: string, target: string): string {
   const path = relative(fromDirectory, target).replaceAll('\\', '/')
+  if (isAbsolute(path)) {
+    throw new Error('The orchestration package and repository must be on the same filesystem volume.')
+  }
   return path.startsWith('.') ? path : `./${path}`
 }
 
@@ -70,8 +73,25 @@ export async function initializeRepository(
   const projectName = projectSlug(requestedName ?? basename(paths.repoRoot))
   let ok = true
 
-  mkdirSync(paths.root, { recursive: true })
   const projectDirectory = join(paths.root, 'project')
+  const typeImport = relativeImport(
+    projectDirectory,
+    join(packageRoot, 'src', 'adapters', 'project.ts'),
+  )
+  const hooksDirectory = join(packageRoot, '.githooks')
+  const hooksPath = relative(paths.repoRoot, hooksDirectory).replaceAll('\\', '/') || '.'
+  if (isAbsolute(hooksPath)) {
+    throw new Error('The orchestration package and repository must be on the same filesystem volume.')
+  }
+  if (hooksPath === '..' || hooksPath.startsWith('../')) {
+    throw new Error('The orchestration package must be inside the repository before init runs.')
+  }
+  if (!existsSync(join(hooksDirectory, 'commit-msg'))
+    || !existsSync(join(hooksDirectory, 'pre-commit'))) {
+    throw new Error(`Core-owned hooks are missing from ${hooksDirectory}.`)
+  }
+
+  mkdirSync(paths.root, { recursive: true })
   mkdirSync(projectDirectory, { recursive: true })
   const existingAdapters = readdirSync(projectDirectory, { withFileTypes: true })
     .filter((entry) => entry.isFile() && /^project-.+\.ts$/.test(entry.name))
@@ -79,10 +99,6 @@ export async function initializeRepository(
     .sort()
   let adapterPath = join(projectDirectory, `project-${projectName}.ts`)
   if (existingAdapters.length === 0) {
-    const typeImport = relativeImport(
-      projectDirectory,
-      join(packageRoot, 'src', 'adapters', 'project.ts'),
-    )
     writeFileSync(adapterPath, renderProjectAdapter(projectName, typeImport))
     report(`CREATED: ${adapterPath}`)
   } else {
@@ -122,15 +138,6 @@ export async function initializeRepository(
     report(`CREATED: ${destination}`)
   }
 
-  const hooksDirectory = join(packageRoot, '.githooks')
-  if (!existsSync(join(hooksDirectory, 'commit-msg'))
-    || !existsSync(join(hooksDirectory, 'pre-commit'))) {
-    throw new Error(`Core-owned hooks are missing from ${hooksDirectory}.`)
-  }
-  const hooksPath = relative(paths.repoRoot, hooksDirectory).replaceAll('\\', '/') || '.'
-  if (hooksPath === '..' || hooksPath.startsWith('../')) {
-    throw new Error('The orchestration package must be inside the repository before init runs.')
-  }
   const configuredHooksPath = currentGitConfig(git, 'core.hooksPath')
   if (configuredHooksPath === '') {
     git(['config', '--local', 'core.hooksPath', hooksPath])

--- a/src/issueQueue.ts
+++ b/src/issueQueue.ts
@@ -1202,18 +1202,28 @@ export function issuePromotionForIssue(
 ): IssuePromotion | undefined {
   const file = promotionFile(paths, issueNumber)
   if (!existsSync(file)) return undefined
+  const malformed = (cause?: unknown): Error => new Error(
+    `Malformed issue promotion record ${file}; repair this file before issue reconciliation can continue`,
+    cause === undefined ? undefined : { cause },
+  )
+  let parsed: unknown
   try {
-    const value = JSON.parse(readFileSync(file, 'utf8')) as Partial<IssuePromotion>
-    if (typeof value.taskId !== 'string'
-      || value.issueNumber !== issueNumber
-      || typeof value.mergeCommit !== 'string'
-      || value.mergeCommit === ''
-      || typeof value.runBranch !== 'string'
-      || value.runBranch === '') return undefined
-    return value as IssuePromotion
-  } catch {
-    return undefined
+    parsed = JSON.parse(readFileSync(file, 'utf8'))
+  } catch (error) {
+    throw malformed(error)
   }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) throw malformed()
+  const value = parsed as Partial<IssuePromotion>
+  if (typeof value.taskId !== 'string'
+    || value.taskId === ''
+    || value.issueNumber !== issueNumber
+    || typeof value.mergeCommit !== 'string'
+    || value.mergeCommit === ''
+    || typeof value.runBranch !== 'string'
+    || value.runBranch === ''
+    || (value.commentConfirmed !== undefined
+      && typeof value.commentConfirmed !== 'boolean')) throw malformed()
+  return value as IssuePromotion
 }
 
 /** Persist the merge identity independently of task status until promotion closes its issue. */

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1255,6 +1255,7 @@ export function createLoop(deps: LoopDeps) {
   function runAutoReview(cycle: number, isFinal: boolean): boolean {
     const roundFile = join(paths.queueDir, `review-round-${cycle}`)
     const idFile = join(paths.queueDir, `review-id-${cycle}`)
+    const pendingIdFile = join(paths.queueDir, `review-pending-id-${cycle}`)
 
     if (!isFinal && cycle % config.reviewEveryNCycles !== 0) {
       return true
@@ -1294,7 +1295,11 @@ export function createLoop(deps: LoopDeps) {
     }
 
     const prUrl = existsSync(prUrlFile) ? readFileSync(prUrlFile, 'utf8').trim() : ''
-    const reviewId = newTaskId(paths, `review-c${cycle}`, now())
+    const pendingId = existsSync(pendingIdFile)
+      ? readFileSync(pendingIdFile, 'utf8').replace(/[\s\r\n]/g, '')
+      : ''
+    const reviewId = pendingId || newTaskId(paths, `review-c${cycle}`, now())
+    if (pendingId === '') writeFileSync(pendingIdFile, `${reviewId}\n`)
     if (!generateReviewTask(reviewId, cycle, prUrl)) {
       event('Stopped', 'Loop', 'review base unavailable')
       writeFileSync(stopFile, '')
@@ -1314,12 +1319,13 @@ export function createLoop(deps: LoopDeps) {
     // being able to perform it, so keep them behind the enqueue boundary.
     writeFileSync(roundFile, `${rounds + 1}\n`)
     writeFileSync(idFile, `${reviewId}\n`)
+    rmSync(pendingIdFile, { force: true })
     return false
   }
 
   function cleanupSessionState(preserveTaskMarkers = false): void {
     for (const name of readdirSync(paths.queueDir)) {
-      if (/^(cycle-complete-|cycle-suite-tip-|cycle-resume-|ci-fix-emitted-|review-round-|review-id-|failed-|scan-yield-|scan-expected-)/.test(name)
+      if (/^(cycle-complete-|cycle-suite-tip-|cycle-resume-|ci-fix-emitted-|ci-fix-pending-id-|review-round-|review-id-|review-pending-id-|failed-|scan-yield-|scan-expected-)/.test(name)
         || name === 'decisions.txt' || name === 'pr-url.txt'
         || name === 'empty-scan-count.txt' || name === 'merge-failure-count.txt') {
         rmSync(join(paths.queueDir, name), { force: true })
@@ -1539,8 +1545,13 @@ export function createLoop(deps: LoopDeps) {
     return 'success'
   }
 
-  function generateCiFixTask(cycle: number, prUrl: string, failSummary: string): void {
-    const fixId = newTaskId(paths, `ci-fix-c${cycle}`, now())
+  function generateCiFixTask(cycle: number, prUrl: string, failSummary: string): string {
+    const pendingIdFile = join(paths.queueDir, `ci-fix-pending-id-${cycle}`)
+    const pendingId = existsSync(pendingIdFile)
+      ? readFileSync(pendingIdFile, 'utf8').replace(/[\s\r\n]/g, '')
+      : ''
+    const fixId = pendingId || newTaskId(paths, `ci-fix-c${cycle}`, now())
+    if (pendingId === '') writeFileSync(pendingIdFile, `${fixId}\n`)
     const text = repositoryInspectionPreamble() + renderTemplate('ci-fix-template.md', {
       FIX_ID: fixId,
       CYCLE: String(cycle),
@@ -1551,6 +1562,7 @@ export function createLoop(deps: LoopDeps) {
     })
     writeFileSync(specFile(paths, fixId), text)
     enqueueTaskImpl(paths, fixId, 0)
+    return pendingIdFile
   }
 
   /** After the final gate: promote the draft PR and print LOOP_DONE. */
@@ -1896,13 +1908,15 @@ export function createLoop(deps: LoopDeps) {
             } catch {
               failSummary = ''
             }
+            let pendingIdFile: string
             try {
-              generateCiFixTask(currentScans, prUrl, failSummary)
+              pendingIdFile = generateCiFixTask(currentScans, prUrl, failSummary)
             } catch (error) {
               event('WARN', `could not enqueue CI fix: ${errorSummary(error)}`)
               return 'continue'
             }
             writeFileSync(ciFixFlag, `${attempts + 1}\n`)
+            rmSync(pendingIdFile, { force: true })
             rmSync(completeFlag, { force: true })
           } else {
             event('ERROR', `CI still failing after ${attempts} fixes; stopping the loop`)

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1361,96 +1361,6 @@ export function createLoop(deps: LoopDeps) {
     writeFileSync(runBranchFile, `${currentBranch}\n`)
   }
 
-  /**
-   * Warn about earlier branches from the same integration-run series which still carry
-   * commits absent from the advertised default branch. Remote objects are fetched
-   * without a destination ref, so this observation never creates, advances, or deletes
-   * a branch.
-   */
-  function reportStrandedRunBranches(): void {
-    try {
-      const currentBranch = gitIn(paths.repoRoot, ['branch', '--show-current']).trim()
-      const runName = /^(.*(?:^|\/)loop-)\d{8}(-.+-run)\d+$/.exec(currentBranch)
-      if (runName === null) return
-
-      const escapeRegex = (value: string): string =>
-        value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      const runBranchPattern = new RegExp(
-        `^${escapeRegex(runName[1]!)}\\d{8}${escapeRegex(runName[2]!)}\\d+$`,
-      )
-      const remote = currentBranchTrackingRemote(paths.repoRoot)
-      const remoteListing = gitIn(paths.repoRoot, [
-        'ls-remote', '--symref', remote, 'HEAD', 'refs/heads/*',
-      ])
-      const defaultBranch = /^ref: refs\/heads\/(.+)\tHEAD$/m.exec(remoteListing)?.[1]
-      if (defaultBranch === undefined) {
-        throw new Error(`${remote} does not advertise a default branch`)
-      }
-
-      const tips = new Map<string, Set<string>>()
-      const addTip = (branch: string, tip: string): void => {
-        if (branch === currentBranch || !runBranchPattern.test(branch)) return
-        const branchTips = tips.get(branch) ?? new Set<string>()
-        branchTips.add(tip)
-        tips.set(branch, branchTips)
-      }
-      for (const branch of gitIn(paths.repoRoot, [
-        'for-each-ref', '--format=%(refname:short)', 'refs/heads/',
-      ]).split(/\r?\n/).filter(Boolean)) {
-        addTip(branch, branch)
-      }
-
-      const remoteHeads = new Map<string, string>()
-      for (const line of remoteListing.split(/\r?\n/)) {
-        const match = /^([0-9a-fA-F]+)\trefs\/heads\/(.+)$/.exec(line)
-        if (match === null) continue
-        remoteHeads.set(match[2]!, match[1]!)
-        addTip(match[2]!, match[1]!)
-      }
-      const defaultTip = remoteHeads.get(defaultBranch)
-      if (defaultTip === undefined) {
-        throw new Error(`could not resolve ${remote}/${defaultBranch}`)
-      }
-
-      const requiredObjects = new Set([defaultTip, ...[...tips.values()].flatMap((refs) =>
-        [...refs].filter((ref) => /^[0-9a-fA-F]+$/.test(ref)))])
-      const missingObjects = [...requiredObjects].filter((object) => {
-        try {
-          gitIn(paths.repoRoot, ['cat-file', '-e', `${object}^{commit}`])
-          return false
-        } catch {
-          return true
-        }
-      })
-      if (missingObjects.length > 0) {
-        gitIn(paths.repoRoot, [
-          'fetch', '--no-tags', '--no-write-fetch-head', remote,
-          ...missingObjects,
-        ])
-      }
-
-      for (const [branch, branchTips] of [...tips].sort(([left], [right]) =>
-        left.localeCompare(right))) {
-        try {
-          const counts = [...branchTips].map((tip) => Number(gitIn(
-            paths.repoRoot, ['rev-list', '--count', `${defaultTip}..${tip}`],
-          ).trim()))
-          const count = Math.max(...counts)
-          if (count > 0) {
-            event(
-              'WARN',
-              `stranded run branch ${branch} has ${count} commit${count === 1 ? '' : 's'} not on ${defaultBranch}`,
-            )
-          }
-        } catch (error) {
-          event('WARN', `stranded run branch ${branch} could not be checked; continuing: ${errorSummary(error)}`)
-        }
-      }
-    } catch (error) {
-      event('WARN', `stranded run branch check failed; continuing: ${errorSummary(error)}`)
-    }
-  }
-
   /** Fail startup before work begins when this run can never publish its branch. */
   function validatePushTarget(): boolean {
     if (!config.autoPr && !config.workerMode) return true
@@ -2734,7 +2644,6 @@ export function createLoop(deps: LoopDeps) {
     initializeIssueQueue,
     validatePushTarget,
     initializeSessionStateForBranch,
-    reportStrandedRunBranches,
     cleanupSessionState,
     restartSubject: () => restartSubject,
     // exported for tests

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -388,13 +388,13 @@ export function createLoop(deps: LoopDeps) {
     return count
   }
 
-  function git(args: string[], quietSuccess = ''): string {
+  function git(args: string[]): string {
+    return gitIn(paths.repoRoot, args)
+  }
+
+  function optionalGit(args: string[], quietSuccess = ''): string {
     try {
-      const output = execFileSync('git', args, {
-        cwd: paths.repoRoot, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        windowsHide: true,
-      })
+      const output = git(args)
       return output === '' ? quietSuccess : output
     } catch {
       return ''
@@ -417,7 +417,7 @@ export function createLoop(deps: LoopDeps) {
     // The comparison base is the checkout's HEAD SHA, not its branch name: a detached
     // worker checkout has an empty branch name, which read as zero commits and left
     // completed work permanently unpublished.
-    const baseSha = git(['rev-parse', 'HEAD']).trim()
+    const baseSha = optionalGit(['rev-parse', 'HEAD']).trim()
     if (gitIn(worktree, ['status', '--porcelain']).trim() !== '') {
       throw new Error(`${taskId} has uncommitted changes`)
     }
@@ -564,7 +564,7 @@ export function createLoop(deps: LoopDeps) {
           throw new MergeError(`Could not fetch ${report.branch} from ${remote}.`)
         }
 
-        const runBranch = git(['branch', '--show-current']).trim()
+        const runBranch = optionalGit(['branch', '--show-current']).trim()
         let appliedMergeCommit: string | undefined
         let promotionPersistenceError: unknown
         const persistPromotion = (mergedCommit: string): void => {
@@ -1188,12 +1188,12 @@ export function createLoop(deps: LoopDeps) {
     }
 
     const remotePrefix = `${remote}/`
-    let baseBranch = git([
+    let baseBranch = optionalGit([
       'symbolic-ref', '--quiet', '--short', `refs/remotes/${remote}/HEAD`,
     ]).trim()
     if (!baseBranch.startsWith(remotePrefix)
-      || git(['rev-parse', '--verify', `${baseBranch}^{commit}`]).trim() === '') {
-      const advertised = git(['ls-remote', '--symref', remote, 'HEAD'])
+      || optionalGit(['rev-parse', '--verify', `${baseBranch}^{commit}`]).trim() === '') {
+      const advertised = optionalGit(['ls-remote', '--symref', remote, 'HEAD'])
       const branch = /^ref: refs\/heads\/(.+)\tHEAD$/m.exec(advertised)?.[1] ?? ''
       baseBranch = branch === '' ? '' : `${remote}/${branch}`
     }
@@ -1208,7 +1208,7 @@ export function createLoop(deps: LoopDeps) {
       }
     }
     if (!baseBranch.startsWith(remotePrefix)
-      || git(['rev-parse', '--verify', `${baseBranch}^{commit}`]).trim() === '') {
+      || optionalGit(['rev-parse', '--verify', `${baseBranch}^{commit}`]).trim() === '') {
       event('WARN', `could not resolve a valid default branch for ${remote}`)
       return false
     }
@@ -1472,7 +1472,7 @@ export function createLoop(deps: LoopDeps) {
   /** Push the branch and create or update the draft PR. Returns false when it must retry. */
   async function ensureDraftPr(mode: 'cycle' | 'final'): Promise<boolean> {
     emptyRun = false
-    const branch = git(['branch', '--show-current']).trim()
+    const branch = optionalGit(['branch', '--show-current']).trim()
     if (branch === '') {
       reportGateFailure('could not get branch name; PR skipped', true)
       return false
@@ -1482,7 +1482,7 @@ export function createLoop(deps: LoopDeps) {
     try {
       pushRemote = currentBranchPushRemote(paths.repoRoot)
       baseRemote = currentBranchTrackingRemote(paths.repoRoot)
-      const hasUpstream = git([
+      const hasUpstream = optionalGit([
         'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}',
       ]).trim() !== ''
       execFileSync('git', [
@@ -1497,7 +1497,7 @@ export function createLoop(deps: LoopDeps) {
       return false
     }
 
-    const baseRef = git([
+    const baseRef = optionalGit([
       'symbolic-ref', '--quiet', '--short', `refs/remotes/${baseRemote}/HEAD`,
     ]).trim()
     if (!baseRef.startsWith(`${baseRemote}/`)) {
@@ -1653,7 +1653,7 @@ export function createLoop(deps: LoopDeps) {
     }
     const prUrl = existsSync(prUrlFile) ? readFileSync(prUrlFile, 'utf8').trim() : ''
     if (prUrl === '') return false
-    const branch = git(['branch', '--show-current']).trim()
+    const branch = optionalGit(['branch', '--show-current']).trim()
     let status
     try {
       status = await forge.prStatus({ kind: 'branch', value: branch })
@@ -1864,7 +1864,7 @@ export function createLoop(deps: LoopDeps) {
               .filter((comment) => comment.author.hasWriteAccess)
               .map((comment) => /^MERGED: [^\r\n]+\r?\nMerged as ([0-9a-f]{40,64}) into run branch /i.exec(comment.body)?.[1])
               .find((sha) => sha !== undefined
-                && git(['merge-base', '--is-ancestor', sha, 'HEAD'], 'ancestor') === 'ancestor')
+                && optionalGit(['merge-base', '--is-ancestor', sha, 'HEAD'], 'ancestor') === 'ancestor')
             if (mergeSha !== undefined) continue
           } catch (error) {
             if (error instanceof ForgeRateLimitError) return 'continue'
@@ -1943,7 +1943,7 @@ export function createLoop(deps: LoopDeps) {
             }
           }
 
-          const currentTip = git(['rev-parse', 'HEAD']).trim()
+          const currentTip = optionalGit(['rev-parse', 'HEAD']).trim()
           const cycleSuiteEnabled = cycleSuiteEnabledForTaskGate()
           const suitePassedForTip = cycleSuiteEnabled
             && currentTip !== ''
@@ -2136,7 +2136,7 @@ export function createLoop(deps: LoopDeps) {
       writeFileSync(stopFile, '')
       return 'stopped'
     }
-    const currentBranch = git(['branch', '--show-current']).trim()
+    const currentBranch = optionalGit(['branch', '--show-current']).trim()
     const recordedBranch = existsSync(runBranchFile)
       ? readFileSync(runBranchFile, 'utf8').replace(/[\r\n]/g, '')
       : ''
@@ -2261,7 +2261,7 @@ export function createLoop(deps: LoopDeps) {
         event('Merged', shortTaskId(taskId), `commit ${mergeCommit.slice(0, 8)}`)
         writeFileSync(mergeFailureFile, '0\n')
         if (linkedIssues.length > 0) {
-          const runBranch = git(['branch', '--show-current']).trim()
+          const runBranch = optionalGit(['branch', '--show-current']).trim()
           await reconcileMergedIssues(taskId, linkedIssues, mergeCommit, runBranch)
         }
         // A task delegated while the gate was waiting merges commits the gate has

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -16,7 +16,7 @@ import {
   shortTaskId,
 } from './ids.ts'
 import {
-  completeTaskWithoutChanges, mergeRemoteTask, mergeTask, MergeError,
+  completeTaskWithoutChanges, mergeRemoteTask, mergeTask, MergeError, MergeRecoveryError,
   NoChangeReconciliationError, RebaseConflictError,
   OrchestrationDepsInstallError,
   type OrchestrationDepsRuntime,
@@ -629,7 +629,9 @@ export function createLoop(deps: LoopDeps) {
         if (error instanceof ForgeRateLimitError) return
         const message = error instanceof Error ? error.message : String(error)
         appendFileSync(mergeLog, `${message}\n`)
-        if (error instanceof OrchestrationDepsInstallError) throw error
+        if (error instanceof OrchestrationDepsInstallError || error instanceof MergeRecoveryError) {
+          throw error
+        }
         if (adoptionTaskId === undefined) {
           event('WARN', `remote adoption failed for issue #${issue.number}`)
         } else {
@@ -2276,7 +2278,9 @@ export function createLoop(deps: LoopDeps) {
           return
         }
         if (error instanceof MergeError) appendFileSync(mergeLog, `${error.message}\n`)
-        if (error instanceof OrchestrationDepsInstallError) throw error
+        if (error instanceof OrchestrationDepsInstallError || error instanceof MergeRecoveryError) {
+          throw error
+        }
         event('Failed', shortTaskId(taskId), `log ${shortLogPath(mergeLog)}`)
         if (error instanceof RebaseConflictError) {
           noteMergeFailure(mergeLog)

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -42,6 +42,13 @@ export class NoChangeReconciliationError extends MergeError {}
 /** A fatal dependency mismatch: continuing would run orchestration on the wrong tree. */
 export class OrchestrationDepsInstallError extends MergeError {}
 
+/** A failed merge left repository state that is not proven safe for another attempt. */
+export class MergeRecoveryError extends MergeError {}
+
+export interface MergeRuntime {
+  git: (cwd: string, args: string[]) => string
+}
+
 export interface MergeOptions {
   /** Explicit test command; overrides the project's check selection. */
   testCmd?: string | undefined
@@ -75,6 +82,8 @@ export interface MergeOptions {
   onMergeStart?: (() => void) | undefined
   /** Report an idempotent attempt without treating it as a merge failure. */
   onMergeSkipped?: ((reason: 'active' | 'succeeded') => void) | undefined
+  /** Merge command implementation; tests replace it to exercise recovery failures. */
+  mergeRuntime?: MergeRuntime | undefined
 }
 
 export interface RemoteMergeOptions extends MergeOptions {
@@ -358,6 +367,83 @@ function git(cwd: string, args: string[]): string {
     cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, windowsHide: true,
     stdio: ['ignore', 'pipe', 'pipe'],
   })
+}
+
+interface MergeRepositoryState {
+  head: string
+  status: string
+  mergeInProgress: boolean
+}
+
+function mergeRepositoryState(cwd: string, runtime: MergeRuntime): MergeRepositoryState {
+  return {
+    head: runtime.git(cwd, ['rev-parse', 'HEAD']).trim(),
+    status: runtime.git(cwd, ['status', '--porcelain']),
+    mergeInProgress: mergeIsInProgress(cwd, runtime),
+  }
+}
+
+function mergeIsInProgress(cwd: string, runtime: MergeRuntime): boolean {
+  const gitPath = runtime.git(cwd, ['rev-parse', '--git-path', 'MERGE_HEAD']).trim()
+  const mergeHead = isAbsolute(gitPath) ? gitPath : resolve(cwd, gitPath)
+  try {
+    statSync(mergeHead)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
+}
+
+function mergeWithVerifiedRecovery(
+  cwd: string,
+  args: string[],
+  conflictMessage: string,
+  runtime: MergeRuntime,
+): void {
+  const before = mergeRepositoryState(cwd, runtime)
+  if (before.mergeInProgress) {
+    throw new MergeRecoveryError(
+      'The integration worktree already has a merge in progress. '
+      + 'Inspect and restore it before restarting orchestration.',
+    )
+  }
+  try {
+    runtime.git(cwd, args)
+    return
+  } catch (mergeError) {
+    let abortError: unknown
+    try {
+      runtime.git(cwd, ['merge', '--abort'])
+    } catch (error) {
+      abortError = error
+    }
+
+    let recovered: MergeRepositoryState
+    try {
+      recovered = mergeRepositoryState(cwd, runtime)
+    } catch (verificationError) {
+      throw new MergeRecoveryError(
+        `${conflictMessage} Recovery could not be verified: ${installFailureSummary(verificationError)}; `
+        + `merge abort ${abortError === undefined ? 'reported success' : `failed: ${installFailureSummary(abortError)}`}. `
+        + `Merge failure: ${installFailureSummary(mergeError)}. `
+        + 'Inspect and restore the integration worktree before restarting orchestration.',
+      )
+    }
+    if (recovered.head !== before.head || recovered.status !== before.status
+      || recovered.mergeInProgress !== before.mergeInProgress) {
+      throw new MergeRecoveryError(
+        `${conflictMessage} Merge recovery did not restore the integration worktree: expected HEAD `
+        + `${before.head.slice(0, 8)}, found ${recovered.head.slice(0, 8)}; `
+        + `working tree ${recovered.status === before.status ? 'matches its prior state' : 'changed'}; `
+        + `merge ${recovered.mergeInProgress ? 'is still in progress' : 'is not in progress'}; `
+        + `merge abort ${abortError === undefined ? 'reported success' : `failed: ${installFailureSummary(abortError)}`}. `
+        + `Merge failure: ${installFailureSummary(mergeError)}. `
+        + 'Inspect and restore the integration worktree before restarting orchestration.',
+      )
+    }
+    throw new MergeError(conflictMessage)
+  }
 }
 
 /** Bring a completed local task up to the run tip before any merge-gate work begins. */
@@ -884,6 +970,7 @@ async function mergeTaskWithGuardHeld(
   options: MergeOptions,
 ): Promise<MergeTaskResult> {
   const io = mergeIo(options.outputFile)
+  const mergeRuntime = options.mergeRuntime ?? { git }
   const depsEvent = options.onOrchestrationDepsEvent
     ?? ((name: 'Installed' | 'Skipped' | 'WARN', subject: string) => io.out(`${name} ${subject}`))
 
@@ -963,16 +1050,12 @@ async function mergeTaskWithGuardHeld(
   )
   try {
     git(paths.repoRoot, ['worktree', 'add', '--quiet', '--detach', prospectiveWorktree, currentBranch])
-    try {
-      git(prospectiveWorktree, ['merge', '--quiet', '--no-ff', branch, '-m', mergeMessage])
-    } catch {
-      try {
-        git(prospectiveWorktree, ['merge', '--abort'])
-      } catch {
-        // nothing to abort
-      }
-      throw new MergeError('A merge conflict occurred. Rebase the worktree, then retry the merge.')
-    }
+    mergeWithVerifiedRecovery(
+      prospectiveWorktree,
+      ['merge', '--quiet', '--no-ff', branch, '-m', mergeMessage],
+      'A merge conflict occurred. Rebase the worktree, then retry the merge.',
+      mergeRuntime,
+    )
     io.out(`=== ${taskId} diff (against ${currentBranch}) ===`)
     try {
       io.out(git(prospectiveWorktree, ['diff', `${currentBranch}...HEAD`]))
@@ -984,16 +1067,12 @@ async function mergeTaskWithGuardHeld(
     removeTemporaryWorktree(paths, prospectiveWorktree)
   }
 
-  try {
-    git(paths.repoRoot, ['merge', '--quiet', '--no-ff', branch, '-m', mergeMessage])
-  } catch {
-    try {
-      git(paths.repoRoot, ['merge', '--abort'])
-    } catch {
-      // nothing to abort
-    }
-    throw new MergeError('A merge conflict occurred. Rebase the worktree, then retry the merge.')
-  }
+  mergeWithVerifiedRecovery(
+    paths.repoRoot,
+    ['merge', '--quiet', '--no-ff', branch, '-m', mergeMessage],
+    'A merge conflict occurred. Rebase the worktree, then retry the merge.',
+    mergeRuntime,
+  )
 
   const mergeCommit = git(paths.repoRoot, ['rev-parse', 'HEAD']).trim()
   // Publish the merge identity before any post-merge work. If dependency synchronization
@@ -1074,6 +1153,7 @@ export async function mergeRemoteTask(
   const taskId = branch.slice('task/'.length)
   const worktree = join(paths.worktreesDir, `.adopt-${issueNumber}-${process.pid}-${Date.now()}`)
   const io = mergeIo(options.outputFile)
+  const mergeRuntime = options.mergeRuntime ?? { git }
   const depsEvent = options.onOrchestrationDepsEvent
     ?? ((name: 'Installed' | 'Skipped' | 'WARN', subject: string) => io.out(`${name} ${subject}`))
   const baseMergeMessage = `Merge ${taskId} via orchestration`
@@ -1105,16 +1185,12 @@ export async function mergeRemoteTask(
   }
   try {
     git(paths.repoRoot, ['worktree', 'add', '--quiet', '--detach', worktree, currentBranch])
-    try {
-      git(worktree, ['merge', '--quiet', '--no-ff', remoteRef, '-m', mergeMessage])
-    } catch {
-      try {
-        git(worktree, ['merge', '--abort'])
-      } catch {
-        // nothing to abort
-      }
-      throw new MergeError(`A merge conflict occurred while adopting ${branch}.`)
-    }
+    mergeWithVerifiedRecovery(
+      worktree,
+      ['merge', '--quiet', '--no-ff', remoteRef, '-m', mergeMessage],
+      `A merge conflict occurred while adopting ${branch}.`,
+      mergeRuntime,
+    )
     io.out(`=== ${taskId} diff (against ${currentBranch}) ===`)
     io.out(git(worktree, ['diff', `${currentBranch}...HEAD`]))
     runMergeChecks(worktree, currentBranch, options, io)
@@ -1122,16 +1198,12 @@ export async function mergeRemoteTask(
     removeTemporaryWorktree(paths, worktree)
   }
 
-  try {
-    git(paths.repoRoot, ['merge', '--quiet', '--no-ff', remoteRef, '-m', mergeMessage])
-  } catch {
-    try {
-      git(paths.repoRoot, ['merge', '--abort'])
-    } catch {
-      // nothing to abort
-    }
-    throw new MergeError(`A merge conflict occurred while adopting ${branch}.`)
-  }
+  mergeWithVerifiedRecovery(
+    paths.repoRoot,
+    ['merge', '--quiet', '--no-ff', remoteRef, '-m', mergeMessage],
+    `A merge conflict occurred while adopting ${branch}.`,
+    mergeRuntime,
+  )
   const mergeCommit = git(paths.repoRoot, ['rev-parse', 'HEAD']).trim()
   options.onMerged?.(mergeCommit)
   syncOrchestrationDepsAfterMerge(

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -757,11 +757,13 @@ interface MergeGuardOwner {
   state: 'active'
   pid: number
   startIdentity: string | null
+  token: string | null
 }
 
 const MALFORMED_MERGE_GUARD_MAX_AGE_MS = 30_000
 const MERGE_GUARD_RECLAIM_TIMEOUT_MS = 10_000
 const MERGE_GUARD_RECLAIM_RETRY_MS = 10
+const retiredMergeGuardTokens = new Set<string>()
 
 function mergeGuardDir(paths: OrchPaths, taskId: string): string {
   return join(paths.queueDir, 'merge-guards', taskId)
@@ -777,6 +779,7 @@ function activeMergeGuardOwner(dir: string): MergeGuardOwner | undefined {
       state: 'active',
       pid: Number(value.pid),
       startIdentity: typeof value.startIdentity === 'string' ? value.startIdentity : null,
+      token: typeof value.token === 'string' ? value.token : null,
     }
   } catch {
     return undefined
@@ -871,6 +874,7 @@ function acquireMergeGuard(
   mkdirSync(dirname(dir), { recursive: true })
   const owner: MergeGuardOwner = {
     state: 'active', pid: process.pid, startIdentity: currentProcessStartIdentity(),
+    token: randomUUID(),
   }
   for (;;) {
     if (publishMergeGuard(dir, owner)) {
@@ -898,6 +902,19 @@ function acquireMergeGuard(
         reclaimDeadline = Date.now() + MERGE_GUARD_RECLAIM_TIMEOUT_MS
       }
       if (reclaimMalformedMergeGuard(dir)) {
+        reclaimDeadline = undefined
+        continue
+      }
+      if (Date.now() >= reclaimDeadline) {
+        throw new MergeError(`Could not remove stale merge guard: ${taskId}`)
+      }
+      return new Promise((resolve) => setTimeout(resolve, MERGE_GUARD_RECLAIM_RETRY_MS))
+        .then(() => acquireMergeGuard(paths, taskId, reclaimDeadline))
+    }
+    if (recorded.token !== null && retiredMergeGuardTokens.has(recorded.token)) {
+      reclaimDeadline ??= Date.now() + MERGE_GUARD_RECLAIM_TIMEOUT_MS
+      if (reclaimRetiredMergeGuard(dir)) {
+        retiredMergeGuardTokens.delete(recorded.token)
         reclaimDeadline = undefined
         continue
       }
@@ -952,11 +969,14 @@ function finishMergeGuard(
   }
   try {
     renameSync(guard.file, retiredGuard)
-  } catch {
-    // Retirement must not replace the merge result. A published marker lets the next
-    // attempt reclaim this daemon's otherwise-live owner without waiting for restart.
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    // Retirement must not replace the merge result. The marker or process-local token
+    // lets the next attempt reclaim this daemon's otherwise-live owner before restart.
+    if (guard.owner.token !== null) retiredMergeGuardTokens.add(guard.owner.token)
     return
   }
+  if (guard.owner.token !== null) retiredMergeGuardTokens.delete(guard.owner.token)
   try {
     rmSync(retiredGuard, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
   } catch {

--- a/src/processOwner.ts
+++ b/src/processOwner.ts
@@ -17,9 +17,10 @@ export function encodeProcessStartIdentity(startIdentity: string | null): string
 /** Decode a recorded identity, treating legacy or invalid metadata as unverifiable. */
 export function decodeProcessStartIdentity(encoded: string | undefined): string | undefined {
   if (encoded === undefined || encoded === '-') return undefined
+  if (!/^[A-Za-z0-9_-]+$/.test(encoded)) return undefined
   try {
     const decoded = Buffer.from(encoded, 'base64url').toString()
-    return decoded === '' ? undefined : decoded
+    return decoded !== '' && encodeProcessStartIdentity(decoded) === encoded ? decoded : undefined
   } catch {
     return undefined
   }

--- a/src/processRegistry.ts
+++ b/src/processRegistry.ts
@@ -1,4 +1,7 @@
-import { mkdirSync, readdirSync, rmSync, statSync, readFileSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import {
+  mkdirSync, readdirSync, renameSync, rmSync, statSync, readFileSync, writeFileSync,
+} from 'node:fs'
 import { uptime } from 'node:os'
 import { join } from 'node:path'
 import { operatingSystem } from './adapters/os.ts'
@@ -47,7 +50,8 @@ function registryFile(paths: OrchPaths, taskId: string): string {
 export function registeredTaskIds(paths: OrchPaths): string[] {
   try {
     return readdirSync(registryDir(paths), { withFileTypes: true })
-      .filter((entry) => entry.isFile())
+      .filter((entry) => entry.isFile()
+        && !(entry.name.startsWith('.') && entry.name.endsWith('.tmp')))
       .map((entry) => entry.name)
       .sort()
   } catch (error) {
@@ -92,9 +96,18 @@ export function recordTaskProcess(
     }
   }
   mkdirSync(registryDir(paths), { recursive: true })
-  writeFileSync(registryFile(paths, taskId), `${JSON.stringify({
-    pid, startIdentity: startIdentity ?? null,
-  })}\n`)
+  const file = registryFile(paths, taskId)
+  const temporary = join(
+    registryDir(paths), `.${taskId}.${process.pid}.${randomUUID()}.tmp`,
+  )
+  try {
+    writeFileSync(temporary, `${JSON.stringify({
+      pid, startIdentity: startIdentity ?? null,
+    })}\n`, { flag: 'wx' })
+    renameSync(temporary, file)
+  } finally {
+    rmSync(temporary, { force: true })
+  }
 }
 
 /** Forget the process for `taskId`. Safe to call when nothing was recorded. */
@@ -123,17 +136,23 @@ function registeredTaskProcessPid(
   }
   try {
     entry = JSON.parse(recorded) as ProcessRegistryEntry
-  } catch {
+  } catch (error) {
+    // Atomic publication prevents new partial records. Keep any malformed published
+    // ownership visible as an error instead of turning a possibly live runner into an
+    // apparently unowned task.
+    throw new Error(`Malformed task process registry entry: ${file}`, { cause: error })
+  }
+
+  // Bare PIDs predate process-start identities and cannot safely establish ownership.
+  if (Number.isSafeInteger(entry) && (entry as unknown as number) > 0) {
     forgetTaskProcess(paths, taskId)
     return undefined
   }
-
   if (entry === null || typeof entry !== 'object'
     || !Number.isSafeInteger(entry.pid) || entry.pid <= 0
     || (typeof entry.startIdentity !== 'string' && entry.startIdentity !== null)
     || entry.startIdentity === '') {
-    forgetTaskProcess(paths, taskId)
-    return undefined
+    throw new Error(`Malformed task process registry entry: ${file}`)
   }
   if (writtenAt + BOOT_COMPARISON_TOLERANCE_MS < boot()) {
     forgetTaskProcess(paths, taskId)

--- a/src/processRegistry.ts
+++ b/src/processRegistry.ts
@@ -37,6 +37,7 @@ type ProcessRegistryEntry = VerifiedProcessRegistryEntry | UnverifiedProcessRegi
 
 export type ProcessStartIdentity = (pid: number) => string | undefined
 export type ProcessIsAlive = (pid: number) => boolean
+export type ProcessTreeIsAlive = (pid: number) => boolean
 
 function registryDir(paths: OrchPaths): string {
   return join(paths.queueDir, 'pids')
@@ -120,7 +121,7 @@ function registeredTaskProcessPid(
   taskId: string,
   boot: () => number,
   processStartIdentity: ProcessStartIdentity,
-  processIsAlive: ProcessIsAlive,
+  processTreeIsAlive: ProcessTreeIsAlive,
   requireVerifiedIdentity: boolean,
 ): number | undefined {
   const file = registryFile(paths, taskId)
@@ -168,7 +169,7 @@ function registeredTaskProcessPid(
   if (currentStartIdentity === undefined) {
     let alive = true
     try {
-      alive = processIsAlive(entry.pid)
+      alive = processTreeIsAlive(entry.pid)
     } catch {
       // An unavailable liveness probe does not prove that the process stopped.
     }
@@ -177,6 +178,13 @@ function registeredTaskProcessPid(
     return undefined
   }
   if (entry.startIdentity !== null && currentStartIdentity !== entry.startIdentity) {
+    let alive = true
+    try {
+      alive = processTreeIsAlive(entry.pid)
+    } catch {
+      // A failed tree probe cannot prove that the recorded tree was cleaned up.
+    }
+    if (alive) return requireVerifiedIdentity ? undefined : entry.pid
     forgetTaskProcess(paths, taskId)
     return undefined
   }
@@ -193,10 +201,10 @@ export function taskProcessPid(
   taskId: string,
   boot: () => number = bootedAt,
   processStartIdentity: ProcessStartIdentity = operatingSystem.processStartIdentity,
-  processIsAlive: ProcessIsAlive = operatingSystem.processIsAlive,
+  processTreeIsAlive: ProcessTreeIsAlive = operatingSystem.processTreeIsAlive,
 ): number | undefined {
   return registeredTaskProcessPid(
-    paths, taskId, boot, processStartIdentity, processIsAlive, false,
+    paths, taskId, boot, processStartIdentity, processTreeIsAlive, false,
   )
 }
 
@@ -210,9 +218,9 @@ export function terminableTaskProcessPid(
   taskId: string,
   boot: () => number = bootedAt,
   processStartIdentity: ProcessStartIdentity = operatingSystem.processStartIdentity,
-  processIsAlive: ProcessIsAlive = operatingSystem.processIsAlive,
+  processTreeIsAlive: ProcessTreeIsAlive = operatingSystem.processTreeIsAlive,
 ): number | undefined {
   return registeredTaskProcessPid(
-    paths, taskId, boot, processStartIdentity, processIsAlive, true,
+    paths, taskId, boot, processStartIdentity, processTreeIsAlive, true,
   )
 }

--- a/src/prune.ts
+++ b/src/prune.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
-import { join, toNamespacedPath } from 'node:path'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { operatingSystem, type OperatingSystem } from './adapters/os.ts'
 import { logFile, worktreeDir, type OrchPaths } from './paths.ts'
 
 // Deletes what finished tasks leave behind: logs, status files, generated specs, and
@@ -27,20 +28,17 @@ function olderThan(file: string, days: number): boolean {
   }
 }
 
-export function pruneTasks(paths: OrchPaths, options: PruneOptions): PruneReport {
+export function pruneTasks(
+  paths: OrchPaths,
+  options: PruneOptions,
+  os: OperatingSystem = operatingSystem,
+): PruneReport {
   const report: PruneReport = { prunedTasks: 0, removed: [], kept: [] }
 
   const remove = (...files: string[]): void => {
     for (const file of files) {
       if (!existsSync(file)) continue
-      if (!options.dryRun) {
-        try {
-          rmSync(file, { recursive: true, force: true, maxRetries: 3 })
-        } catch (error) {
-          if (process.platform !== 'win32') throw error
-          rmSync(toNamespacedPath(file), { recursive: true, force: true, maxRetries: 3 })
-        }
-      }
+      if (!options.dryRun) os.removeDirectory(file)
       report.removed.push(file)
     }
   }

--- a/src/status.ts
+++ b/src/status.ts
@@ -8,8 +8,7 @@ import { operatingSystem } from './adapters/os.ts'
 import { branchName, statusFile, worktreeDir, type OrchPaths } from './paths.ts'
 import { currentProcessStartIdentity, lockOwnerIsCurrent } from './processOwner.ts'
 import {
-  forgetTaskProcess, recordTaskProcess, taskProcessPid, type ProcessIsAlive,
-  type ProcessStartIdentity,
+  recordTaskProcess, taskProcessPid, type ProcessStartIdentity, type ProcessTreeIsAlive,
 } from './processRegistry.ts'
 
 // A task reads `running` while its runner process is alive, `completed` once the
@@ -90,7 +89,7 @@ export function readStatus(
   paths: OrchPaths,
   taskId: string,
   processStartIdentity: ProcessStartIdentity = operatingSystem.processStartIdentity,
-  processIsAlive: ProcessIsAlive = operatingSystem.processIsAlive,
+  processTreeIsAlive: ProcessTreeIsAlive = operatingSystem.processTreeIsAlive,
 ): TaskStatus | undefined {
   let parsed: unknown
   try {
@@ -113,7 +112,7 @@ export function readStatus(
   // process, so a number left in an old record is not read back as a live task.
   return {
     ...record,
-    pid: taskProcessPid(paths, taskId, undefined, processStartIdentity, processIsAlive) ?? null,
+    pid: taskProcessPid(paths, taskId, undefined, processStartIdentity, processTreeIsAlive) ?? null,
   }
 }
 
@@ -348,7 +347,9 @@ function writeStatusUnlocked(
   } finally {
     rmSync(temporaryFile, { force: true })
   }
-  if (pid === undefined || !Number.isInteger(pid)) forgetTaskProcess(paths, taskId)
+  // Publishing a terminal status does not prove that the runner's descendants stopped.
+  // Reading the registry releases it only after the whole tree is confirmed gone.
+  if (pid === undefined || !Number.isInteger(pid)) taskProcessPid(paths, taskId)
 }
 
 export async function writeStatus(

--- a/src/taskProcesses.ts
+++ b/src/taskProcesses.ts
@@ -59,7 +59,15 @@ export function terminateLiveTaskProcesses(
       continue
     }
     try {
-      if (os.terminateProcessTree(terminablePid)) result.terminated.push(task)
+      const terminated = os.terminateProcessTree(terminablePid)
+      if (!terminated) {
+        result.failures.push({
+          ...task,
+          error: 'process tree termination could not be verified',
+        })
+        continue
+      }
+      result.terminated.push(task)
       // Stopping is what makes the recorded number false, so it is dropped here rather
       // than left for whoever reads next. A tree that resisted termination keeps its
       // entry: something is still running under that number.

--- a/src/taskProcesses.ts
+++ b/src/taskProcesses.ts
@@ -28,13 +28,12 @@ export function liveTaskProcesses(
   const taskIds = new Set([...listTaskIds(paths), ...registeredTaskIds(paths)])
   for (const taskId of [...taskIds].sort()) {
     const pid = taskProcessPid(
-      paths, taskId, bootedAt, os.processStartIdentity, os.processIsAlive,
+      paths, taskId, bootedAt, os.processStartIdentity, os.processTreeIsAlive,
     )
     if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) continue
-    // Detection asks whether that process is running, not whether it leads a group. A
-    // recorded PID that is not a group leader answered "gone" on POSIX, so this waved
-    // through a daemon starting beside a live foreign task.
-    if (os.processIsAlive(pid)) {
+    // Ownership blocks while any member of the recorded tree is alive. The runner root
+    // can exit before a descendant, and cleanup must still find that orphaned tree.
+    if (os.processTreeIsAlive(pid)) {
       live.push({ taskId, pid })
     }
   }
@@ -49,7 +48,7 @@ export function terminateLiveTaskProcesses(
   const result: TaskProcessTermination = { terminated: [], failures: [] }
   for (const task of liveTaskProcesses(paths, os)) {
     const terminablePid = terminableTaskProcessPid(
-      paths, task.taskId, bootedAt, os.processStartIdentity, os.processIsAlive,
+      paths, task.taskId, bootedAt, os.processStartIdentity, os.processTreeIsAlive,
     )
     if (terminablePid === undefined) {
       result.failures.push({

--- a/tests/backlog.test.ts
+++ b/tests/backlog.test.ts
@@ -182,6 +182,25 @@ describe('backlog process lock', () => {
     expect(existsSync(lockDir)).toBe(false)
   })
 
+  it('does not reclaim an aged lock with a live PID and malformed identity token', () => {
+    const backlog = join(paths.queueDir, 'backlog.txt')
+    const lockDir = `${backlog}.lock`
+    mkdirSync(lockDir)
+    const encodedIdentity = Buffer.from('previous-start').toString('base64url')
+    writeFileSync(
+      join(lockDir, 'owner'),
+      `${process.pid} ${Date.now() - 31_000} v2.old-token.${encodedIdentity}!\n`,
+    )
+    vi.spyOn(operatingSystem, 'processStartIdentity').mockReturnValue('current-start')
+    const processIsAlive = vi.spyOn(operatingSystem, 'processIsAlive').mockReturnValue(true)
+    vi.spyOn(Atomics, 'wait').mockReturnValue('timed-out')
+
+    expect(() => withBacklogLock(backlog, () => undefined))
+      .toThrow(`Timed out waiting for the backlog lock: ${backlog}`)
+    expect(processIsAlive).toHaveBeenCalledWith(process.pid)
+    expect(existsSync(lockDir)).toBe(true)
+  })
+
   it('recovers an aged recovery mutex abandoned beside a stale lock', () => {
     const backlog = join(paths.queueDir, 'backlog.txt')
     const lockDir = `${backlog}.lock`

--- a/tests/branch-state.test.ts
+++ b/tests/branch-state.test.ts
@@ -1,5 +1,7 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -113,6 +115,29 @@ describe('initializeSessionStateForBranch', () => {
     makeLoop().initializeSessionStateForBranch()
 
     expect(logged).toHaveLength(0)
+    expect(readFileSync(join(paths.queueDir, 'scan-count.txt'), 'utf8').trim()).toBe('4')
+    for (const name of cycleFileNames) {
+      expect(readFileSync(join(paths.queueDir, name), 'utf8').trim()).toBe('cycle state')
+    }
+    expect(readFileSync(join(paths.queueDir, 'merge-failure-count.txt'), 'utf8').trim()).toBe('3')
+    assertPersistentState()
+  })
+
+  it('preserves resumable state when the current branch cannot be queried', () => {
+    seedState()
+    writeFileSync(join(paths.queueDir, 'run-branch.txt'), 'current-branch\n')
+    const gitDir = join(repoRoot, '.git')
+    const unavailableGitDir = join(repoRoot, '.git-unavailable')
+    renameSync(gitDir, unavailableGitDir)
+
+    try {
+      expect(() => makeLoop().initializeSessionStateForBranch()).toThrow()
+    } finally {
+      renameSync(unavailableGitDir, gitDir)
+    }
+
+    expect(readFileSync(join(paths.queueDir, 'run-branch.txt'), 'utf8').trim())
+      .toBe('current-branch')
     expect(readFileSync(join(paths.queueDir, 'scan-count.txt'), 'utf8').trim()).toBe('4')
     for (const name of cycleFileNames) {
       expect(readFileSync(join(paths.queueDir, name), 'utf8').trim()).toBe('cycle state')

--- a/tests/branch-topology.test.ts
+++ b/tests/branch-topology.test.ts
@@ -12,6 +12,7 @@ import { mergeTask } from '../src/merge.ts'
 import {
   branchName, orchPaths, worktreeDir, type OrchPaths,
 } from '../src/paths.ts'
+import { forgetTaskProcess } from '../src/processRegistry.ts'
 import { startTask } from '../src/start.ts'
 import { writeStatus } from '../src/status.ts'
 import { specFile } from '../src/tasks.ts'
@@ -121,6 +122,9 @@ describe('integration branch topology', () => {
       'chore: update orchestration package',
     )
     const taskHead = git(taskRoot, ['rev-parse', 'HEAD'])
+    // The fake runner uses this Vitest worker's PID without launching a process. Drop
+    // that synthetic ownership before merge cleanup considers stopping the runner.
+    forgetTaskProcess(paths, taskId)
     await writeStatus(paths, taskId, 'completed')
     const install = vi.fn()
 

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -187,6 +187,7 @@ describe('cleanupTask', () => {
       os: {
         ...windowsOperatingSystem(),
         processIsAlive: () => true,
+        processTreeIsAlive: () => true,
         processStartIdentity: () => undefined,
         terminateProcessTree,
       },

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1074,6 +1074,14 @@ describe('loop daemon ownership', () => {
   it('refuses startup while a task status names a foreign live PID', async () => {
     const paths = orchPaths(repoRoot)
     const taskId = '20260812_010203_040_auto-foreign-task'
+    const foreignProcess = testProcesses.spawn(process.execPath, [
+      '-e', 'setInterval(() => {}, 1000)',
+    ], {
+      stdio: 'ignore',
+      windowsHide: true,
+    })
+    const foreignPid = foreignProcess.pid
+    expect(foreignPid).toBeTypeOf('number')
     writeFileSync(statusFile(paths, taskId), JSON.stringify({
       task_id: taskId,
       status: 'running',
@@ -1081,10 +1089,10 @@ describe('loop daemon ownership', () => {
       updated_at: '2026-08-12T01:02:03Z',
       worktree: worktreeDir(paths, taskId),
       branch: branchName(taskId),
-      pid: process.pid,
+      pid: foreignPid,
     }))
     // A task's process lives in the registry, not in the record.
-    recordTaskProcess(paths, taskId, process.pid)
+    recordTaskProcess(paths, taskId, foreignPid as number)
 
     const result = spawnSync(process.execPath, [CLI, 'loop', '--approve-mode', 'local'], {
       cwd: repoRoot,
@@ -1096,7 +1104,7 @@ describe('loop daemon ownership', () => {
 
     expect(result.status).toBe(1)
     expect(result.stdout).toContain(taskId)
-    expect(result.stdout).toContain(`foreign live process tree PID ${process.pid}`)
+    expect(result.stdout).toContain(`foreign live process tree PID ${foreignPid}`)
     expect(result.stdout).toContain('terminate or adopt the foreign task before starting')
     expect(existsSync(daemonFile('loop.pid'))).toBe(false)
     expect(existsSync(daemonFile('cycle-cap.txt'))).toBe(false)

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -166,6 +166,13 @@ describe('loadConfig', () => {
     expect(config.pollIntervalSeconds).toBe(30)
   })
 
+  it('validates only the effective value when a file overrides the environment', () => {
+    const filePath = configFile(JSON.stringify({ MAX_PARALLEL: 7 }))
+    const config = loadConfig({ MAX_PARALLEL: 'invalid' }, { filePath })
+
+    expect(config.maxParallel).toBe(7)
+  })
+
   it('stops when a file value fails startup validation', () => {
     const events: string[] = []
     const filePath = configFile(JSON.stringify({ TASK_GATE: 'fast' }))

--- a/tests/core-update.test.ts
+++ b/tests/core-update.test.ts
@@ -207,6 +207,28 @@ describe('pre-cycle core update', () => {
     expect(events).toContain('Restarting core for cycle 1')
   })
 
+  it('finds the newest squash-import after its run branch is squash-merged', async () => {
+    const runBranch = 'chore/import-core'
+    git(repoRoot, ['switch', '-c', runBranch])
+    const importedCore = advanceUpstream('version two\n')
+    git(repoRoot, [
+      'subtree', 'pull', '--prefix=orchestration/ts', upstreamRoot, 'main', '--squash',
+    ])
+    git(repoRoot, ['switch', 'main'])
+    git(repoRoot, ['merge', '--squash', runBranch])
+    commit(repoRoot, 'Merge pull request #1 from consumer/chore/import-core')
+    git(repoRoot, ['branch', '-D', runBranch])
+    const newCore = advanceUpstream('version three\n')
+    const loop = makeLoop(config())
+
+    expect(await loop.poll(), events.join('\n')).toBe('restart')
+    expect(readFileSync(join(packageRoot, 'core.txt'), 'utf8').replaceAll('\r', ''))
+      .toBe('version three\n')
+    expect(events).toContain(
+      `Updated core ${importedCore.slice(0, 8)}..${newCore.slice(0, 8)}`,
+    )
+  })
+
   it('updates integration source without restarting the fixed daemon', async () => {
     const oldCore = git(upstreamRoot, ['rev-parse', 'HEAD'])
     const newCore = advanceUpstream('version two\n')
@@ -492,6 +514,12 @@ export const consumerProject: ProjectAdapter & Record<string, unknown> = {
       .toBe('version one\n')
     expect(runnerStarts).toHaveLength(1)
     expect(events, events.join('\n')).toContain('WARN core update skipped: working tree is dirty')
+    const imported = git(upstreamRoot, ['rev-parse', 'HEAD^'])
+    const upstream = git(upstreamRoot, ['rev-parse', 'HEAD'])
+    expect(events).toContain(
+      `Status core behind imported ${imported.slice(0, 8)} upstream ${upstream.slice(0, 8)}; `
+      + 'continuing on old code: working tree is dirty',
+    )
   })
 
   it('aborts a conflicting pull, warns, and starts the cycle on the old code', async () => {
@@ -510,6 +538,12 @@ export const consumerProject: ProjectAdapter & Record<string, unknown> = {
     expect(events.some((line) => line.startsWith(
       'WARN core update pull conflicted; continuing on old code:',
     )), events.join('\n')).toBe(true)
+    const imported = git(upstreamRoot, ['rev-parse', 'HEAD^'])
+    const upstream = git(upstreamRoot, ['rev-parse', 'HEAD'])
+    expect(events).toContain(
+      `Status core behind imported ${imported.slice(0, 8)} upstream ${upstream.slice(0, 8)}; `
+      + 'continuing on old code: pull conflicted',
+    )
   })
 
   it('stops when a failed core pull cannot confirm a successful merge abort', async () => {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -56,7 +56,10 @@ describe('deploy', () => {
     expect(dispatchWorkflow).toHaveBeenCalledWith('deploy.yml', 'main', 'dispatch-73')
     expect(findWorkflowRun).toHaveBeenLastCalledWith('deploy.yml', 'main', 'dispatch-73')
     expect(getWorkflowRun).toHaveBeenCalledWith(73)
-    expect(fetcher).toHaveBeenCalledWith('https://shiora.jp/.well-known/shiora-revision')
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://shiora.jp/.well-known/shiora-revision',
+      { signal: expect.any(AbortSignal) },
+    )
     expect(result).toMatchObject({
       dispatchToken: 'dispatch-73',
       expectedRevision: '73aa',
@@ -118,6 +121,96 @@ describe('deploy', () => {
         createDispatchToken: () => 'dispatch-75',
       },
     )).rejects.toThrow('Deployment verification request failed with HTTP 404.')
+  })
+
+  it('aborts when fetching the deployed revision exceeds its deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      const forge = makeFakeForge()
+      forge.findWorkflowRun = async () => ({
+        id: 78,
+        createdAt: '2026-08-08T15:00:00Z',
+        headSha: 'expected-sha',
+        status: 'completed',
+        conclusion: 'success',
+      })
+      let signal: AbortSignal | undefined
+      const fetcher = vi.fn(async (_url: string, options?: { signal?: AbortSignal }) => {
+        signal = options?.signal
+        return await new Promise<never>(() => {})
+      })
+
+      const result = deploy(
+        {
+          workflow: 'deploy.yml',
+          revisionUrl: 'https://shiora.jp/.well-known/shiora-revision',
+        },
+        'main',
+        forge,
+        {
+          clock: clock(),
+          fetcher,
+          revisionTimeoutMilliseconds: 2_000,
+          createDispatchToken: () => 'fetch-timeout-dispatch',
+        },
+      )
+      const rejection = expect(result).rejects.toThrow(
+        "Timed out after 2000ms fetching deployed revision from 'https://shiora.jp/.well-known/shiora-revision'.",
+      )
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      await rejection
+      expect(signal?.aborted).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the abort deadline active while reading the revision response body', async () => {
+    vi.useFakeTimers()
+    try {
+      const forge = makeFakeForge()
+      forge.findWorkflowRun = async () => ({
+        id: 79,
+        createdAt: '2026-08-08T15:00:00Z',
+        headSha: 'expected-sha',
+        status: 'completed',
+        conclusion: 'success',
+      })
+      let signal: AbortSignal | undefined
+      const fetcher = vi.fn(async (_url: string, options?: { signal?: AbortSignal }) => {
+        signal = options?.signal
+        return {
+          ok: true,
+          status: 200,
+          text: async () => await new Promise<string>(() => {}),
+        }
+      })
+
+      const result = deploy(
+        {
+          workflow: 'deploy.yml',
+          revisionUrl: 'https://shiora.jp/.well-known/shiora-revision',
+        },
+        'main',
+        forge,
+        {
+          clock: clock(),
+          fetcher,
+          revisionTimeoutMilliseconds: 2_000,
+          createDispatchToken: () => 'body-timeout-dispatch',
+        },
+      )
+      const rejection = expect(result).rejects.toThrow(
+        "Timed out after 2000ms fetching deployed revision from 'https://shiora.jp/.well-known/shiora-revision'.",
+      )
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      await rejection
+      expect(signal?.aborted).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('rejects a completed failed workflow before fetching the deployed revision', async () => {

--- a/tests/initialize-cross-drive.test.ts
+++ b/tests/initialize-cross-drive.test.ts
@@ -1,0 +1,38 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it, vi } from 'vitest'
+
+vi.mock('node:path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:path')>()
+  return {
+    ...actual,
+    isAbsolute: (path: string) => /^[A-Za-z]:[\\/]/.test(path) || actual.isAbsolute(path),
+    relative: (from: string, to: string) => to.includes('cross-drive-package')
+      ? 'D:\\cross-drive-package\\src\\adapters\\project.ts'
+      : actual.relative(from, to),
+  }
+})
+
+const repositories: string[] = []
+
+afterEach(() => {
+  for (const repository of repositories.splice(0)) {
+    rmSync(repository, { recursive: true, force: true })
+  }
+})
+
+it('rejects a cross-drive package before writing scaffold files', async () => {
+  const repository = mkdtempSync(join(tmpdir(), 'orchestration-cross-drive-'))
+  repositories.push(repository)
+  const { initializeRepository } = await import('../src/initialize.ts')
+  const { orchPaths } = await import('../src/paths.ts')
+  const { makeFakeForge } = await import('./fakeForge.ts')
+  const paths = orchPaths(repository, false)
+
+  await expect(initializeRepository(paths, makeFakeForge(), 'consumer', {
+    packageRoot: join(repository, 'cross-drive-package'),
+  })).rejects.toThrow('must be on the same filesystem volume')
+
+  expect(existsSync(paths.root)).toBe(false)
+})

--- a/tests/issue-queue.test.ts
+++ b/tests/issue-queue.test.ts
@@ -1784,6 +1784,50 @@ describe('issue claim release', () => {
 })
 
 describe('reapStaleLeases', () => {
+  it('stops reconciliation and preserves a stale lease when promotion JSON needs repair', async () => {
+    forge.clock = () => new Date('2026-08-08T06:00:00Z')
+    const issueNumber = await forge.createIssue({
+      title: 'merged with damaged promotion state', body: '',
+      labels: [LABEL_FINDING, LABEL_IN_PROGRESS], assignees: ['worker-gone'],
+    })
+    const promotion = join(paths.queueDir, 'issue-promotion', `${issueNumber}.json`)
+    mkdirSync(join(paths.queueDir, 'issue-promotion'), { recursive: true })
+    writeFileSync(promotion, '{"taskId":"merged-task"')
+
+    await expect(reapStaleLeases(
+      forge, paths, 3, new Date('2026-08-08T12:00:00Z'),
+    )).rejects.toThrow(
+      `Malformed issue promotion record ${promotion}; repair this file before issue reconciliation can continue`,
+    )
+
+    const issue = await forge.getIssue(issueNumber)
+    expect(issue.assignees).toEqual(['worker-gone'])
+    expect(issue.labels).toContain(LABEL_IN_PROGRESS)
+    expect(issue.labels).not.toContain(LABEL_READY)
+    expect(readFileSync(promotion, 'utf8')).toBe('{"taskId":"merged-task"')
+  })
+
+  it.each([
+    ['a scalar', 'null'],
+    ['an empty task id', JSON.stringify({
+      taskId: '', issueNumber: 41, mergeCommit: 'abc123', runBranch: 'main',
+    })],
+    ['a mismatched issue number', JSON.stringify({
+      taskId: 'merged-task', issueNumber: 42, mergeCommit: 'abc123', runBranch: 'main',
+    })],
+    ['an invalid confirmation flag', JSON.stringify({
+      taskId: 'merged-task', issueNumber: 41, mergeCommit: 'abc123', runBranch: 'main',
+      commentConfirmed: 'yes',
+    })],
+  ])('rejects a promotion record containing %s', (_description, contents) => {
+    const promotion = join(paths.queueDir, 'issue-promotion', '41.json')
+    mkdirSync(join(paths.queueDir, 'issue-promotion'), { recursive: true })
+    writeFileSync(promotion, contents)
+
+    expect(() => issuePromotionForIssue(paths, 41)).toThrow(/repair this file/)
+    expect(readFileSync(promotion, 'utf8')).toBe(contents)
+  })
+
   it('surfaces persisted release failures before reporting stale-lease recovery', async () => {
     const issueNumber = await forge.createIssue({
       title: 'cleanup release', body: '',

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -2038,6 +2038,35 @@ describe('cycle gate', () => {
     return { attemptFile, completeFlag }
   }
 
+  it.each([
+    ['pending', [{ name: 'frontend', conclusion: 'pending', startedAt: '' }]],
+    ['unknown', []],
+  ] as const)('keeps the completed cycle resumable while CI is %s', async (
+    _verdict, checks,
+  ) => {
+    const enqueue = vi.fn<typeof enqueueTask>()
+    const loop = makeLoop({
+      autoPr: false,
+      reviewEnabled: true,
+      ciGateEnabled: true,
+      maxCiFixAttempts: 1,
+    }, stubProject, undefined, undefined, undefined, enqueue)
+    const { attemptFile, completeFlag } = prepareFailedCiGate()
+    forgeStatus.checks = [...checks]
+
+    expect(await loop.triggerScanIfIdle()).toBe('continue')
+    expect(await loop.triggerScanIfIdle()).toBe('continue')
+
+    expect(prStatusCalls).toBe(2)
+    expect(enqueue).not.toHaveBeenCalled()
+    expect(existsSync(attemptFile)).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'ci-fix-pending-id-1'))).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
+    expect(existsSync(completeFlag)).toBe(true)
+    expect(existsSync(join(paths.queueDir, 'cycle-resume-1'))).toBe(false)
+    expect(readFileSync(join(paths.queueDir, 'scan-count.txt'), 'utf8')).toBe('1\n')
+  })
+
   it('enqueues a task with the failed checks and consumes one CI fix attempt', async () => {
     const enqueue = vi.fn<typeof enqueueTask>((_paths, taskId, depth) => ({
       outcome: 'enqueued', taskId, depth: depth ?? 0,

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1891,6 +1891,55 @@ describe('cycle gate', () => {
     expect(readFileSync(join(paths.queueDir, 'scan-count.txt'), 'utf8')).toBe('0\n')
   })
 
+  it('retries and stops when the branch comparison fails instead of reporting an empty run', async () => {
+    const head = initializeGitRepo()
+    configureRemoteDefaultBranch()
+    writeFileSync(join(paths.queueDir, 'scan-count.txt'), '1\n')
+    forgeStatus = { state: 'none', isDraft: false, url: '', headSha: '', checks: [] }
+    const loop = makeLoop({
+      scanEnabled: false,
+      autoPr: true,
+      reviewEnabled: false,
+    })
+    loop.initializeSessionStateForBranch()
+    const createPr = vi.fn(async () => 'https://example.test/pull/1')
+    fakeForge.createPr = createPr
+    const objectPath = join(
+      repoRoot,
+      git(['rev-parse', '--git-path', `objects/${head.slice(0, 2)}/${head.slice(2)}`]),
+    )
+    const commitObject = readFileSync(objectPath)
+    fakeForge.prStatus = async () => {
+      rmSync(objectPath)
+      return forgeStatus
+    }
+
+    try {
+      expect(await loop.poll()).toBe('continue')
+    } finally {
+      writeFileSync(objectPath, commitObject)
+    }
+
+    expect(logText()).toContain('WARN could not compare branch with origin/main:')
+    expect(logged.some((line) => line.startsWith('LOOP_DONE:'))).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'cycle-complete-1'))).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
+    expect(createPr).not.toHaveBeenCalled()
+
+    try {
+      expect(await loop.poll()).toBe('continue')
+    } finally {
+      writeFileSync(objectPath, commitObject)
+    }
+
+    expect(logText()).toContain('ERROR could not compare branch with origin/main:')
+    expect(logText()).toContain('(repeated 2 times)')
+    expect(logged.some((line) => line.startsWith('LOOP_DONE:'))).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'cycle-complete-1'))).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'stop'))).toBe(true)
+    expect(createPr).not.toHaveBeenCalled()
+  })
+
   it('retains empty-cap session state when promotion fails, then retries', async () => {
     initializeGitRepo()
     configureRemoteDefaultBranch()
@@ -3905,6 +3954,61 @@ describe('completed task merge recovery', () => {
     expect(existsSync(join(paths.queueDir, 'cycle-complete-1'))).toBe(true)
     expect(existsSync(join(paths.queueDir, 'review-id-1'))).toBe(true)
     expect(attempts).toBe(2)
+  })
+
+  it('keeps promotion unconfirmed while a published merge marker is absent from read-back', async () => {
+    const taskId = '20260811_120000_068_auto-listing-lag'
+    initializeGitRepo()
+    configureRemoteDefaultBranch()
+    makeCompletedTask(taskId)
+    mkdirSync(join(paths.root, 'templates'), { recursive: true })
+    writeFileSync(join(paths.root, 'templates', 'review-template.md'),
+      '# {{REVIEW_ID}} review of cycle {{CYCLE}} against {{BASE_BRANCH}} for {{PR_URL}}\n')
+    writeFileSync(join(paths.queueDir, 'scan-count.txt'), '1\n')
+    const loop = makeLoop({
+      autoMerge: true,
+      issueQueueEnabled: true,
+      scanEnabled: true,
+      maxParallel: 0,
+      autoPr: false,
+      reviewEnabled: true,
+      autoReview: true,
+    })
+    loop.initializeSessionStateForBranch()
+    const issueNumber = await fakeForge.createIssue({
+      title: 'lagging merge marker', body: '', labels: [LABEL_FINDING, LABEL_IN_PROGRESS],
+    })
+    const issue = fakeForge.issues.get(issueNumber)
+    if (issue !== undefined) issue.updatedAt = '2026-08-01T00:00:00.000Z'
+    recordIssuesForTask(paths, taskId, [issueNumber])
+    const listIssueComments = fakeForge.listIssueComments.bind(fakeForge)
+    let markerVisible = false
+    fakeForge.listIssueComments = async (number) => {
+      const comments = await listIssueComments(number)
+      return markerVisible ? comments : []
+    }
+
+    expect(await loop.poll()).toBe('continue')
+
+    const mergedStatus = readStatus(paths, taskId)
+    const expectedMarker = `MERGED: ${taskId}\nMerged as ${mergedStatus?.merge_commit} into run branch main. This issue closes on promotion.`
+    expect(mergedStatus).toMatchObject({ status: 'merged', run_branch: 'main' })
+    expect(fakeForge.issueComments.get(issueNumber)).toEqual([expectedMarker])
+    expect(issuePromotionForIssue(paths, issueNumber)?.commentConfirmed).not.toBe(true)
+    expect(existsSync(join(paths.queueDir, 'cycle-complete-1'))).toBe(false)
+    expect(existsSync(join(paths.queueDir, 'review-id-1'))).toBe(false)
+    expect(logText()).toContain('merge comment is not visible after publishing it')
+
+    markerVisible = true
+    expect(await loop.poll()).toBe('continue')
+
+    expect(fakeForge.issueComments.get(issueNumber)).toEqual([expectedMarker])
+    expect(fakeForge.issueCommentAuthors.get(issueNumber)).toEqual([
+      { login: 'worker-a', hasWriteAccess: true },
+    ])
+    expect(issuePromotionForIssue(paths, issueNumber)?.commentConfirmed).toBe(true)
+    expect(existsSync(join(paths.queueDir, 'cycle-complete-1'))).toBe(true)
+    expect(existsSync(join(paths.queueDir, 'review-id-1'))).toBe(true)
   })
 
   it('retries a failed automerge on the next poll and lets the cycle gate proceed', async () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -393,59 +393,6 @@ describe('daemon startup', () => {
   })
 })
 
-describe('stranded run branch startup report', () => {
-  const currentRun = 'chore/loop-20260820-core-run12'
-  const previousRun = 'chore/loop-20260814-core-run11'
-
-  function startCurrentRun(): ReturnType<typeof makeLoop> {
-    git(['switch', '-c', currentRun, 'main'])
-    return makeLoop({ integrationBranch: currentRun })
-  }
-
-  it('reports commits stranded on a remote run branch', () => {
-    initializeGitRepo()
-    configureRemoteDefaultBranch()
-    git(['switch', '-c', previousRun])
-    writeFileSync(join(repoRoot, 'stranded.txt'), 'unfinished work\n')
-    git(['add', 'stranded.txt'])
-    git(['commit', '-m', 'feat: stranded work'])
-    git(['push', 'origin', previousRun])
-    git(['switch', 'main'])
-    git(['branch', '-D', previousRun])
-
-    const loop = startCurrentRun()
-    loop.reportStrandedRunBranches()
-
-    expect(logged).toContain(
-      `WARN stranded run branch ${previousRun} has 1 commit not on main`,
-    )
-  })
-
-  it('stays silent for a fully merged run branch', () => {
-    initializeGitRepo()
-    configureRemoteDefaultBranch()
-    git(['branch', previousRun, 'main'])
-
-    const loop = startCurrentRun()
-    loop.reportStrandedRunBranches()
-
-    expect(logged).toEqual([])
-  })
-
-  it('never reports the current run branch', () => {
-    initializeGitRepo()
-    configureRemoteDefaultBranch()
-    const loop = startCurrentRun()
-    writeFileSync(join(repoRoot, 'current-run.txt'), 'current work\n')
-    git(['add', 'current-run.txt'])
-    git(['commit', '-m', 'feat: current run work'])
-
-    loop.reportStrandedRunBranches()
-
-    expect(logged).toEqual([])
-  })
-})
-
 describe('status file safety', () => {
   it('stops the poll when an existing task status is malformed', async () => {
     const taskId = '20260811_000000_001_user-existing'

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1274,12 +1274,20 @@ describe('runAutoReview', () => {
     expect(existsSync(idFile)).toBe(false)
     expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
     expect(logText()).toContain('WARN could not enqueue review: queue unavailable')
+    const failedReviewId = enqueue.mock.calls[0]?.[1] as string
+    expect(readFileSync(join(paths.queueDir, 'review-pending-id-7'), 'utf8').trim())
+      .toBe(failedReviewId)
+    expect(existsSync(join(paths.tasksDir, `${failedReviewId}.md`))).toBe(true)
+    expect(existsSync(join(paths.queueDir, 'effort', failedReviewId))).toBe(true)
 
     expect(loop.runAutoReview(7, false)).toBe(false)
     expect(enqueue).toHaveBeenCalledTimes(2)
+    expect(enqueue.mock.calls[1]?.[1]).toBe(failedReviewId)
     expect(readFileSync(roundFile, 'utf8')).toBe('1\n')
     const reviewId = readFileSync(idFile, 'utf8').trim()
+    expect(reviewId).toBe(failedReviewId)
     expect(readFileSync(join(paths.queueDir, 'backlog.txt'), 'utf8')).toContain(reviewId)
+    expect(existsSync(join(paths.queueDir, 'review-pending-id-7'))).toBe(false)
     expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
   })
 
@@ -2055,6 +2063,10 @@ describe('cycle gate', () => {
     expect(existsSync(completeFlag)).toBe(true)
     expect(existsSync(join(paths.queueDir, 'stop'))).toBe(false)
     expect(logText()).toContain('WARN could not enqueue CI fix: queue unavailable')
+    const failedFixId = enqueue.mock.calls[0]?.[1] as string
+    expect(readFileSync(join(paths.queueDir, 'ci-fix-pending-id-1'), 'utf8').trim())
+      .toBe(failedFixId)
+    expect(existsSync(join(paths.tasksDir, `${failedFixId}.md`))).toBe(true)
   })
 
   it('stops instead of resetting a malformed CI fix attempt count', async () => {
@@ -2098,13 +2110,15 @@ describe('cycle gate', () => {
     expect(readFileSync(attemptFile, 'utf8')).toBe('1\n')
     expect(existsSync(completeFlag)).toBe(false)
     expect(existsSync(stopFile)).toBe(false)
+    expect(enqueue.mock.calls[1]?.[1]).toBe(enqueue.mock.calls[0]?.[1])
+    expect(existsSync(join(paths.queueDir, 'ci-fix-pending-id-1'))).toBe(false)
 
     // Reaching the numeric cap does not stop while the dispatched fix remains queued.
     expect(await loop.triggerScanIfIdle()).toBe('continue')
     expect(existsSync(stopFile)).toBe(false)
 
     const fixId = enqueue.mock.calls[1]?.[1]
-    expect(fixId).toMatch(/^20260808_120000_002_ci-fix-c1$/)
+    expect(fixId).toMatch(/^20260808_120000_001_ci-fix-c1$/)
     writeFileSync(join(paths.queueDir, 'backlog.txt'), '')
     writeRawStatus(fixId as string, 'completed')
     writeFileSync(join(paths.queueDir, 'scanned', fixId as string), '')

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -544,6 +544,7 @@ describe('forge poll budget', () => {
   })
 
   it('does not claim from a poll whose duplicate re-read cannot be verified', async () => {
+    initializeGitRepo()
     const loop = makeLoop({
       issueQueueEnabled: true, scanEnabled: false, autoMerge: false, maxParallel: 1,
     })

--- a/tests/merge-guard.test.ts
+++ b/tests/merge-guard.test.ts
@@ -4,11 +4,18 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({ renameSync: vi.fn(), rmSync: vi.fn() }))
+const mocks = vi.hoisted(() => ({
+  renameSync: vi.fn(), rmSync: vi.fn(), writeFileSync: vi.fn(),
+}))
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
-  return { ...actual, renameSync: mocks.renameSync, rmSync: mocks.rmSync }
+  return {
+    ...actual,
+    renameSync: mocks.renameSync,
+    rmSync: mocks.rmSync,
+    writeFileSync: mocks.writeFileSync,
+  }
 })
 
 import { mergeTask, MergeError } from '../src/merge.ts'
@@ -42,6 +49,12 @@ async function makeCompletedTask(
 }
 
 beforeEach(() => {
+  mocks.rmSync.mockReset().mockImplementation((...args: unknown[]) =>
+    Reflect.apply(actualFs.rmSync, actualFs, args))
+  mocks.renameSync.mockReset().mockImplementation((...args: unknown[]) =>
+    Reflect.apply(actualFs.renameSync, actualFs, args))
+  mocks.writeFileSync.mockReset().mockImplementation((...args: unknown[]) =>
+    Reflect.apply(actualFs.writeFileSync, actualFs, args))
   repoRoot = mkdtempSync(join(tmpdir(), 'orch-merge-guard-'))
   paths = orchPaths(repoRoot)
   git(repoRoot, ['init', '-q', '-b', 'main'])
@@ -50,10 +63,6 @@ beforeEach(() => {
   writeFileSync(join(repoRoot, 'README.md'), '# repo\n')
   git(repoRoot, ['add', '-A'])
   git(repoRoot, ['commit', '-qm', 'chore: initial commit'])
-  mocks.rmSync.mockReset().mockImplementation((...args: unknown[]) =>
-    Reflect.apply(actualFs.rmSync, actualFs, args))
-  mocks.renameSync.mockReset().mockImplementation((...args: unknown[]) =>
-    Reflect.apply(actualFs.renameSync, actualFs, args))
 })
 
 afterEach(() => {
@@ -62,6 +71,31 @@ afterEach(() => {
 })
 
 describe('merge guard retirement', () => {
+  it('reclaims a failed merge when guard retirement marker and rename both fail', async () => {
+    const taskId = '20260826_203919_001_auto-failed-guard-retirement'
+    await makeCompletedTask(taskId, { dirty: true })
+    const guard = join(paths.queueDir, 'merge-guards', taskId)
+    mocks.writeFileSync.mockImplementation((...args: unknown[]) => {
+      if (args[0] === join(guard, 'retired')) throw new Error('retirement marker failed')
+      return Reflect.apply(actualFs.writeFileSync, actualFs, args)
+    })
+    mocks.renameSync.mockImplementation((...args: unknown[]) => {
+      if (args[0] === guard) throw new Error('guard retirement rename failed')
+      return Reflect.apply(actualFs.renameSync, actualFs, args)
+    })
+
+    await expect(mergeTask(paths, taskId, {
+      taskGate: 'light', project: stubProject,
+    })).rejects.toBeInstanceOf(MergeError)
+    expect(actualFs.existsSync(join(guard, 'retired'))).toBe(false)
+
+    const onMergeStart = vi.fn()
+    await expect(mergeTask(paths, taskId, {
+      taskGate: 'light', project: stubProject, onMergeStart,
+    })).rejects.toBeInstanceOf(MergeError)
+    expect(onMergeStart).toHaveBeenCalledOnce()
+  })
+
   it('reclaims a failed merge after guard retirement rename fails', async () => {
     const taskId = '20260822_093823_001_auto-failed-guard-rename'
     await makeCompletedTask(taskId, { dirty: true })

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -531,6 +531,7 @@ describe('mergeTask', () => {
     const runnerPid = 12345
     vi.spyOn(operatingSystem, 'processStartIdentity').mockReturnValue(undefined)
     vi.spyOn(operatingSystem, 'processIsAlive').mockReturnValue(true)
+    vi.spyOn(operatingSystem, 'processTreeIsAlive').mockReturnValue(true)
     const terminate = vi.spyOn(operatingSystem, 'terminateProcessTree')
     await writeStatus(paths, taskId, 'completed', runnerPid)
 
@@ -550,6 +551,7 @@ describe('mergeTask', () => {
       'No implementation is needed.\nNO_CHANGE_WARRANTED\nTASK_COMPLETE\n')
     vi.spyOn(operatingSystem, 'processStartIdentity').mockReturnValue(undefined)
     vi.spyOn(operatingSystem, 'processIsAlive').mockReturnValue(true)
+    vi.spyOn(operatingSystem, 'processTreeIsAlive').mockReturnValue(true)
     const terminate = vi.spyOn(operatingSystem, 'terminateProcessTree')
     await writeStatus(paths, taskId, 'completed', runnerPid)
 

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -11,8 +11,8 @@ import { operatingSystem, type OperatingSystem } from '../src/adapters/os.ts'
 import { createOperatingSystem as createPosixOperatingSystem } from '../src/adapters/os-posix.ts'
 import { createOperatingSystem as createWindowsOperatingSystem } from '../src/adapters/os-windows.ts'
 import {
-  completeTaskWithoutChanges, MergeError, mergeRemoteTask, mergeTask, removeMergedWorktree,
-  removeTemporaryWorktree,
+  completeTaskWithoutChanges, MergeError, MergeRecoveryError, mergeRemoteTask, mergeTask,
+  removeMergedWorktree, removeTemporaryWorktree,
 } from '../src/merge.ts'
 import {
   branchName, finalMessageFile, orchPaths, worktreeDir, type OrchPaths,
@@ -1045,6 +1045,37 @@ describe('mergeTask', () => {
     expect(event).not.toHaveBeenCalled()
     expect(readStatus(paths, taskId)?.status).toBe('merged')
   })
+
+  it('stops when a failed local merge cannot prove that the worktree was restored', async () => {
+    const taskId = '20260824_084607_019_auto-merge-recovery'
+    await makeCompletedTask(taskId, { commit: true })
+    const runHead = git(repoRoot, ['rev-parse', 'HEAD']).trim()
+    let mergeCalls = 0
+    const mergeRuntime = {
+      git: (cwd: string, args: string[]): string => {
+        if (args[0] === 'merge' && args[1] === '--quiet') {
+          mergeCalls += 1
+          if (mergeCalls === 2) {
+            git(cwd, ['merge', '--no-commit', '--no-ff', args[3]!])
+            throw new Error('merge result was not reported')
+          }
+        }
+        if (args[0] === 'merge' && args[1] === '--abort') {
+          throw new Error('abort failed')
+        }
+        return git(cwd, args)
+      },
+    }
+
+    const failure = mergeTask(paths, taskId, {
+      taskGate: 'light', project: noCheckProject, mergeRuntime,
+    })
+    await expect(failure).rejects.toThrow(MergeRecoveryError)
+    await expect(failure).rejects.toThrow('merge is still in progress; merge abort failed')
+
+    expect(git(repoRoot, ['rev-parse', 'HEAD']).trim()).toBe(runHead)
+    expectNoTemporaryWorktree('.merge-')
+  })
 })
 
 describe('mergeRemoteTask', () => {
@@ -1261,6 +1292,65 @@ describe('mergeRemoteTask', () => {
     expect(readFileSync(join(repoRoot, 'README.md'), 'utf8')).toBe('# run version\n')
     expect(git(repoRoot, ['rev-parse', remoteRef]).trim()).toBe(expectedHead)
     expect(git(repoRoot, ['show', `${remoteRef}:README.md`])).toBe('# remote version\n')
+    expectNoTemporaryWorktree('.adopt-')
+  })
+
+  it('stops when abort leaves a remote adoption merge in progress', async () => {
+    const branch = 'task/remote-unrecoverable-conflict'
+    git(repoRoot, ['switch', '-qc', branch])
+    writeFileSync(join(repoRoot, 'task.txt'), 'remote recovery work\n')
+    git(repoRoot, ['add', 'task.txt'])
+    git(repoRoot, ['commit', '-qm', 'feat: add remote recovery work'])
+    const expectedHead = git(repoRoot, ['rev-parse', 'HEAD']).trim()
+    git(repoRoot, ['switch', '-q', 'main'])
+    git(repoRoot, ['update-ref', `refs/remotes/origin/${branch}`, expectedHead])
+    let mergeCalls = 0
+    const mergeRuntime = {
+      git: (cwd: string, args: string[]): string => {
+        if (args[0] === 'merge' && args[1] === '--quiet') {
+          mergeCalls += 1
+          if (mergeCalls === 2) {
+            git(cwd, ['merge', '--no-commit', '--no-ff', args[3]!])
+            throw new Error('merge result was not reported')
+          }
+        }
+        if (args[0] === 'merge' && args[1] === '--abort') throw new Error('abort is blocked')
+        return git(cwd, args)
+      },
+    }
+
+    await expect(mergeRemoteTask(paths, 228, 'origin', branch, expectedHead, {
+      taskGate: 'light', project: noCheckProject, mergeRuntime,
+      forge: { issueClosingCommitMessage: (message) => message },
+    })).rejects.toThrow('merge is still in progress; merge abort failed: abort is blocked')
+
+    expectNoTemporaryWorktree('.adopt-')
+  })
+
+  it('returns a retryable conflict when a failed abort is proven harmless', async () => {
+    const branch = 'task/remote-safe-abort-failure'
+    git(repoRoot, ['switch', '-qc', branch])
+    writeFileSync(join(repoRoot, 'task.txt'), 'task work\n')
+    git(repoRoot, ['add', 'task.txt'])
+    git(repoRoot, ['commit', '-qm', 'feat: add safe abort fixture'])
+    const expectedHead = git(repoRoot, ['rev-parse', 'HEAD']).trim()
+    git(repoRoot, ['switch', '-q', 'main'])
+    git(repoRoot, ['update-ref', `refs/remotes/origin/${branch}`, expectedHead])
+    const mergeRuntime = {
+      git: (cwd: string, args: string[]): string => {
+        if (args[0] === 'merge' && args[1] === '--quiet') throw new Error('merge did not start')
+        if (args[0] === 'merge' && args[1] === '--abort') throw new Error('nothing to abort')
+        return git(cwd, args)
+      },
+    }
+
+    const failure = mergeRemoteTask(paths, 229, 'origin', branch, expectedHead, {
+      taskGate: 'light', project: noCheckProject, mergeRuntime,
+      forge: { issueClosingCommitMessage: (message) => message },
+    })
+    await expect(failure).rejects.toThrow(MergeError)
+    await expect(failure).rejects.not.toThrow(MergeRecoveryError)
+    await expect(failure).rejects.toThrow(`A merge conflict occurred while adopting ${branch}.`)
     expectNoTemporaryWorktree('.adopt-')
   })
 })

--- a/tests/merger-adoption.test.ts
+++ b/tests/merger-adoption.test.ts
@@ -122,6 +122,66 @@ describe('remote task adoption', () => {
     expect(logged.filter((line) => line.startsWith('Merged '))).toHaveLength(1)
   })
 
+  it('quarantines every reporter when a forged group names an unavailable issue', async () => {
+    const task = pushWorkerBranch('20260809_000000_010_auto-forged-unavailable-group')
+    const headBefore = git(repoRoot, ['rev-parse', 'HEAD']).trim()
+    const issueNumbers = await Promise.all([1, 2].map(() => forge.createIssue({
+      title: 'forged unavailable grouped task',
+      body: 'A worker report names an issue outside the available findings.',
+      labels: [LABEL_FINDING, LABEL_MERGE_READY],
+      assignees: ['worker-a'],
+    })))
+    const unavailableIssueNumber = 999
+    await Promise.all(issueNumbers.map((issueNumber) => forge.commentIssue(issueNumber,
+      `Worker completed the task.\nBranch: ${task.branch}\nHead commit: ${task.head}\nIssues: #${issueNumber} #${unavailableIssueNumber}`)))
+
+    await makeLoop(stubProject).adoptRemoteTasks()
+
+    expect(git(repoRoot, ['rev-parse', 'HEAD']).trim()).toBe(headBefore)
+    expect(existsSync(join(repoRoot, 'worker-change.txt'))).toBe(false)
+    for (const issueNumber of issueNumbers) {
+      const issue = await forge.getIssue(issueNumber)
+      expect(issue.labels).toContain(LABEL_MERGE_FAILED)
+      expect(issue.labels).not.toContain(LABEL_MERGE_READY)
+      expect(issuePromotionForIssue(paths, issueNumber)).toBeUndefined()
+      expect(forge.issueComments.get(issueNumber)?.join('\n'))
+        .toContain(`names unavailable issue #${unavailableIssueNumber}`)
+    }
+  })
+
+  it('releases every member when forged grouped reports name different worker branches', async () => {
+    const firstTask = pushWorkerBranch('20260809_000000_011_auto-forged-group-a')
+    const secondTask = pushWorkerBranch('20260809_000000_012_auto-forged-group-b')
+    const headBefore = git(repoRoot, ['rev-parse', 'HEAD']).trim()
+    const issueNumbers = await Promise.all([1, 2].map(() => forge.createIssue({
+      title: 'inconsistent grouped worker task',
+      body: 'Grouped members report different worker branches.',
+      labels: [LABEL_FINDING, LABEL_MERGE_READY],
+      assignees: ['worker-a'],
+    })))
+    const issueList = issueNumbers.map((number) => `#${number}`).join(' ')
+    await forge.commentIssue(issueNumbers[0]!,
+      `Worker completed the task.\nBranch: ${firstTask.branch}\nHead commit: ${firstTask.head}\nIssues: ${issueList}`)
+    await forge.commentIssue(issueNumbers[1]!,
+      `Worker completed the task.\nBranch: ${secondTask.branch}\nHead commit: ${secondTask.head}\nIssues: ${issueList}`)
+
+    await makeLoop(stubProject).adoptRemoteTasks()
+
+    expect(git(repoRoot, ['rev-parse', 'HEAD']).trim()).toBe(headBefore)
+    expect(existsSync(join(repoRoot, 'worker-change.txt'))).toBe(false)
+    for (const issueNumber of issueNumbers) {
+      const issue = await forge.getIssue(issueNumber)
+      expect(issue.labels).toContain(LABEL_READY)
+      expect(issue.labels).toContain(LABEL_GROUP_SINGLETON)
+      expect(issue.labels).not.toContain(LABEL_MERGE_READY)
+      expect(issue.labels).not.toContain(LABEL_MERGE_FAILED)
+      expect(issue.assignees).toEqual([])
+      expect(issuePromotionForIssue(paths, issueNumber)).toBeUndefined()
+      expect(forge.issueComments.get(issueNumber)?.join('\n'))
+        .toContain('does not report the same worker branch')
+    }
+  })
+
   it('returns every member of an abandoned remote group as singleton-ready', async () => {
     const branch = 'task/20260809_000000_099_auto-missing-group'
     const head = 'a'.repeat(40)

--- a/tests/process-registry.test.ts
+++ b/tests/process-registry.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const fsFailures = vi.hoisted(() => ({
   read: undefined as NodeJS.ErrnoException | undefined,
   stat: undefined as NodeJS.ErrnoException | undefined,
+  rename: undefined as ((source: string, destination: string) => void) | undefined,
 }))
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -18,6 +19,12 @@ vi.mock('node:fs', async (importOriginal) => {
       if (fsFailures.read !== undefined) throw fsFailures.read
       return Reflect.apply(actual.readFileSync, actual, args)
     }) as typeof actual.readFileSync,
+    renameSync: ((...args: Parameters<typeof actual.renameSync>) => {
+      if (fsFailures.rename !== undefined) {
+        return fsFailures.rename(String(args[0]), String(args[1]))
+      }
+      return Reflect.apply(actual.renameSync, actual, args)
+    }) as typeof actual.renameSync,
     statSync: ((...args: Parameters<typeof actual.statSync>) => {
       if (fsFailures.stat !== undefined) throw fsFailures.stat
       return Reflect.apply(actual.statSync, actual, args)
@@ -27,7 +34,8 @@ vi.mock('node:fs', async (importOriginal) => {
 
 import { orchPaths, type OrchPaths } from '../src/paths.ts'
 import {
-  bootedAt, forgetTaskProcess, recordTaskProcess, taskProcessPid, terminableTaskProcessPid,
+  bootedAt, forgetTaskProcess, recordTaskProcess, registeredTaskIds, taskProcessPid,
+  terminableTaskProcessPid,
 } from '../src/processRegistry.ts'
 
 describe('task process registry', () => {
@@ -38,6 +46,7 @@ describe('task process registry', () => {
   beforeEach(() => {
     fsFailures.read = undefined
     fsFailures.stat = undefined
+    fsFailures.rename = undefined
     repoRoot = mkdtempSync(join(tmpdir(), 'orch process-registry-'))
     paths = orchPaths(repoRoot)
   })
@@ -53,6 +62,26 @@ describe('task process registry', () => {
     recordTaskProcess(paths, taskId, 4321, identity)
 
     expect(taskProcessPid(paths, taskId, undefined, identity)).toBe(4321)
+  })
+
+  it('keeps the previous owner published if replacing it is interrupted', () => {
+    recordTaskProcess(paths, taskId, 4321, identity)
+    fsFailures.rename = (temporary, destination) => {
+      expect(destination).toBe(registryFile())
+      expect(JSON.parse(readFileSync(temporary, 'utf8'))).toEqual({
+        pid: 9876, startIdentity: 'started:9876',
+      })
+      expect(taskProcessPid(paths, taskId, undefined, identity)).toBe(4321)
+      expect(registeredTaskIds(paths)).toEqual([taskId])
+      throw new Error('publication interrupted')
+    }
+
+    expect(() => recordTaskProcess(paths, taskId, 9876, identity))
+      .toThrow('publication interrupted')
+
+    expect(taskProcessPid(paths, taskId, undefined, identity)).toBe(4321)
+    expect(readFileSync(registryFile(), 'utf8')).toContain('"pid":4321')
+    expect(registeredTaskIds(paths)).toEqual([taskId])
   })
 
   it('answers with nothing for a task it never recorded', () => {
@@ -153,20 +182,24 @@ describe('task process registry', () => {
     expect(existsSync(registryFile())).toBe(false)
   })
 
-  it('drops an entry that does not name a process', () => {
+  it('fails closed and retains an entry that is not valid JSON', () => {
     recordTaskProcess(paths, taskId, 4321, identity)
     writeFileSync(registryFile(), 'not-a-pid\n')
 
-    expect(taskProcessPid(paths, taskId)).toBeUndefined()
-    expect(existsSync(registryFile())).toBe(false)
+    expect(() => taskProcessPid(paths, taskId)).toThrow(
+      `Malformed task process registry entry: ${registryFile()}`,
+    )
+    expect(existsSync(registryFile())).toBe(true)
   })
 
-  it('drops a JSON entry that is not a registry object', () => {
+  it('fails closed and retains a malformed current-format entry', () => {
     recordTaskProcess(paths, taskId, 4321, identity)
-    writeFileSync(registryFile(), 'null\n')
+    writeFileSync(registryFile(), '{"pid":4321}\n')
 
-    expect(taskProcessPid(paths, taskId, undefined, identity)).toBeUndefined()
-    expect(existsSync(registryFile())).toBe(false)
+    expect(() => taskProcessPid(paths, taskId, undefined, identity)).toThrow(
+      `Malformed task process registry entry: ${registryFile()}`,
+    )
+    expect(existsSync(registryFile())).toBe(true)
   })
 
   it('derives the boot time from how long the system has been up', () => {

--- a/tests/process-registry.test.ts
+++ b/tests/process-registry.test.ts
@@ -174,6 +174,27 @@ describe('task process registry', () => {
     expect(existsSync(registryFile())).toBe(false)
   })
 
+  it('retains ownership while descendants remain after the runner root exits', () => {
+    recordTaskProcess(paths, taskId, 4321, identity)
+
+    expect(taskProcessPid(paths, taskId, undefined, () => undefined, () => true)).toBe(4321)
+    expect(terminableTaskProcessPid(
+      paths, taskId, undefined, () => undefined, () => true,
+    )).toBeUndefined()
+    expect(existsSync(registryFile())).toBe(true)
+  })
+
+  it('retains blocking ownership but refuses termination after identity replacement', () => {
+    recordTaskProcess(paths, taskId, 4321, identity)
+    const replacementIdentity = (): string => 'started:replacement'
+
+    expect(taskProcessPid(paths, taskId, undefined, replacementIdentity, () => true)).toBe(4321)
+    expect(terminableTaskProcessPid(
+      paths, taskId, undefined, replacementIdentity, () => true,
+    )).toBeUndefined()
+    expect(existsSync(registryFile())).toBe(true)
+  })
+
   it('drops a legacy bare-PID entry because it has no process-start identity', () => {
     recordTaskProcess(paths, taskId, 4321, identity)
     writeFileSync(registryFile(), '4321\n')

--- a/tests/prune.test.ts
+++ b/tests/prune.test.ts
@@ -3,24 +3,9 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync }
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { operatingSystem, type OperatingSystem } from '../src/adapters/os.ts'
 import { orchPaths, type OrchPaths } from '../src/paths.ts'
 import { pruneTasks } from '../src/prune.ts'
-
-const fsMockState = vi.hoisted(() => ({ removalFailurePath: undefined as string | undefined }))
-
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>()
-  return {
-    ...actual,
-    rmSync: vi.fn((path: Parameters<typeof actual.rmSync>[0], options?: Parameters<typeof actual.rmSync>[1]) => {
-      if (fsMockState.removalFailurePath !== undefined
-          && String(path).includes(fsMockState.removalFailurePath)) {
-        throw new Error('simulated removal failure')
-      }
-      actual.rmSync(path, options)
-    }),
-  }
-})
 
 let repoRoot: string
 let paths: OrchPaths
@@ -46,7 +31,6 @@ function makeTask(id: string, status: string, age: 'old' | 'new'): void {
 }
 
 beforeEach(() => {
-  fsMockState.removalFailurePath = undefined
   repoRoot = mkdtempSync(join(tmpdir(), 'orch-prune-'))
   paths = orchPaths(repoRoot)
   git(['init', '-q'])
@@ -125,19 +109,31 @@ describe('pruneTasks', () => {
     mkdirSync(mergeGuard, { recursive: true })
     writeFileSync(join(mergeGuard, 'succeeded'), '')
 
-    const report = pruneTasks(paths, { days: 14, dryRun: false })
+    const removeDirectory = vi.fn((path: string) => {
+      rmSync(path, { recursive: true, force: true })
+    })
+    const os = { ...operatingSystem, removeDirectory } satisfies OperatingSystem
+
+    const report = pruneTasks(paths, { days: 14, dryRun: false }, os)
 
     expect(report.removed).toContain(mergeGuard)
+    expect(removeDirectory).toHaveBeenCalledWith(mergeGuard)
     expect(existsSync(mergeGuard)).toBe(false)
   })
 
   it('retains the status file when removing an earlier artifact fails', () => {
     makeTask(OLD_MERGED, 'merged', 'old')
-    fsMockState.removalFailurePath = `${OLD_MERGED}.log`
+    const failedPath = join(paths.logsDir, `${OLD_MERGED}.log`)
+    const removeDirectory = vi.fn((path: string) => {
+      if (path === failedPath) throw new Error('simulated removal failure')
+      rmSync(path, { recursive: true, force: true })
+    })
+    const os = { ...operatingSystem, removeDirectory } satisfies OperatingSystem
 
-    expect(() => pruneTasks(paths, { days: 14, dryRun: false }))
+    expect(() => pruneTasks(paths, { days: 14, dryRun: false }, os))
       .toThrow('simulated removal failure')
 
+    expect(removeDirectory).toHaveBeenCalledWith(failedPath)
     expect(existsSync(join(paths.statusDir, `${OLD_MERGED}.json`))).toBe(true)
   })
 

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -114,6 +114,7 @@ describe('refreshTask', () => {
 
   it('defers failure while identity is unavailable and keeps ownership after recovery', async () => {
     const processIsAlive = vi.spyOn(operatingSystem, 'processIsAlive').mockReturnValue(true)
+    vi.spyOn(operatingSystem, 'processTreeIsAlive').mockReturnValue(true)
     const processStartIdentity = vi.spyOn(operatingSystem, 'processStartIdentity')
       .mockReturnValue('started:protected')
     writeRawStatus(
@@ -127,6 +128,21 @@ describe('refreshTask', () => {
     processStartIdentity.mockReturnValue('started:protected')
     expect((await refreshTask(paths, 'probe-task'))?.status).toBe('running')
     expect(processIsAlive).toHaveBeenCalledWith(2147483647)
+  })
+
+  it('retains ownership when the runner exits but its process tree remains alive', async () => {
+    const processStartIdentity = vi.spyOn(operatingSystem, 'processStartIdentity')
+      .mockReturnValue('started:orphaned')
+    vi.spyOn(operatingSystem, 'processIsAlive').mockReturnValue(false)
+    vi.spyOn(operatingSystem, 'processTreeIsAlive').mockReturnValue(true)
+    writeRawStatus(
+      'orphaned-task',
+      '{"task_id":"orphaned-task","status":"running","pid":2147483647}\n',
+    )
+    processStartIdentity.mockReturnValue(undefined)
+
+    expect((await refreshTask(paths, 'orphaned-task'))?.status).toBe('failed')
+    expect(terminableTaskProcessPid(paths, 'orphaned-task')).toBeUndefined()
   })
 
   it('completes a live task once the marker appears', async () => {

--- a/tests/run-tests.test.ts
+++ b/tests/run-tests.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawn } from 'node:child_process'
 import {
-  existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync,
+  existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -13,6 +13,14 @@ async function waitForPath(path: string): Promise<void> {
   const deadline = Date.now() + 5_000
   while (!existsSync(path)) {
     if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${path}`)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+async function waitForTicketCount(path: string, count: number): Promise<void> {
+  const deadline = Date.now() + 5_000
+  while (!existsSync(path) || readdirSync(path).filter((name) => name.endsWith('.json')).length < count) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${count} tickets in ${path}`)
     await new Promise((resolve) => setTimeout(resolve, 20))
   }
 }
@@ -86,7 +94,11 @@ describe('test suite wrapper', () => {
     })
     const sharedRoot = join(fixture, 'shared')
     mkdirSync(sharedRoot)
-    const env = { ...process.env, ORCHESTRATION_TEST_SHARED_ROOT: sharedRoot }
+    const env = {
+      ...process.env,
+      ORCHESTRATION_TEST_DELAY_MS: '1500',
+      ORCHESTRATION_TEST_SHARED_ROOT: sharedRoot,
+    }
 
     const first = run(
       process.execPath,
@@ -94,22 +106,33 @@ describe('test suite wrapper', () => {
       firstWorktree,
       env,
     )
+    await waitForPath(join(sharedRoot, 'active'))
     const second = run(
       process.execPath,
       [join(secondWorktree, 'scripts', 'run-tests.mjs'), '--poolOptions.threads.singleThread'],
       secondWorktree,
       env,
     )
-    const results = await Promise.all([first, second])
+    const queue = join(repository, '.git', '.orchestration-test-suite-lock-queue')
+    await waitForTicketCount(queue, 1)
+    const third = run(
+      process.execPath,
+      [join(firstWorktree, 'scripts', 'run-tests.mjs'), '--pool=forks'],
+      firstWorktree,
+      env,
+    )
+    const results = await Promise.all([first, second, third])
 
-    expect(results.map(({ status }) => status)).toEqual([0, 0])
-    expect(results.map(({ stderr }) => stderr)).toEqual(['', ''])
+    expect(results.map(({ status }) => status)).toEqual([0, 0, 0])
+    expect(results.map(({ stderr }) => stderr)).toEqual(['', '', ''])
     expect(() => readFileSync(join(sharedRoot, 'overlap'), 'utf8')).toThrow()
     const invocations = readFileSync(join(sharedRoot, 'args'), 'utf8')
       .trim().split(/\r?\n/).map((line) => JSON.parse(line) as string[])
-    expect(invocations).toHaveLength(2)
-    expect(invocations).toContainEqual(['run', '--pool=threads'])
-    expect(invocations).toContainEqual(['run', '--poolOptions.threads.singleThread'])
+    expect(invocations).toEqual([
+      ['run', '--pool=threads'],
+      ['run', '--poolOptions.threads.singleThread'],
+      ['run', '--pool=forks'],
+    ])
     expect(results.some(({ stdout }) => stdout.includes('waiting for its repository lock'))).toBe(true)
   })
 
@@ -237,7 +260,9 @@ describe('test suite wrapper', () => {
       "import { join } from 'node:path'",
       "const active = join(process.env.ORCHESTRATION_TEST_SHARED_ROOT, 'active')",
       'mkdirSync(active)',
-      'await new Promise((resolve) => setTimeout(resolve, 1_500))',
+      // Leave enough time for the waiter to start and inspect the owner on a loaded
+      // Windows runner, where process identity lookup starts a PowerShell process.
+      'await new Promise((resolve) => setTimeout(resolve, 5_000))',
       'rmSync(active, { recursive: true, force: true })',
       '',
     ].join('\n'))

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -140,6 +140,97 @@ describe('setup verification', () => {
     )
   })
 
+  it.each([
+    {
+      name: 'typecheck',
+      run: (_cwd: string, command: string) => command !== 'npm run typecheck',
+      expected: [
+        /^FAIL: orchestration TypeScript typecheck$/,
+      ],
+    },
+    {
+      name: 'adapter loading',
+      omitAdapter: true,
+      expected: [
+        /^FAIL: loadProject adapter discovery;/,
+        /^SKIP: adapter suite; adapter could not be loaded$/,
+        /^SKIP: adapter referenced paths; adapter could not be loaded$/,
+      ],
+    },
+    {
+      name: 'adapter suite',
+      run: (_cwd: string, command: string) => command !== 'suite',
+      expected: [
+        /^FAIL: adapter suite step 'Consumer suite'$/,
+        /^FAIL: adapter suite$/,
+      ],
+    },
+    {
+      name: 'push upstream',
+      failGitCall: '--dry-run',
+      expected: [
+        /^FAIL: current branch has no pushable upstream; simulated push upstream failure$/,
+      ],
+    },
+    {
+      name: 'hooks',
+      configuredHooks: 'wrong/hooks',
+      expected: [
+        /^FAIL: core\.hooksPath is not orchestration\/ts\/\.githooks; wrong\/hooks != orchestration\/ts\/\.githooks$/,
+      ],
+    },
+    {
+      name: 'labels',
+      missingLabel: QUEUE_LABELS[0].name,
+      expected: [
+        new RegExp(`^FAIL: loop labels; missing ${QUEUE_LABELS[0].name}$`),
+      ],
+    },
+  ])('returns failure and reports the $name failure distinctly', async ({
+    name,
+    omitAdapter = false,
+    run = () => true,
+    failGitCall,
+    configuredHooks = 'orchestration/ts/.githooks',
+    missingLabel,
+    expected,
+  }) => {
+    const repository = mkdtempSync(join(tmpdir(), 'orchestration-verify-failure-'))
+    repositories.push(repository)
+    const packageRoot = join(repository, 'orchestration', 'ts')
+    mkdirSync(join(packageRoot, '.githooks'), { recursive: true })
+    const projectDirectory = join(repository, 'orchestration', 'project')
+    mkdirSync(projectDirectory, { recursive: true })
+    if (!omitAdapter) {
+      const adapter = renderProjectAdapter('consumer', '../ts/src/adapters/project.ts')
+        .replace('cycleSuite: () => []', "cycleSuite: () => [{ label: 'Consumer suite', cwd: '', command: 'suite' }]")
+      writeFileSync(join(projectDirectory, 'project-consumer.ts'), adapter)
+    }
+    const forge = makeFakeForge()
+    for (const label of QUEUE_LABELS) {
+      if (label.name !== missingLabel) forge.labels.add(label.name)
+    }
+    const reports: string[] = []
+    const git = (args: string[]): string => {
+      if (args.includes(failGitCall ?? 'never')) throw new Error(`simulated ${name} failure`)
+      if (args.includes('@{upstream}')) return 'origin/topic'
+      if (args.includes('core.hooksPath')) return configuredHooks
+      if (args.includes('--dry-run')) return ''
+      throw new Error(`unexpected git call: ${args.join(' ')}`)
+    }
+
+    const ok = await verifyRepositorySetup(orchPaths(repository), forge, {
+      packageRoot,
+      env: {},
+      report: (line) => reports.push(line),
+      git,
+      run,
+    })
+
+    expect(ok).toBe(false)
+    for (const report of expected) expect(reports).toContainEqual(expect.stringMatching(report))
+  })
+
   it('uses PROJECT to select one of multiple supported adapters', async () => {
     const repository = mkdtempSync(join(tmpdir(), 'orchestration-verify-project-'))
     repositories.push(repository)

--- a/tests/task-processes.test.ts
+++ b/tests/task-processes.test.ts
@@ -124,6 +124,25 @@ describe('terminateLiveTaskProcesses', () => {
     expect(taskProcessPid(paths, 'blocked-task', undefined, () => 'started:possibly-reused'))
       .toBe(101)
   })
+
+  it('retains registry state when termination is not verified', () => {
+    writeRunningTask('still-live', 101)
+    const os = {
+      processStartIdentity: () => 'started:101',
+      processIsAlive: () => true,
+      terminateProcessTree: () => false,
+    } as unknown as OperatingSystem
+
+    const result = terminateLiveTaskProcesses(paths, os)
+
+    expect(result).toEqual({
+      terminated: [],
+      failures: [{
+        taskId: 'still-live', pid: 101, error: 'process tree termination could not be verified',
+      }],
+    })
+    expect(taskProcessPid(paths, 'still-live', undefined, () => 'started:101')).toBe(101)
+  })
 })
 
 describe('orphanedWorktreeDirectories', () => {
@@ -215,6 +234,37 @@ describe('process-group liveness', () => {
     }
 
     expect(createWindowsOperatingSystem(runtime).processTreeIsAlive(4321)).toBe(true)
+  })
+
+  it('probes a live Windows root omitted from the CIM snapshot', () => {
+    const runtime: WindowsOperatingSystemRuntime = {
+      spawn: () => {},
+      listProcesses: () => [],
+      probeProcess: () => {},
+      remove: () => {},
+      now: Date.now,
+      sleep: () => {},
+    }
+
+    expect(createWindowsOperatingSystem(runtime).processTreeIsAlive(4321)).toBe(true)
+  })
+
+  it('terminates a live Windows root omitted from the CIM snapshot', () => {
+    let alive = true
+    const spawn = vi.fn(() => { alive = false })
+    const runtime: WindowsOperatingSystemRuntime = {
+      spawn,
+      listProcesses: () => [],
+      probeProcess: () => {
+        if (!alive) throw gone()
+      },
+      remove: () => {},
+      now: Date.now,
+      sleep: () => {},
+    }
+
+    expect(createWindowsOperatingSystem(runtime).terminateProcessTree(4321)).toBe(true)
+    expect(spawn).toHaveBeenCalledWith('taskkill', ['/PID', '4321', '/T', '/F'])
   })
 
   it('verifies captured Windows descendants after taskkill stops the parent', () => {

--- a/tests/task-processes.test.ts
+++ b/tests/task-processes.test.ts
@@ -292,6 +292,25 @@ describe('process-group liveness', () => {
     expect(spawn).toHaveBeenCalledWith('taskkill', ['/PID', '4321', '/T', '/F'])
   })
 
+  it('refuses to terminate a Windows tree containing the test runner', () => {
+    const spawn = vi.fn()
+    const runtime: WindowsOperatingSystemRuntime = {
+      spawn,
+      listProcesses: () => [
+        { pid: 4321, parentPid: 0 },
+        { pid: process.pid, parentPid: 4321 },
+      ],
+      probeProcess: () => {},
+      remove: () => {},
+      now: Date.now,
+      sleep: () => {},
+    }
+
+    expect(() => createWindowsOperatingSystem(runtime).terminateProcessTree(4321))
+      .toThrow(`Refusing to stop process tree 4321 because it contains the current process ${process.pid}.`)
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
   it('verifies captured Windows descendants after taskkill stops the parent', () => {
     const alive = new Set([4321, 4322])
     let now = 0

--- a/tests/task-processes.test.ts
+++ b/tests/task-processes.test.ts
@@ -51,6 +51,7 @@ describe('terminateLiveTaskProcesses', () => {
     const os = {
       processStartIdentity: (pid: number) => alive.has(pid) ? `started:${pid}` : undefined,
       processIsAlive: (pid: number) => alive.has(pid),
+      processTreeIsAlive: (pid: number) => alive.has(pid),
       terminateProcessTree,
     } as unknown as OperatingSystem
 
@@ -109,6 +110,7 @@ describe('terminateLiveTaskProcesses', () => {
     const os = {
       processStartIdentity: () => 'started:possibly-reused',
       processIsAlive: () => true,
+      processTreeIsAlive: () => true,
       terminateProcessTree,
     } as unknown as OperatingSystem
 
@@ -130,6 +132,7 @@ describe('terminateLiveTaskProcesses', () => {
     const os = {
       processStartIdentity: () => 'started:101',
       processIsAlive: () => true,
+      processTreeIsAlive: () => true,
       terminateProcessTree: () => false,
     } as unknown as OperatingSystem
 
@@ -142,6 +145,28 @@ describe('terminateLiveTaskProcesses', () => {
       }],
     })
     expect(taskProcessPid(paths, 'still-live', undefined, () => 'started:101')).toBe(101)
+  })
+
+  it('finds an orphaned tree after its runner root exits and retains failed cleanup', () => {
+    writeRunningTask('orphaned-tree', 101)
+    const terminateProcessTree = vi.fn(() => false)
+    const os = {
+      processStartIdentity: () => undefined,
+      processIsAlive: () => false,
+      processTreeIsAlive: () => true,
+      terminateProcessTree,
+    } as unknown as OperatingSystem
+
+    const result = terminateLiveTaskProcesses(paths, os)
+
+    expect(terminateProcessTree).not.toHaveBeenCalled()
+    expect(result.failures).toEqual([{
+      taskId: 'orphaned-tree', pid: 101,
+      error: 'process identity was not captured at launch or is currently unavailable',
+    }])
+    expect(taskProcessPid(
+      paths, 'orphaned-tree', undefined, () => undefined, () => true,
+    )).toBe(101)
   })
 })
 

--- a/tests/windows-process.test.ts
+++ b/tests/windows-process.test.ts
@@ -135,7 +135,34 @@ it('rejects cleanup while any captured startup descendant remains alive', async 
     'Could not stop Windows startup process tree 43210.',
   )
   expect(runtime.requestLauncherTreeTermination).toHaveBeenCalledOnce()
+  expect(runtime.removeDirectory).not.toHaveBeenCalled()
   expect(runtime.sleep).toHaveBeenCalled()
+})
+
+it('verifies cleanup directly when startup process enumeration fails', async () => {
+  const runtime = testRuntime(() => {}, 20)
+  runtime.listProcesses = () => { throw new Error('process enumeration failed') }
+
+  await expect(startWindowsProcess(options, runtime)).rejects.toThrow(
+    'never published a PID before startup timed out; startup cleanup found and terminated a live process tree',
+  )
+  expect(runtime.requestLauncherTreeTermination).toHaveBeenCalledOnce()
+  expect(runtime.removeDirectory).toHaveBeenCalledOnce()
+})
+
+it('retains startup state when direct cleanup verification cannot prove the launcher stopped', async () => {
+  const runtime = testRuntime(() => {}, 20)
+  let now = 0
+  runtime.listProcesses = () => { throw new Error('process enumeration failed') }
+  runtime.requestLauncherTreeTermination = vi.fn(() => true)
+  runtime.now = () => now
+  runtime.sleep = vi.fn(async (milliseconds: number) => { now += milliseconds })
+
+  await expect(startWindowsProcess(options, runtime)).rejects.toThrow(
+    /Could not stop Windows startup process tree 43210\. Startup state was retained at .+\./,
+  )
+  expect(runtime.requestLauncherTreeTermination).toHaveBeenCalledOnce()
+  expect(runtime.removeDirectory).not.toHaveBeenCalled()
 })
 
 it('returns the published PID when temporary-directory cleanup fails', async () => {

--- a/tests/windows-run-tests-cancellation.test.ts
+++ b/tests/windows-run-tests-cancellation.test.ts
@@ -138,3 +138,69 @@ it('terminates Vitest and releases its lock when the invoking PowerShell exits',
   expect(contender.status).toBe(0)
   expect(contender.stderr).toBe('')
 })
+
+it('stops a locked waiter when its invoking PowerShell exits', async () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'orch-run-tests-locked-cancel-'))
+  fixtures.push(fixture)
+  const scripts = join(fixture, 'scripts')
+  const vitest = join(fixture, 'node_modules', 'vitest')
+  const invocationFile = join(fixture, 'invocations')
+  const waiterPidFile = join(fixture, 'waiter-pid')
+  const waitingFile = join(fixture, 'waiting')
+  mkdirSync(scripts, { recursive: true })
+  mkdirSync(vitest, { recursive: true })
+  const wrapper = readFileSync(join(import.meta.dirname, '..', 'scripts', 'run-tests.mjs'), 'utf8')
+    .replace(
+      'async function runTestSuite() {',
+      "async function runTestSuite() {\n  if (process.env.ORCHESTRATION_TEST_WAITER_PID_FILE) writeFileSync(process.env.ORCHESTRATION_TEST_WAITER_PID_FILE, String(process.pid))",
+    )
+    .replace(
+      'console.log(`Another worktree is running the test suite;',
+      "if (process.env.ORCHESTRATION_TEST_WAITING_FILE) writeFileSync(process.env.ORCHESTRATION_TEST_WAITING_FILE, '')\n      console.log(`Another worktree is running the test suite;",
+    )
+  writeFileSync(join(scripts, 'run-tests.mjs'), wrapper)
+  writeFileSync(join(vitest, 'package.json'), '{"name":"vitest","version":"0.0.0"}\n')
+  writeFileSync(join(vitest, 'vitest.mjs'), [
+    "import { appendFileSync } from 'node:fs'",
+    "appendFileSync(process.env.ORCHESTRATION_TEST_INVOCATION_FILE, `${process.pid}\\n`)",
+    '',
+  ].join('\n'))
+  const lock = join(fixture, '.orchestration-test-suite-lock')
+  mkdirSync(lock)
+  writeFileSync(join(lock, 'owner.json'), `${JSON.stringify({
+    pid: process.pid,
+    token: 'fixture-owner',
+  })}\n`)
+
+  const invoker = spawn('powershell.exe', [
+    '-NoLogo', '-NoProfile', '-NonInteractive', '-Command',
+    '& $env:ORCHESTRATION_TEST_NODE $env:ORCHESTRATION_TEST_WRAPPER',
+  ], {
+    cwd: fixture,
+    env: {
+      ...process.env,
+      ORCHESTRATION_TEST_INVOCATION_FILE: invocationFile,
+      ORCHESTRATION_TEST_NODE: process.execPath,
+      ORCHESTRATION_TEST_WAITER_PID_FILE: waiterPidFile,
+      ORCHESTRATION_TEST_WAITING_FILE: waitingFile,
+      ORCHESTRATION_TEST_WRAPPER: join(scripts, 'run-tests.mjs'),
+    },
+    stdio: 'ignore',
+    windowsHide: true,
+  })
+  if (invoker.pid !== undefined) processRoots.push(invoker.pid)
+  await waitForPath(waiterPidFile)
+  const waiterPid = Number(readFileSync(waiterPidFile, 'utf8'))
+  processRoots.push(waiterPid)
+  expect(processIsAlive(waiterPid)).toBe(true)
+  await waitForPath(waitingFile)
+
+  invoker.kill('SIGKILL')
+  await waitUntil(
+    () => !processIsAlive(waiterPid),
+    `Test wrapper ${waiterPid} survived its invoking PowerShell process while waiting for the lock`,
+  )
+  rmSync(lock, { recursive: true, force: true })
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  expect(existsSync(invocationFile)).toBe(false)
+})


### PR DESCRIPTION
## Features
- None

## Bug Fixes
- [Test infrastructure] The full suite can no longer end silently without a summary: the run's own waiter-serialization change was fixed so an abandoned waiter fails loudly (#360), and the daemon-ownership tests that passed locally while failing on both CI platforms now pin their environmental assumptions in the fixture, holding in both environments (#367).
- [Consumer updates] The silent core auto-update failure is fixed (#359): the behind check works against squash-imported subtrees in the consumer shape, and a cycle that stays on old code while behind says so with both revisions named — silence again means up to date.
- [Runner safety] The regression the cycle gate caught mid-run — a merge terminating a runner whose identity it had not verified — was corrected back to the safe contract (#358), and the remaining fixes harden lock retirement, restart settling, promotion records, and orphaned-tree ownership.

## Security
- None

## Project Operations
- [Internals] Scan-found cleanups across the run's three cycles.

## Risks
- This run needed four operator interventions (two gate deaths, a damaged node_modules, a CI-only failure) and produced the fixes for three of those failure classes; the cycle gate caught its own regression before promotion each time.
- Verified: CI green on both platforms, `npm run test:linux` passes with 1045 tests, nothing skipped.
